### PR TITLE
Disable doclint when building with java8

### DIFF
--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -166,6 +166,15 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>disable-java8-doclint</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <additionalparam>-Xdoclint:none</additionalparam>
+      </properties>
+    </profile>
   </profiles>
 
   <dependencies>


### PR DESCRIPTION
The generated javadoc comments in the `models` packages contain several
`<` characters which the java8 doclint plugin rejects. Note - this means if you
build with java8 you will _not_ have javadocs. Another solution would be
to fix the stems for the comments in that package, but I'm not sure how
to go about that.