### PR TITLE
Release parent project (to release util module)

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -11,7 +11,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>io.kubernetes</groupId>
-			<artifactId>client-java</artifactId>
+			<artifactId>client-java-api</artifactId>
 			<version>1.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
@@ -32,6 +32,18 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<version>2.5.3</version>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<properties>
 		<java.version>1.7</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -2,9 +2,9 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.kubernetes</groupId>
-  <artifactId>client-java</artifactId>
+  <artifactId>client-java-api</artifactId>
   <packaging>jar</packaging>
-  <name>client-java</name>
+  <name>client-java-api</name>
   <version>1.0-SNAPSHOT</version>
   <url>https://github.com/swagger-api/swagger-codegen</url>
   <description>Swagger Java</description>
@@ -30,20 +30,9 @@
       <name>The Kubernetes Authors</name>
       <email>kubernetes-dev@googlegroups.com</email>
       <organization>Kubernetes</organization>
-      <organizationUrl>http://kubernetes.io</organizationUrl>
+      <organizationUrl>https://kubernetes.io</organizationUrl>
     </developer>
   </developers>
-
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
 
   <build>
     <plugins>
@@ -76,20 +65,6 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
-        <!--
-          During release:perform, enable the "release" profile
-        -->
-        <configuration>
-          <autoVersionSubmodules>true</autoVersionSubmodules>
-          <useReleaseProfile>false</useReleaseProfile>
-          <releaseProfiles>release</releaseProfiles>
-          <goals>deploy</goals>
-        </configuration>
       </plugin>
 
       <!-- attach test jar -->
@@ -170,27 +145,6 @@
   </build>
 
   <profiles>
-    <profile>
-      <id>sign-artifacts</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.5</version>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
     <profile>
       <id>disable-java8-doclint</id>
       <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -2,13 +2,94 @@
 	xmlns="http://maven.apache.org/POM/4.0.0" 
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>parent</artifactId>
+	<artifactId>client-java</artifactId>
 	<groupId>io.kubernetes</groupId>
 	<version>1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
+  <name>Kubernetes Client API</name>
+
 	<modules>
 		<module>kubernetes</module>
 		<module>examples</module>
 		<module>util</module>
 	</modules>
+
+  <scm>
+    <connection>scm:git:git@github.com:kubernetes-client/java.git</connection>
+    <developerConnection>scm:git:git@github.com:kubernetes-client/java.git</developerConnection>
+    <url>https://github.com/kubernetes-client/java</url>
+  </scm>
+
+  <prerequisites>
+    <maven>2.2.0</maven>
+  </prerequisites>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>The Kubernetes Authors</name>
+      <email>kubernetes-dev@googlegroups.com</email>
+      <organization>Kubernetes</organization>
+      <organizationUrl>https://kubernetes.io</organizationUrl>
+    </developer>
+  </developers>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>2.5.3</version>
+        <configuration>
+          <autoVersionSubmodules>true</autoVersionSubmodules>
+          <useReleaseProfile>false</useReleaseProfile>
+          <releaseProfiles>release</releaseProfiles>
+          <goals>deploy</goals>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>sign-artifacts</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -11,7 +11,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>io.kubernetes</groupId>
-			<artifactId>client-java</artifactId>
+			<artifactId>client-java-api</artifactId>
 			<version>1.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
I realized we need to build & release the `util` submodule as well. I moved the release-specific bits of the `kubernetes/pom.xml` to the top-level `pom.xml`, and added a flag to the `examples` module to avoid releasing that.