### PR TITLE
Allow ApiClient to be constructed from KubeConfig

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/Config.java
+++ b/util/src/main/java/io/kubernetes/client/util/Config.java
@@ -99,8 +99,10 @@ public class Config {
     }
 
     public static ApiClient fromConfig(Reader input) {
+        return fromConfig(KubeConfig.loadKubeConfig(input));
+    }
 
-        KubeConfig config = KubeConfig.loadKubeConfig(input);
+    public static ApiClient fromConfig(KubeConfig config) {
         ApiClient client = new ApiClient();
         client.setBasePath(config.getServer());
 


### PR DESCRIPTION
Given that the `KubeConfig` object is public, exposing a constructor like this is useful to users who want to have more control in how the client authenticates. For example, being able to load a `KubeConfig` from disk, edit the context, and then authenticate with the user & cluster in that context is useful.