### PR TITLE
Allow kubeconfig to be loaded without current-context

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/KubeConfig.java
+++ b/util/src/main/java/io/kubernetes/client/util/KubeConfig.java
@@ -96,6 +96,10 @@ public class KubeConfig {
     }
 
     public boolean setContext(String context) {
+        if (context == null) {
+            return false;
+        }
+
         currentCluster = null;
         currentUser = null;
         Map<String, Object> ctx = findObject(contexts, context);
@@ -197,6 +201,9 @@ public class KubeConfig {
     }
 
     public boolean verifySSL() {
+        if (currentCluster == null) {
+            return false;
+        }
         if (currentCluster.containsKey("insecure-skip-tls-verify")) {
             return ! ((Boolean) currentCluster.get("insecure-skip-tls-verify")).booleanValue();
         }


### PR DESCRIPTION
Before this change, any attempt to load a kubeconfig w/o current-context field would NPE. Since `kubectl` doesn't have this behavior, and we expose the ability to set a custom context on a kubeconfig, we shouldn't crash here.