### PR TITLE
Add IntOrString model and GSON adapter

### DIFF
--- a/kubernetes/src/main/java/io/kubernetes/client/custom/IntOrString.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/custom/IntOrString.java
@@ -1,0 +1,69 @@
+package io.kubernetes.client.custom;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+@JsonAdapter(IntOrString.IntOrStringAdapter.class)
+public class IntOrString {
+    private final boolean isInt;
+    private final String strValue;
+    private final Integer intValue;
+
+    public IntOrString(final String value) {
+        this.isInt = false;
+        this.strValue = value;
+        this.intValue = null;
+    }
+
+    public IntOrString(final int value) {
+        this.isInt = true;
+        this.intValue = value;
+        this.strValue = null;
+    }
+
+    public boolean isInteger() {
+        return isInt;
+    }
+
+    public String getStrValue() {
+        if (isInt) {
+            throw new IllegalStateException("Not a string");
+        }
+        return strValue;
+    }
+
+    public Integer getIntValue() {
+        if (!isInt) {
+            throw new IllegalStateException("Not an integer");
+        }
+        return intValue;
+    }
+
+    public static class IntOrStringAdapter extends TypeAdapter<IntOrString> {
+        @Override
+        public void write(JsonWriter jsonWriter, IntOrString intOrString) throws IOException {
+            if (intOrString.isInteger()) {
+                jsonWriter.value(intOrString.getIntValue());
+            } else {
+                jsonWriter.value(intOrString.getStrValue());
+            }
+        }
+
+        @Override
+        public IntOrString read(JsonReader jsonReader) throws IOException {
+            final JsonToken nextToken = jsonReader.peek();
+            if (nextToken == JsonToken.NUMBER) {
+                return new IntOrString(jsonReader.nextInt());
+            } else if (nextToken == JsonToken.STRING) {
+                return new IntOrString(jsonReader.nextString());
+            } else {
+                throw new IllegalStateException("Could not deserialize to IntOrString. Was " + nextToken);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add an `IntOrString` model along with its type adapter. This type allows us to receive a type from the API and then re-serialize it without changing its type. Previously all values received from the API were converted to strings. This meant that if returned to the API, the API would respond with a 400 Bad Request because the type was not always as expected (e.g. `maxUnavailable` should either be an `int` or a `String` that ends with a `%` - if previously `1` had been specified it would be rejected as it was not `1%`).

There will be a corresponding PR in [the gen repo](https://github.com/kubernetes-client/gen) for this.