### PR TITLE
Use a version of deploy-plugin that exists in Maven Central

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -45,7 +45,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
-				<version>2.5.3</version>
+				<version>2.8.2</version>
 				<configuration>
 					<skip>true</skip>
 				</configuration>

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -25,7 +25,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
-				<version>2.5.3</version>
+				<version>2.8.2</version>
 				<configuration>
 					<skip>true</skip>
 				</configuration>


### PR DESCRIPTION
`maven-deploy-plugin@2.5.3` doesn't exist in [Maven Central](https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.apache.maven.plugins%22%20AND%20a%3A%22maven-deploy-plugin%22) and prevents deploying it to our local Nexus. 

It's a valid version of `maven-release-plugin` so I think this may have been a copy-paste error.