### PR TITLE
PortForwarder doesn't work for higher port numbers

### DIFF
--- a/util/src/main/java/io/kubernetes/client/PortForward.java
+++ b/util/src/main/java/io/kubernetes/client/PortForward.java
@@ -138,7 +138,7 @@ public class PortForward {
                 InputStream is = handler.getInputStream(i);
                 byte[] data = new byte[2];
                 is.read(data);
-                int port = data[0] + data[1] * 256;
+                int port = (data[0] & 0xFF) + (data[1] & 0xFF) * 256;
                 streams.put(port, i);
             }
         }


### PR DESCRIPTION
The `PortForwarder` class doesn't work for higher port numbers. Java converts bytes by default to signed integers. Therefore this formula:
```
int port = data[0] + data[1] * 256;
```
can fail because data[0] and data[1] might be interpreted as negative numbers. For example when trying to forward port `8080`, `port` will be set to `7824` (-112 + 31*256). This will cause the PortForwarder not to work (it will not find the streams for port `8080`). 

This PR makes sure that the bytes are interpreted as unsigned integers and and makes sure that the port number will be as expected.