### PR TITLE
Use junit system-rules dependency with test scope

### DIFF
--- a/util/pom.xml
+++ b/util/pom.xml
@@ -62,6 +62,7 @@
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-rules</artifactId>
             <version>1.16.1</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
com.github.stefanbirkner:system-rules is licensed under Common Public License 1.0, which is "weak copyleft" licence according to the[ ASF policies](https://www.apache.org/legal/resolved.html).

As it is used only in test files I propose to change the scope of the dependency to test. With test scope it won't be included in the final artifacts and will be easier to use this client project from Apache projects.