### PR TITLE
Use slf4j instead of log4j

### DIFF
--- a/util/pom.xml
+++ b/util/pom.xml
@@ -47,9 +47,14 @@
             <version>22.0</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.25</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
         </dependency>
         <!-- test dependencies -->
         <dependency>

--- a/util/src/main/java/io/kubernetes/client/util/ClientBuilder.java
+++ b/util/src/main/java/io/kubernetes/client/util/ClientBuilder.java
@@ -32,12 +32,12 @@ import java.io.Reader;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** A Builder which allows the construction of {@link ApiClient}s in a fluent fashion. */
 public class ClientBuilder {
-
-  private static final Logger log = Logger.getLogger(ClientBuilder.class);
+  private static final Logger log = LoggerFactory.getLogger(ClientBuilder.class);
 
   private String basePath = Config.DEFAULT_FALLBACK_HOST;
   private byte[] caCertBytes = null;

--- a/util/src/main/java/io/kubernetes/client/util/Config.java
+++ b/util/src/main/java/io/kubernetes/client/util/Config.java
@@ -20,9 +20,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Config {
+  private static final Logger log = LoggerFactory.getLogger(Config.class);
+
   public static final String SERVICEACCOUNT_ROOT = "/var/run/secrets/kubernetes.io/serviceaccount";
   public static final String SERVICEACCOUNT_CA_PATH = SERVICEACCOUNT_ROOT + "/ca.crt";
   public static final String SERVICEACCOUNT_TOKEN_PATH = SERVICEACCOUNT_ROOT + "/token";
@@ -31,8 +34,6 @@ public class Config {
   public static final String ENV_SERVICE_PORT = "KUBERNETES_SERVICE_PORT";
   // The last resort host to try
   public static final String DEFAULT_FALLBACK_HOST = "http://localhost:8080";
-
-  private static final Logger log = Logger.getLogger(Config.class);
 
   public static ApiClient fromCluster() throws IOException {
     return ClientBuilder.cluster().build();

--- a/util/src/main/java/io/kubernetes/client/util/KubeConfig.java
+++ b/util/src/main/java/io/kubernetes/client/util/KubeConfig.java
@@ -25,12 +25,15 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 /** KubeConfig represents a kubernetes client configuration */
 public class KubeConfig {
+  private static final Logger log = LoggerFactory.getLogger(KubeConfig.class);
+
   // Defaults for where to find a kubeconfig file
   public static final String ENV_HOME = "HOME";
   public static final String KUBEDIR = ".kube";
@@ -48,8 +51,6 @@ public class KubeConfig {
   Map<String, Object> currentCluster;
   Map<String, Object> currentUser;
   String currentNamespace;
-
-  private static final Logger log = Logger.getLogger(KubeConfig.class);
 
   public static void registerAuthenticator(Authenticator auth) {
     synchronized (authenticators) {

--- a/util/src/main/java/io/kubernetes/client/util/WebSocketStreamHandler.java
+++ b/util/src/main/java/io/kubernetes/client/util/WebSocketStreamHandler.java
@@ -28,19 +28,20 @@ import java.io.Reader;
 import java.util.HashMap;
 import java.util.Map;
 import okio.ByteString;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * WebSocketStreamHandler understands the Kubernetes streaming protocol and separates a single
  * WebSockets stream into a number of different streams using that protocol.
  */
 public class WebSocketStreamHandler implements WebSockets.SocketListener, Closeable {
+  private static final Logger log = LoggerFactory.getLogger(WebSocketStreamHandler.class);
+
   Map<Integer, PipedOutputStream> output;
   Map<Integer, PipedInputStream> input;
   WebSocket socket;
   String protocol;
-
-  private static final Logger log = Logger.getLogger(WebSockets.class);
 
   public WebSocketStreamHandler() {
     output = new HashMap<>();

--- a/util/src/main/java/io/kubernetes/client/util/WebSockets.java
+++ b/util/src/main/java/io/kubernetes/client/util/WebSockets.java
@@ -32,17 +32,18 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import okio.Buffer;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class WebSockets {
+  private static final Logger log = LoggerFactory.getLogger(WebSockets.class);
+
   public static final String V4_STREAM_PROTOCOL = "v4.channel.k8s.io";
   public static final String V3_STREAM_PROTOCOL = "v3.channel.k8s.io";
   public static final String V2_STREAM_PROTOCOL = "v2.channel.k8s.io";
   public static final String V1_STREAM_PROTOCOL = "channel.k8s.io";
   public static final String STREAM_PROTOCOL_HEADER = "X-Stream-Protocol-Version";
   public static final String SPDY_3_1 = "SPDY/3.1";
-
-  private static final Logger log = Logger.getLogger(WebSockets.class);
 
   /** A simple interface for a listener on a web socket */
   public interface SocketListener {

--- a/util/src/main/java/io/kubernetes/client/util/credentials/ClientCertificateAuthentication.java
+++ b/util/src/main/java/io/kubernetes/client/util/credentials/ClientCertificateAuthentication.java
@@ -9,11 +9,12 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
 import javax.net.ssl.KeyManager;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Uses Client Certificates to configure {@link ApiClient} authentication to the Kubernetes API. */
 public class ClientCertificateAuthentication implements Authentication {
-  private static final Logger log = Logger.getLogger(ClientCertificateAuthentication.class);
+  private static final Logger log = LoggerFactory.getLogger(ClientCertificateAuthentication.class);
   private final byte[] certificate;
   private final byte[] key;
 

--- a/util/src/main/resources/logback.xml
+++ b/util/src/main/resources/logback.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="console" />
+  </root>
+</configuration>


### PR DESCRIPTION
* Removes `log4j`
* Adds `slf4j`
* Adds `logback-classic` as default implementation of logging (dependency can be excluded by end user)
* Adds logback configuration
* Fixes erroneously named loggers

Resolves #186 