### PR TITLE
Exec improvements to read non-zero exit code and implement waitFor(long, TimeUnit)

### DIFF
--- a/examples/src/main/java/io/kubernetes/client/examples/ExecExample.java
+++ b/examples/src/main/java/io/kubernetes/client/examples/ExecExample.java
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2017, 2018 The Kubernetes Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -19,6 +19,9 @@ import io.kubernetes.client.Configuration;
 import io.kubernetes.client.Exec;
 import io.kubernetes.client.util.Config;
 import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A simple example of how to use the Java API
@@ -30,47 +33,68 @@ import java.io.IOException;
  */
 public class ExecExample {
   public static void main(String[] args) throws IOException, ApiException, InterruptedException {
+    String podName = "nginx-4217019353-k5sn9";
+    String namespace = "default";
+    List<String> commands = new ArrayList<>();
+
+    int len = args.length;
+    if (len >= 1) podName = args[0];
+    if (len >= 2) namespace = args[1];
+    for (int i = 2; i < len; i++) {
+      commands.add(args[i]);
+    }
+
     ApiClient client = Config.defaultClient();
     Configuration.setDefaultApiClient(client);
 
     Exec exec = new Exec();
-    boolean tty = System.console() != null;
-    //        final Process proc = exec.exec("default", "nginx-2371676037-czqx3", new String[]
-    // {"sh", "-c", "echo foo"}, true, tty);
+    boolean tty = true; // Optional: System.console() != null;
+    // final Process proc = exec.exec("default", "nginx-4217019353-k5sn9", new String[]
+    //   {"sh", "-c", "echo foo"}, true, tty);
     final Process proc =
-        exec.exec("default", "nginx-4217019353-k5sn9", new String[] {"sh"}, true, tty);
+        exec.exec(
+            namespace,
+            podName,
+            commands.isEmpty()
+                ? new String[] {"sh"}
+                : commands.toArray(new String[commands.size()]),
+            true,
+            tty);
 
-    new Thread(
+    Thread in =
+        new Thread(
             new Runnable() {
               public void run() {
                 try {
                   ByteStreams.copy(System.in, proc.getOutputStream());
+                } catch (InterruptedIOException ie) {
+                  // no-op
                 } catch (IOException ex) {
                   ex.printStackTrace();
                 }
               }
-            })
-        .start();
+            });
+    in.start();
 
-    new Thread(
+    Thread out =
+        new Thread(
             new Runnable() {
               public void run() {
                 try {
                   ByteStreams.copy(proc.getInputStream(), System.out);
+                } catch (InterruptedIOException ie) {
+                  // no-op
                 } catch (IOException ex) {
                   ex.printStackTrace();
                 }
               }
-            })
-        .start();
+            });
+    out.start();
 
     proc.waitFor();
-    try {
-      // Wait for buffers to flush.
-      Thread.sleep(2000);
-    } catch (InterruptedException ex) {
-      ex.printStackTrace();
-    }
+
+    // wait for any last output; no need to wait for input thread
+    out.join();
 
     proc.destroy();
 

--- a/examples/src/main/java/io/kubernetes/client/examples/ExecExample.java
+++ b/examples/src/main/java/io/kubernetes/client/examples/ExecExample.java
@@ -19,7 +19,6 @@ import io.kubernetes.client.Configuration;
 import io.kubernetes.client.Exec;
 import io.kubernetes.client.util.Config;
 import java.io.IOException;
-import java.io.InterruptedIOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -67,8 +66,6 @@ public class ExecExample {
               public void run() {
                 try {
                   ByteStreams.copy(System.in, proc.getOutputStream());
-                } catch (InterruptedIOException ie) {
-                  // no-op
                 } catch (IOException ex) {
                   ex.printStackTrace();
                 }
@@ -82,8 +79,6 @@ public class ExecExample {
               public void run() {
                 try {
                   ByteStreams.copy(proc.getInputStream(), System.out);
-                } catch (InterruptedIOException ie) {
-                  // no-op
                 } catch (IOException ex) {
                   ex.printStackTrace();
                 }

--- a/examples/src/main/java/io/kubernetes/client/examples/ExecExample.java
+++ b/examples/src/main/java/io/kubernetes/client/examples/ExecExample.java
@@ -47,7 +47,7 @@ public class ExecExample {
     Configuration.setDefaultApiClient(client);
 
     Exec exec = new Exec();
-    boolean tty = true; // Optional: System.console() != null;
+    boolean tty = System.console() != null;
     // final Process proc = exec.exec("default", "nginx-4217019353-k5sn9", new String[]
     //   {"sh", "-c", "echo foo"}, true, tty);
     final Process proc =
@@ -93,6 +93,6 @@ public class ExecExample {
 
     proc.destroy();
 
-    System.exit(0);
+    System.exit(proc.exitValue());
   }
 }

--- a/util/src/main/java/io/kubernetes/client/Exec.java
+++ b/util/src/main/java/io/kubernetes/client/Exec.java
@@ -181,6 +181,7 @@ public class Exec {
   private static class ExecProcess extends Process {
     private final WebSocketStreamHandler streamHandler;
     private volatile int statusCode;
+    private volatile boolean isDestroyed = false;
 
     public ExecProcess() throws IOException {
       this.statusCode = -1;
@@ -215,7 +216,8 @@ public class Exec {
                   ExecProcess.this.notifyAll();
                 }
               }
-              super.close();
+
+              if (isDestroyed) super.close();
             }
           };
     }
@@ -263,6 +265,7 @@ public class Exec {
 
     @Override
     public void destroy() {
+      isDestroyed = true;
       streamHandler.close();
     }
   }

--- a/util/src/main/java/io/kubernetes/client/util/WebSocketStreamHandler.java
+++ b/util/src/main/java/io/kubernetes/client/util/WebSocketStreamHandler.java
@@ -67,22 +67,28 @@ public class WebSocketStreamHandler implements WebSockets.SocketListener, Closea
   @Override
   public void bytesMessage(InputStream in) {
     try {
-      OutputStream out = getSocketInputOutputStream(in.read());
-      ByteStreams.copy(in, out);
+      handleMessage(in.read(), in);
     } catch (IOException ex) {
-      log.error("Error writing message", ex);
+      log.error("Error reading message channel", ex);
     }
   }
 
   @Override
   public void textMessage(Reader in) {
     try {
-      OutputStream out = getSocketInputOutputStream(in.read());
-      InputStream inStream =
-          new ByteArrayInputStream(CharStreams.toString(in).getBytes(Charsets.UTF_8));
-      ByteStreams.copy(inStream, out);
+      handleMessage(
+          in.read(), new ByteArrayInputStream(CharStreams.toString(in).getBytes(Charsets.UTF_8)));
     } catch (IOException ex) {
       log.error("Error writing message", ex);
+    }
+  }
+
+  protected void handleMessage(int stream, InputStream inStream) {
+    try {
+      OutputStream out = getSocketInputOutputStream(stream);
+      ByteStreams.copy(inStream, out);
+    } catch (IOException ex) {
+      log.error("Error handling message", ex);
     }
   }
 

--- a/util/src/main/java/io/kubernetes/client/util/WebSocketStreamHandler.java
+++ b/util/src/main/java/io/kubernetes/client/util/WebSocketStreamHandler.java
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2017, 2018 The Kubernetes Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -21,6 +21,7 @@ import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
@@ -38,20 +39,29 @@ import org.slf4j.LoggerFactory;
 public class WebSocketStreamHandler implements WebSockets.SocketListener, Closeable {
   private static final Logger log = LoggerFactory.getLogger(WebSocketStreamHandler.class);
 
-  Map<Integer, PipedOutputStream> output;
-  Map<Integer, PipedInputStream> input;
-  WebSocket socket;
-  String protocol;
+  private final Map<Integer, PipedInputStream> input = new HashMap<>();
+  private final Map<Integer, PipedOutputStream> pipedOutput = new HashMap<>();
+  private final Map<Integer, OutputStream> output = new HashMap<>();
+  private WebSocket socket;
 
-  public WebSocketStreamHandler() {
-    output = new HashMap<>();
-    input = new HashMap<>();
-  }
+  @SuppressWarnings("unused")
+  private String protocol;
+
+  private State state = State.UNINITIALIZED;
+
+  private static enum State {
+    UNINITIALIZED,
+    OPEN,
+    CLOSED
+  };
 
   @Override
-  public void open(String protocol, WebSocket socket) {
+  public synchronized void open(String protocol, WebSocket socket) {
+    if (state != State.UNINITIALIZED) throw new IllegalStateException();
     this.protocol = protocol;
     this.socket = socket;
+    state = State.OPEN;
+    notifyAll();
   }
 
   @Override
@@ -77,37 +87,43 @@ public class WebSocketStreamHandler implements WebSockets.SocketListener, Closea
   }
 
   @Override
-  public void close() {
-    for (PipedOutputStream out : output.values()) {
-      try {
-        out.close();
-      } catch (IOException ex) {
-        // TODO use a logger here
-        ex.printStackTrace();
+  public synchronized void close() {
+    if (state != State.CLOSED) {
+      state = State.CLOSED;
+      // Close all output streams.  Caller of getInputStream(int) is responsible
+      // for closing returned input streams
+      for (PipedOutputStream out : pipedOutput.values()) {
+        try {
+          out.close();
+        } catch (IOException ex) {
+          log.error("Error on close", ex);
+        }
       }
-    }
-    for (PipedInputStream in : input.values()) {
-      try {
-        in.close();
-      } catch (IOException ex) {
-        // TODO use a logger here
-        ex.printStackTrace();
+      for (OutputStream out : output.values()) {
+        try {
+          out.close();
+        } catch (IOException ex) {
+          log.error("Error on close", ex);
+        }
       }
     }
   }
 
   /**
-   * Get a specific input stream using its identifier
+   * Get a specific input stream using its identifier. Caller is responsible for closing these
+   * streams.
    *
    * @param stream The stream to return
    * @return The specified stream.
    */
   public synchronized InputStream getInputStream(int stream) {
+    if (state == State.CLOSED) throw new IllegalStateException();
+
     if (!input.containsKey(stream)) {
       try {
         PipedInputStream pipeIn = new PipedInputStream();
         PipedOutputStream pipeOut = new PipedOutputStream(pipeIn);
-        output.put(stream, pipeOut);
+        pipedOutput.put(stream, pipeOut);
         input.put(stream, pipeIn);
       } catch (IOException ex) {
         // This is _very_ unlikely, as it requires the above constructor to fail.
@@ -124,8 +140,11 @@ public class WebSocketStreamHandler implements WebSockets.SocketListener, Closea
    * @param stream The stream to return
    * @return The specified stream.
    */
-  public OutputStream getOutputStream(int stream) {
-    return new WebSocketOutputStream(stream);
+  public synchronized OutputStream getOutputStream(int stream) {
+    if (!output.containsKey(stream)) {
+      output.put(stream, new WebSocketOutputStream(stream));
+    }
+    return output.get(stream);
   }
 
   /**
@@ -136,11 +155,11 @@ public class WebSocketStreamHandler implements WebSockets.SocketListener, Closea
    * @return The specified stream.
    */
   private synchronized OutputStream getSocketInputOutputStream(int stream) {
-    if (!output.containsKey(stream)) {
+    if (!pipedOutput.containsKey(stream)) {
       try {
         PipedInputStream pipeIn = new PipedInputStream();
         PipedOutputStream pipeOut = new PipedOutputStream(pipeIn);
-        output.put(stream, pipeOut);
+        pipedOutput.put(stream, pipeOut);
         input.put(stream, pipeIn);
       } catch (IOException ex) {
         // This is _very_ unlikely, as it requires the above constructor to fail.
@@ -148,11 +167,11 @@ public class WebSocketStreamHandler implements WebSockets.SocketListener, Closea
         throw new IllegalStateException(ex);
       }
     }
-    return output.get(stream);
+    return pipedOutput.get(stream);
   }
 
   private class WebSocketOutputStream extends OutputStream {
-    private byte stream;
+    private final byte stream;
 
     public WebSocketOutputStream(int stream) {
       this.stream = (byte) stream;
@@ -165,13 +184,23 @@ public class WebSocketStreamHandler implements WebSockets.SocketListener, Closea
 
     @Override
     public void write(byte[] b) throws IOException {
-      this.write(b, 0, b.length);
+      write(b, 0, b.length);
     }
 
     @Override
     public void write(byte[] b, int offset, int length) throws IOException {
       if (WebSocketStreamHandler.this.socket == null) {
-        throw new IOException("No websocket connection!");
+        synchronized (WebSocketStreamHandler.this) {
+          if (state == State.CLOSED) throw new IllegalStateException();
+          if (WebSocketStreamHandler.this.socket == null) {
+            // wait for the websocket to be opened
+            try {
+              WebSocketStreamHandler.this.wait();
+            } catch (InterruptedException e) {
+              throw new InterruptedIOException();
+            }
+          }
+        }
       }
       byte[] buffer = new byte[length + 1];
       buffer[0] = stream;

--- a/util/src/main/java/io/kubernetes/client/util/WebSockets.java
+++ b/util/src/main/java/io/kubernetes/client/util/WebSockets.java
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2017, 2018 The Kubernetes Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -51,7 +51,7 @@ public class WebSockets {
     public void open(String protocol, WebSocket socket);
 
     /**
-     * Callled when a binary media type message is received
+     * Called when a binary media type message is received
      *
      * @param in The input stream containing the binary data
      */

--- a/util/src/main/java/io/kubernetes/client/util/WebSockets.java
+++ b/util/src/main/java/io/kubernetes/client/util/WebSockets.java
@@ -38,11 +38,9 @@ import org.slf4j.LoggerFactory;
 public class WebSockets {
   private static final Logger log = LoggerFactory.getLogger(WebSockets.class);
 
+  // Only support v4 stream protocol as it was available since k8s 1.4
   public static final String V4_STREAM_PROTOCOL = "v4.channel.k8s.io";
-  public static final String V3_STREAM_PROTOCOL = "v3.channel.k8s.io";
-  public static final String V2_STREAM_PROTOCOL = "v2.channel.k8s.io";
-  public static final String V1_STREAM_PROTOCOL = "channel.k8s.io";
-  public static final String STREAM_PROTOCOL_HEADER = "X-Stream-Protocol-Version";
+  public static final String STREAM_PROTOCOL_HEADER = "Sec-WebSocket-Protocol";
   public static final String SPDY_3_1 = "SPDY/3.1";
 
   /** A simple interface for a listener on a web socket */
@@ -86,11 +84,7 @@ public class WebSockets {
       throws ApiException, IOException {
 
     HashMap<String, String> headers = new HashMap<String, String>();
-    String allProtocols =
-        String.format(
-            "%s,%s,%s,%s",
-            V4_STREAM_PROTOCOL, V3_STREAM_PROTOCOL, V2_STREAM_PROTOCOL, V1_STREAM_PROTOCOL);
-    headers.put(STREAM_PROTOCOL_HEADER, allProtocols);
+    headers.put(STREAM_PROTOCOL_HEADER, V4_STREAM_PROTOCOL);
     headers.put(HttpHeaders.CONNECTION, HttpHeaders.UPGRADE);
     headers.put(HttpHeaders.UPGRADE, SPDY_3_1);
     String[] localVarAuthNames = new String[] {"BearerToken"};

--- a/util/src/test/java/io/kubernetes/client/ExecTest.java
+++ b/util/src/test/java/io/kubernetes/client/ExecTest.java
@@ -1,0 +1,51 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+
+/** Tests for the Exec helper class */
+public class ExecTest {
+  private static final String OUTPUT_EXIT1 =
+      "command terminated with non-zero exit code: Error executing in Docker Container: 1";
+  private static final String OUTPUT_EXIT126 =
+      "command terminated with non-zero exit code: Error executing in Docker Container: 126";
+
+  @Test
+  public void testExit0() {
+    InputStream inputStream = new ByteArrayInputStream(new byte[0]);
+    int exitCode = Exec.parseExitCode(inputStream);
+    assertEquals(0, exitCode);
+  }
+
+  @Test
+  public void testExit1() {
+    InputStream inputStream =
+        new ByteArrayInputStream(OUTPUT_EXIT1.getBytes(StandardCharsets.UTF_8));
+    int exitCode = Exec.parseExitCode(inputStream);
+    assertEquals(1, exitCode);
+  }
+
+  @Test
+  public void testExit126() {
+    InputStream inputStream =
+        new ByteArrayInputStream(OUTPUT_EXIT126.getBytes(StandardCharsets.UTF_8));
+    int exitCode = Exec.parseExitCode(inputStream);
+    assertEquals(126, exitCode);
+  }
+}

--- a/util/src/test/java/io/kubernetes/client/ExecTest.java
+++ b/util/src/test/java/io/kubernetes/client/ExecTest.java
@@ -25,6 +25,9 @@ public class ExecTest {
       "command terminated with non-zero exit code: Error executing in Docker Container: 1";
   private static final String OUTPUT_EXIT126 =
       "command terminated with non-zero exit code: Error executing in Docker Container: 126";
+  private static final String BAD_OUTPUT_INCOMPLETE_MSG1 =
+      "command terminated with non-zero exit code: Error ";
+  private static final String BAD_OUTPUT_INCOMPLETE_MSG2 = "command terminated with non-zero";
 
   @Test
   public void testExit0() {
@@ -47,5 +50,21 @@ public class ExecTest {
         new ByteArrayInputStream(OUTPUT_EXIT126.getBytes(StandardCharsets.UTF_8));
     int exitCode = Exec.parseExitCode(inputStream);
     assertEquals(126, exitCode);
+  }
+
+  @Test
+  public void testIncompleteData1() {
+    InputStream inputStream =
+        new ByteArrayInputStream(BAD_OUTPUT_INCOMPLETE_MSG1.getBytes(StandardCharsets.UTF_8));
+    int exitCode = Exec.parseExitCode(inputStream);
+    assertEquals(-1, exitCode);
+  }
+
+  @Test
+  public void testIncompleteData2() {
+    InputStream inputStream =
+        new ByteArrayInputStream(BAD_OUTPUT_INCOMPLETE_MSG2.getBytes(StandardCharsets.UTF_8));
+    int exitCode = Exec.parseExitCode(inputStream);
+    assertEquals(-1, exitCode);
   }
 }

--- a/util/src/test/java/io/kubernetes/client/ExecTest.java
+++ b/util/src/test/java/io/kubernetes/client/ExecTest.java
@@ -41,13 +41,6 @@ public class ExecTest {
   }
 
   @Test
-  public void testExit0NoMessage() {
-    InputStream inputStream = new ByteArrayInputStream(new byte[0]);
-    int exitCode = Exec.parseExitCode(client, inputStream);
-    assertEquals(0, exitCode);
-  }
-
-  @Test
   public void testExit0() {
     InputStream inputStream =
         new ByteArrayInputStream(OUTPUT_EXIT0.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
Three improvements:

1) Correct exitValue() to match Process.exitValue() documentation and implement waitFor(long, TimeUnit).

2) When the web socket is being closed parse the message in channel 3, if any, since this will contain the non-zero exit value of the exec.

3) Delay closing web socket streams until destroy() to resolve timing issue around reading from and closing these streams.

@brendanburns My fault getting the request for beta3 release and this change confused in order.  I initially requested beta3 thinking that exec would work fully and then realizing I could contribute the improvements.  If possible, and if this change is approved, please hold beta3 so that this can be included.  Thanks!

Note: I still can't resolve the the fact that the API server returns 400 Bad Request any time stdin=false; however, it doesn't seem to hurt anything if I consistently pass stdin=true even if the command I'm exec'ing doesn't need any input.