### PR TITLE
Add default true to stdout and stderr on Exec.

### DIFF
--- a/util/src/main/java/io/kubernetes/client/Exec.java
+++ b/util/src/main/java/io/kubernetes/client/Exec.java
@@ -88,6 +88,8 @@ public class Exec {
             + "/exec?"
             + "stdin="
             + stdin
+            + "&stdout=true"
+            + "&stderr=true"
             + "&tty="
             + tty
             + (container != null ? "&container=" + container : "")
@@ -204,6 +206,9 @@ public class Exec {
       }
 
       V1Status status = client.getJSON().deserialize(body, returnType);
+      if (status == null) {
+        return -1;
+      }
       if (V1STATUS_SUCCESS.equals(status.getStatus())) return 0;
 
       if (V1STATUS_REASON_NONZEROEXITCODE.equals(status.getReason())) {


### PR DESCRIPTION
Fixes #225, though I would argue this is a breaking change for Kubernetes 1.9 and 1.10.

I'm going to try to repro and file a bug on upstream...

Sorry for the big diff. I also stripped `\r\n` from the file, I can revert for a cleaner diff if that is preferred.

The key diff is:

```java
+            + "&stdout=true"
+            + "&stderr=true"
```

in `Exec.java`

@rjeberhard 