### PR TITLE
Changes to the Yaml object auto-detection

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/Yaml.java
+++ b/util/src/main/java/io/kubernetes/client/util/Yaml.java
@@ -18,7 +18,13 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.lang3.tuple.MutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,31 +65,30 @@ public class Yaml {
     apiVersions.add("V1");
   }
 
-  private static String[] getApiGroup(String name) {
-    String[] parts = new String[2];
-
+  private static Pair<String, String> getApiGroup(String name) {
+    MutablePair<String, String> parts = new MutablePair<>();
     for (String prefix : apiGroups.keySet()) {
       if (name.startsWith(prefix)) {
-        parts[0] = apiGroups.get(prefix);
-        parts[1] = name.substring(prefix.length());
+        parts.left = apiGroups.get(prefix);
+        parts.right = name.substring(prefix.length());
         break;
       }
     }
-    if (parts[0] == null) parts[1] = name;
+    if (parts.left == null) parts.right = name;
 
     return parts;
   }
 
-  private static String[] getApiVersion(String name) {
-    String[] parts = new String[2];
+  private static Pair<String, String> getApiVersion(String name) {
+    MutablePair<String, String> parts = new MutablePair<>();
     for (String version : apiVersions) {
       if (name.startsWith(version)) {
-        parts[0] = version.toLowerCase();
-        parts[1] = name.substring(version.length());
+        parts.left = version.toLowerCase();
+        parts.right = name.substring(version.length());
         break;
       }
     }
-    if (parts[0] == null) parts[1] = name;
+    if (parts.left == null) parts.right = name;
 
     return parts;
   }
@@ -97,12 +102,12 @@ public class Yaml {
 
     for (ClassPath.ClassInfo clazz : allClasses) {
       String modelName = "";
-      String[] nameParts = getApiGroup(clazz.getSimpleName());
-      modelName += nameParts[0] == null ? "" : nameParts[0] + "/";
+      Pair<String, String> nameParts = getApiGroup(clazz.getSimpleName());
+      modelName += nameParts.getLeft() == null ? "" : nameParts.getLeft() + "/";
 
-      nameParts = getApiVersion(nameParts[1]);
-      modelName += nameParts[0] == null ? "" : nameParts[0] + "/";
-      modelName += nameParts[1];
+      nameParts = getApiVersion(nameParts.getRight());
+      modelName += nameParts.getLeft() == null ? "" : nameParts.getLeft() + "/";
+      modelName += nameParts.getRight();
 
       classes.put(modelName, clazz.load());
     }

--- a/util/src/main/java/io/kubernetes/client/util/Yaml.java
+++ b/util/src/main/java/io/kubernetes/client/util/Yaml.java
@@ -169,6 +169,12 @@ public class Yaml {
 
     Class<?> clazz = (Class<?>) classes.get(apiVersion + "/" + kind);
     if (clazz == null) {
+      // Attempt to detect class from version and kind alone
+      if (apiVersion.contains("/")) {
+        clazz = (Class<?>) classes.get(apiVersion.split("/")[1] + "/" + kind);
+      }
+    }
+    if (clazz == null) {
       throw new IOException(
           "Unknown apiVersionKind: "
               + apiVersion

--- a/util/src/main/java/io/kubernetes/client/util/Yaml.java
+++ b/util/src/main/java/io/kubernetes/client/util/Yaml.java
@@ -31,11 +31,14 @@ public class Yaml {
   static final Logger logger = LoggerFactory.getLogger(Yaml.class);
 
   public static String getApiGroupVersion(String name) {
-    if (name.startsWith("AppsV1")) {
-      return "apps/v1";
+    if (name.startsWith("AppsV1beta2")) {
+      return "apps/v1beta2";
     }
     if (name.startsWith("AppsV1beta1")) {
       return "apps/v1beta1";
+    }
+    if (name.startsWith("AppsV1")) {
+      return "apps/v1";
     }
     if (name.startsWith("ExtensionsV1beta1")) {
       return "extensions/v1beta1";

--- a/util/src/test/java/io/kubernetes/client/util/YamlTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/YamlTest.java
@@ -36,11 +36,11 @@ public class YamlTest {
     String[] apiVersions =
         new String[] {
           "v1",
-          "v2alpha1",
-          "v2beta1",
-          "v1alpha1",
-          "v1beta2",
-          "v1beta1",
+          "batch/v2alpha1",
+          "autoscaling/v2beta1",
+          "rbac.authorization.k8s.io/v1alpha1",
+          "apps/v1beta2",
+          "apiregistration.k8s.io/v1beta1",
           "extensions/v1beta1",
           "apps/v1beta1"
         };

--- a/util/src/test/java/io/kubernetes/client/util/YamlTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/YamlTest.java
@@ -22,16 +22,19 @@ import org.junit.Test;
 public class YamlTest {
   @Test
   public void testLoad() {
-    String[] kinds = new String[] {"Pod", "Deployment", "ClusterRole", "APIService", "Scale"};
+    String[] kinds = new String[] {"Pod", "CronJob", "HorizontalPodAutoscaler", "ClusterRole", "Deployment", "APIService", "Scale", "Deployment"};
     String[] apiVersions =
-        new String[] {"v1", "v1beta2", "v1alpha1", "v1beta1", "extensions/v1beta1"};
+        new String[] {"v1", "v2alpha1", "v2beta1", "v1alpha1", "v1beta2", "v1beta1", "extensions/v1beta1", "apps/v1beta1"};
     String[] classNames =
         new String[] {
           "V1Pod",
-          "V1beta2Deployment",
+          "V2alpha1CronJob",
+          "V2beta1HorizontalPodAutoscaler",
           "V1alpha1ClusterRole",
+          "V1beta2Deployment",
           "V1beta1APIService",
-          "ExtensionsV1beta1Scale"
+          "ExtensionsV1beta1Scale",
+          "AppsV1beta1Deployment"
         };
     for (int i = 0; i < kinds.length; i++) {
       String kind = kinds[i];

--- a/util/src/test/java/io/kubernetes/client/util/YamlTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/YamlTest.java
@@ -22,9 +22,28 @@ import org.junit.Test;
 public class YamlTest {
   @Test
   public void testLoad() {
-    String[] kinds = new String[] {"Pod", "CronJob", "HorizontalPodAutoscaler", "ClusterRole", "Deployment", "APIService", "Scale", "Deployment"};
+    String[] kinds =
+        new String[] {
+          "Pod",
+          "CronJob",
+          "HorizontalPodAutoscaler",
+          "ClusterRole",
+          "Deployment",
+          "APIService",
+          "Scale",
+          "Deployment"
+        };
     String[] apiVersions =
-        new String[] {"v1", "v2alpha1", "v2beta1", "v1alpha1", "v1beta2", "v1beta1", "extensions/v1beta1", "apps/v1beta1"};
+        new String[] {
+          "v1",
+          "v2alpha1",
+          "v2beta1",
+          "v1alpha1",
+          "v1beta2",
+          "v1beta1",
+          "extensions/v1beta1",
+          "apps/v1beta1"
+        };
     String[] classNames =
         new String[] {
           "V1Pod",


### PR DESCRIPTION
There are some issues with the way the Yaml class auto-detects the Kubernetes object during the `load` function.

Commit `9e0b3b8` fixes a bug where the Apps Api is checked in the wrong order.
Commit `dd93b9d` auto-detects in a different way to include more of the available Api groups.
Commit `5a0439c` attempts to temporarily address the issue #221 where some classes have not been prefixed with their Api groups, until the class names have been generated properly.

See `dd93b9d`'s commit message for a list of Api prefixes that are missing from class names.

Keep what you want