### PR TITLE
add Yaml.loadAll() method

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/Yaml.java
+++ b/util/src/main/java/io/kubernetes/client/util/Yaml.java
@@ -217,8 +217,8 @@ public class Yaml {
    * @return List of instantiated objects.
    * @throws IOException If an error occurs while reading the YAML.
    */
-  public static List<Object> loadAllAs(String content) throws IOException {
-    return loadAllAs(new StringReader(content));
+  public static List<Object> loadAll(String content) throws IOException {
+    return loadAll(new StringReader(content));
   }
 
   /**
@@ -231,8 +231,8 @@ public class Yaml {
    * @return List of instantiated of the objects.
    * @throws IOException If an error occurs while reading the YAML.
    */
-  public static List<Object> loadAllAs(File f) throws IOException {
-    return loadAllAs(new FileReader(f));
+  public static List<Object> loadAll(File f) throws IOException {
+    return loadAll(new FileReader(f));
   }
 
   /**
@@ -246,7 +246,7 @@ public class Yaml {
    * @return List of instantiated of the objects.
    * @throws IOException If an error occurs while reading the YAML.
    */
-  public static List<Object> loadAllAs(Reader reader) throws IOException {
+  public static List<Object> loadAll(Reader reader) throws IOException {
     Iterable<Object> iterable = getSnakeYaml().loadAll(reader);
     List<Object> list = new ArrayList<Object>();
     for (Object object : iterable) {

--- a/util/src/main/java/io/kubernetes/client/util/Yaml.java
+++ b/util/src/main/java/io/kubernetes/client/util/Yaml.java
@@ -166,7 +166,7 @@ public class Yaml {
    */
   public static Object load(Reader reader) throws IOException {
     Map<String, Object> data = getSnakeYaml().load(reader);
-    return ModelMapper(data);
+    return modelMapper(data);
   }
 
   /**
@@ -251,7 +251,11 @@ public class Yaml {
     List<Object> list = new ArrayList<Object>();
     for (Object object : iterable) {
       if (object != null) {
-        list.add(ModelMapper((Map<String, Object>) object));
+        try {
+          list.add(modelMapper((Map<String, Object>) object));
+        } catch (ClassCastException ex) {
+          logger.error("Unexpected exception while casting: " + ex);
+        }
       }
     }
 
@@ -287,7 +291,7 @@ public class Yaml {
    * @return An instantiation of the object.
    * @throws IOException
    */
-  private static Object ModelMapper(Map<String, Object> data) throws IOException {
+  private static Object modelMapper(Map<String, Object> data) throws IOException {
     String kind = (String) data.get("kind");
     if (kind == null) {
       throw new IOException("Missing kind in YAML file!");

--- a/util/src/main/java/io/kubernetes/client/util/Yaml.java
+++ b/util/src/main/java/io/kubernetes/client/util/Yaml.java
@@ -33,8 +33,6 @@ import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.ScalarNode;
 
 public class Yaml {
-  private static org.yaml.snakeyaml.Yaml yaml =
-      new org.yaml.snakeyaml.Yaml(new CustomConstructor());
   private static Map<String, Class<?>> classes = new HashMap<>();
   private static Map<String, String> apiGroups = new HashMap<>();
   private static List<String> apiVersions = new ArrayList<>();
@@ -167,7 +165,129 @@ public class Yaml {
    * @throws IOException If an error occurs while reading the YAML.
    */
   public static Object load(Reader reader) throws IOException {
-    Map<String, Object> data = yaml.load(reader);
+    Map<String, Object> data = getSnakeYaml().load(reader);
+    return ModelMapper(data);
+  }
+
+  /**
+   * Load an API object from a YAML string representation. Returns a concrete typed object using the
+   * type specified.
+   *
+   * @param content The YAML content
+   * @param clazz The class of object to return.
+   * @return An instantiation of the object.
+   * @throws IOException If an error occurs while reading the YAML.
+   */
+  public static <T> T loadAs(String content, Class<T> clazz) {
+    return getSnakeYaml().loadAs(new StringReader(content), clazz);
+  }
+
+  /**
+   * Load an API object from a YAML file. Returns a concrete typed object using the type specified.
+   *
+   * @param f The YAML file
+   * @param clazz The class of object to return.
+   * @return An instantiation of the object.
+   * @throws IOException If an error occurs while reading the YAML.
+   */
+  public static <T> T loadAs(File f, Class<T> clazz) throws IOException {
+    return getSnakeYaml().loadAs(new FileReader(f), clazz);
+  }
+
+  /**
+   * Load an API object from a YAML stream. Returns a concrete typed object using the type
+   * specified.
+   *
+   * @param reader The YAML stream
+   * @param clazz The class of object to return.
+   * @return An instantiation of the object.
+   * @throws IOException If an error occurs while reading the YAML.
+   */
+  public static <T> T loadAs(Reader reader, Class<T> clazz) {
+    return getSnakeYaml().loadAs(reader, clazz);
+  }
+
+  /**
+   * Load list of instantiated API objects from a YAML string representation. Returns list of
+   * concrete typed objects (e.g. { V1Pod, V1SERVICE })
+   *
+   * <p>Order of API objects in list will be preserved according to order of objects in YAML string.
+   *
+   * @param content The YAML content
+   * @return List of instantiated objects.
+   * @throws IOException If an error occurs while reading the YAML.
+   */
+  public static List<Object> loadAllAs(String content) throws IOException {
+    return loadAllAs(new StringReader(content));
+  }
+
+  /**
+   * Load list of instantiated API objects from a YAML file. Returns list of concrete typed objects
+   * (e.g. { V1Pod, V1SERVICE })
+   *
+   * <p>Order of API objects in list will be preserved according to order of objects in YAML file.
+   *
+   * @param f The file to load.
+   * @return List of instantiated of the objects.
+   * @throws IOException If an error occurs while reading the YAML.
+   */
+  public static List<Object> loadAllAs(File f) throws IOException {
+    return loadAllAs(new FileReader(f));
+  }
+
+  /**
+   * Load list of instantiated API objects from a stream of data. Returns list of concrete typed
+   * objects (e.g. { V1Pod, V1SERVICE })
+   *
+   * <p>Order of API objects in list will be preserved according to order of objects in stream of
+   * data.
+   *
+   * @param reader The stream to load.
+   * @return List of instantiated of the objects.
+   * @throws IOException If an error occurs while reading the YAML.
+   */
+  public static List<Object> loadAllAs(Reader reader) throws IOException {
+    Iterable<Object> iterable = getSnakeYaml().loadAll(reader);
+    List<Object> list = new ArrayList<Object>();
+    for (Object object : iterable) {
+      if (object != null) {
+        list.add(ModelMapper((Map<String, Object>) object));
+      }
+    }
+
+    return list;
+  }
+
+  /** Defines constructor logic for custom types in this library. */
+  public static class CustomConstructor extends Constructor {
+    @Override
+    protected Object constructObject(Node node) {
+      if (node.getType() == IntOrString.class) {
+        return constructIntOrString((ScalarNode) node);
+      }
+      return super.constructObject(node);
+    }
+
+    private IntOrString constructIntOrString(ScalarNode node) {
+      try {
+        return new IntOrString(Integer.parseInt(node.getValue()));
+      } catch (NumberFormatException err) {
+        return new IntOrString(node.getValue());
+      }
+    }
+  }
+
+  /** @return An instantiated SnakeYaml Object. */
+  public static org.yaml.snakeyaml.Yaml getSnakeYaml() {
+    return new org.yaml.snakeyaml.Yaml(new CustomConstructor());
+  }
+
+  /**
+   * @param data Map that will be converted to concrete API object.
+   * @return An instantiation of the object.
+   * @throws IOException
+   */
+  private static Object ModelMapper(Map<String, Object> data) throws IOException {
     String kind = (String) data.get("kind");
     if (kind == null) {
       throw new IOException("Missing kind in YAML file!");
@@ -193,63 +313,6 @@ public class Yaml {
               + " known kinds are: "
               + classes.toString());
     }
-    return loadAs(new StringReader(yaml.dump(data)), clazz);
-  }
-
-  /**
-   * Load an API object from a YAML string representation. Returns a concrete typed object using the
-   * type specified.
-   *
-   * @param content The YAML content
-   * @param clazz The class of object to return.
-   * @return An instantiation of the object.
-   * @throws IOException If an error occurs while reading the YAML.
-   */
-  public static <T> T loadAs(String content, Class<T> clazz) {
-    return yaml.loadAs(new StringReader(content), clazz);
-  }
-
-  /**
-   * Load an API object from a YAML file. Returns a concrete typed object using the type specified.
-   *
-   * @param f The YAML file
-   * @param clazz The class of object to return.
-   * @return An instantiation of the object.
-   * @throws IOException If an error occurs while reading the YAML.
-   */
-  public static <T> T loadAs(File f, Class<T> clazz) throws IOException {
-    return yaml.loadAs(new FileReader(f), clazz);
-  }
-
-  /**
-   * Load an API object from a YAML stream. Returns a concrete typed object using the type
-   * specified.
-   *
-   * @param reader The YAML stream
-   * @param clazz The class of object to return.
-   * @return An instantiation of the object.
-   * @throws IOException If an error occurs while reading the YAML.
-   */
-  public static <T> T loadAs(Reader reader, Class<T> clazz) {
-    return yaml.loadAs(reader, clazz);
-  }
-
-  /** Defines constructor logic for custom types in this library. */
-  public static class CustomConstructor extends Constructor {
-    @Override
-    protected Object constructObject(Node node) {
-      if (node.getType() == IntOrString.class) {
-        return constructIntOrString((ScalarNode) node);
-      }
-      return super.constructObject(node);
-    }
-
-    private IntOrString constructIntOrString(ScalarNode node) {
-      try {
-        return new IntOrString(Integer.parseInt(node.getValue()));
-      } catch (NumberFormatException err) {
-        return new IntOrString(node.getValue());
-      }
-    }
+    return loadAs(new StringReader(getSnakeYaml().dump(data)), clazz);
   }
 }

--- a/util/src/test/java/io/kubernetes/client/util/YamlTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/YamlTest.java
@@ -84,7 +84,7 @@ public class YamlTest {
   }
 
   @Test
-  public void testLoadAllAs() throws IOException {
+  public void testLoadAll() throws IOException {
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < kinds.length; i++) {
       sb.append(input.replace("XXXX", kinds[i]).replace("YYYY", apiVersions[i]));
@@ -92,7 +92,7 @@ public class YamlTest {
     }
 
     List<Object> list = null;
-    list = (List<Object>) Yaml.loadAllAs(sb.toString());
+    list = (List<Object>) Yaml.loadAll(sb.toString());
     for (int i = 0; i < kinds.length; i++) {
       String className = classNames[i];
       try {
@@ -109,8 +109,8 @@ public class YamlTest {
   }
 
   @Test
-  public void testLoadAllAsFile() throws Exception {
-    List<Object> list = Yaml.loadAllAs(new File(TEST_YAML_FILE_PATH));
+  public void testLoadAllFile() throws Exception {
+    List<Object> list = Yaml.loadAll(new File(TEST_YAML_FILE_PATH));
     for (Object object : list) {
       String type = object.getClass().getSimpleName();
       if (type.equals("V1Service")) {

--- a/util/src/test/java/io/kubernetes/client/util/YamlTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/YamlTest.java
@@ -14,62 +14,64 @@ package io.kubernetes.client.util;
 
 import static org.junit.Assert.*;
 
+import com.google.common.io.Resources;
+import io.kubernetes.client.models.AppsV1beta1Deployment;
 import io.kubernetes.client.models.V1ObjectMeta;
+import io.kubernetes.client.models.V1Service;
 import io.kubernetes.client.models.V1ServicePort;
+import java.io.File;
+import java.io.IOException;
 import java.io.StringReader;
 import java.lang.reflect.Method;
+import java.util.List;
 import org.junit.Test;
 
 public class YamlTest {
+  private static final String TEST_YAML_FILE_PATH = Resources.getResource("test.yaml").getPath();
+  private static final String[] kinds =
+      new String[] {
+        "Pod",
+        "CronJob",
+        "HorizontalPodAutoscaler",
+        "ClusterRole",
+        "Deployment",
+        "APIService",
+        "Scale",
+        "Deployment"
+      };
+  private static final String[] apiVersions =
+      new String[] {
+        "v1",
+        "batch/v2alpha1",
+        "autoscaling/v2beta1",
+        "rbac.authorization.k8s.io/v1alpha1",
+        "apps/v1beta2",
+        "apiregistration.k8s.io/v1beta1",
+        "extensions/v1beta1",
+        "apps/v1beta1"
+      };
+  private static final String[] classNames =
+      new String[] {
+        "V1Pod",
+        "V2alpha1CronJob",
+        "V2beta1HorizontalPodAutoscaler",
+        "V1alpha1ClusterRole",
+        "V1beta2Deployment",
+        "V1beta1APIService",
+        "ExtensionsV1beta1Scale",
+        "AppsV1beta1Deployment"
+      };
+  private static final String input =
+      "kind: " + "XXXX" + "\n" + "apiVersion: " + "YYYY" + "\n" + "metadata:\n" + "  name: foo";
+
   @Test
   public void testLoad() {
-    String[] kinds =
-        new String[] {
-          "Pod",
-          "CronJob",
-          "HorizontalPodAutoscaler",
-          "ClusterRole",
-          "Deployment",
-          "APIService",
-          "Scale",
-          "Deployment"
-        };
-    String[] apiVersions =
-        new String[] {
-          "v1",
-          "batch/v2alpha1",
-          "autoscaling/v2beta1",
-          "rbac.authorization.k8s.io/v1alpha1",
-          "apps/v1beta2",
-          "apiregistration.k8s.io/v1beta1",
-          "extensions/v1beta1",
-          "apps/v1beta1"
-        };
-    String[] classNames =
-        new String[] {
-          "V1Pod",
-          "V2alpha1CronJob",
-          "V2beta1HorizontalPodAutoscaler",
-          "V1alpha1ClusterRole",
-          "V1beta2Deployment",
-          "V1beta1APIService",
-          "ExtensionsV1beta1Scale",
-          "AppsV1beta1Deployment"
-        };
     for (int i = 0; i < kinds.length; i++) {
-      String kind = kinds[i];
       String className = classNames[i];
       try {
-        String input =
-            "kind: "
-                + kind
-                + "\n"
-                + "apiVersion: "
-                + apiVersions[i]
-                + "\n"
-                + "metadata:\n"
-                + "  name: foo";
-        Object obj = Yaml.load(new StringReader(input));
+        Object obj =
+            Yaml.load(
+                new StringReader(input.replace("XXXX", kinds[i]).replace("YYYY", apiVersions[i])));
         Method m = obj.getClass().getMethod("getMetadata");
         V1ObjectMeta metadata = (V1ObjectMeta) m.invoke(obj);
 
@@ -77,6 +79,52 @@ public class YamlTest {
         assertEquals(className, obj.getClass().getSimpleName());
       } catch (Exception ex) {
         assertNull("Unexpected exception: " + ex.toString(), ex);
+      }
+    }
+  }
+
+  @Test
+  public void testLoadAllAs() throws IOException {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < kinds.length; i++) {
+      sb.append(input.replace("XXXX", kinds[i]).replace("YYYY", apiVersions[i]));
+      sb.append("\n---\n");
+    }
+
+    List<Object> list = null;
+    list = (List<Object>) Yaml.loadAllAs(sb.toString());
+    for (int i = 0; i < kinds.length; i++) {
+      String className = classNames[i];
+      try {
+        Object obj = list.get(i);
+        Method m = obj.getClass().getMethod("getMetadata");
+        V1ObjectMeta metadata = (V1ObjectMeta) m.invoke(obj);
+
+        assertEquals("foo", metadata.getName());
+        assertEquals(className, obj.getClass().getSimpleName());
+      } catch (Exception ex) {
+        assertNull("Unexpected exception: " + ex.toString(), ex);
+      }
+    }
+  }
+
+  @Test
+  public void testLoadAllAsFile() throws Exception {
+    List<Object> list = Yaml.loadAllAs(new File(TEST_YAML_FILE_PATH));
+    for (Object object : list) {
+      String type = object.getClass().getSimpleName();
+      if (type.equals("V1Service")) {
+        V1Service svc = (V1Service) object;
+        assertEquals("v1", svc.getApiVersion());
+        assertEquals("Service", svc.getKind());
+        assertEquals("mock", svc.getMetadata().getName());
+      } else if (type.equals("AppsV1beta1Deployment")) {
+        AppsV1beta1Deployment deploy = (AppsV1beta1Deployment) object;
+        assertEquals("apps/v1beta1", deploy.getApiVersion());
+        assertEquals("Deployment", deploy.getKind());
+        assertEquals("helloworld", deploy.getMetadata().getName());
+      } else {
+        throw new Exception("some thing wrong happened");
       }
     }
   }

--- a/util/src/test/resources/test.yaml
+++ b/util/src/test/resources/test.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mock
+  labels:
+    app: mock
+spec:
+  ports:
+  - port: 99
+    protocol: TCP
+    targetPort: 9949
+  selector:
+    app: mock
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: helloworld
+  name: helloworld
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: helloworld
+      name: helloworld
+    spec:
+      containers:
+        - name: helloworld
+          image: gcr.io/hightowerlabs/helloworld:0.0.1
+          imagePullPolicy: Always
+          args:
+            - "-http=127.0.0.1:8080"
+


### PR DESCRIPTION

- adding Yaml.loadAllAs() method to support multi yaml documents from single file. issue https://github.com/kubernetes-client/java/issues/254
- Moved static org.yaml.snakeyaml.Yaml(new CustomConstructor()) to getSnakeYaml() as, loading(loadAll)  multi yaml file using static snake yaml object and again using same static snake yaml object to instantiate the individual objects (org.yaml.snakeyaml.Yaml.loadAs()) is causing the Iterable to loose next element and causes null pointer exceptions.

- methods added:
  * List<Object> loadAllAs(String content)
  * List<Object> loadAllAs(File f)
  * List<Object> loadAllAs(Reader reader)

