### PR TITLE
BatchV1Api throw IllegalStateException.

### DIFF
--- a/kubernetes/src/main/java/io/kubernetes/client/apis/BatchV1Api.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/apis/BatchV1Api.java
@@ -13,6 +13,7 @@
 
 package io.kubernetes.client.apis;
 
+import com.google.gson.reflect.TypeToken;
 import io.kubernetes.client.ApiCallback;
 import io.kubernetes.client.ApiClient;
 import io.kubernetes.client.ApiException;
@@ -21,18 +22,13 @@ import io.kubernetes.client.Configuration;
 import io.kubernetes.client.Pair;
 import io.kubernetes.client.ProgressRequestBody;
 import io.kubernetes.client.ProgressResponseBody;
-
-import com.google.gson.reflect.TypeToken;
-
-import java.io.IOException;
-
-
 import io.kubernetes.client.models.V1APIResourceList;
 import io.kubernetes.client.models.V1DeleteOptions;
 import io.kubernetes.client.models.V1Job;
 import io.kubernetes.client.models.V1JobList;
-import io.kubernetes.client.models.V1Status;
+import io.kubernetes.client.models.V1JobStatus;
 
+import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -308,11 +304,11 @@ public class BatchV1Api {
      * @param resourceVersion When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history. When specified for list: - if unset, then the result is returned from remote storage based on quorum-read flag; - if it&#39;s 0, then we simply return what we currently have in cache, no guarantee; - if set to non zero, then the result is at least as fresh as given rv. (optional)
      * @param timeoutSeconds Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity. (optional)
      * @param watch Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion. (optional)
-     * @return V1Status
+     * @return V1JobStatus
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public V1Status deleteCollectionNamespacedJob(String namespace, String pretty, String _continue, String fieldSelector, Boolean includeUninitialized, String labelSelector, Integer limit, String resourceVersion, Integer timeoutSeconds, Boolean watch) throws ApiException {
-        ApiResponse<V1Status> resp = deleteCollectionNamespacedJobWithHttpInfo(namespace, pretty, _continue, fieldSelector, includeUninitialized, labelSelector, limit, resourceVersion, timeoutSeconds, watch);
+    public V1JobStatus deleteCollectionNamespacedJob(String namespace, String pretty, String _continue, String fieldSelector, Boolean includeUninitialized, String labelSelector, Integer limit, String resourceVersion, Integer timeoutSeconds, Boolean watch) throws ApiException {
+        ApiResponse<V1JobStatus> resp = deleteCollectionNamespacedJobWithHttpInfo(namespace, pretty, _continue, fieldSelector, includeUninitialized, labelSelector, limit, resourceVersion, timeoutSeconds, watch);
         return resp.getData();
     }
 
@@ -329,12 +325,12 @@ public class BatchV1Api {
      * @param resourceVersion When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history. When specified for list: - if unset, then the result is returned from remote storage based on quorum-read flag; - if it&#39;s 0, then we simply return what we currently have in cache, no guarantee; - if set to non zero, then the result is at least as fresh as given rv. (optional)
      * @param timeoutSeconds Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity. (optional)
      * @param watch Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion. (optional)
-     * @return ApiResponse&lt;V1Status&gt;
+     * @return ApiResponse&lt;V1JobStatus&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public ApiResponse<V1Status> deleteCollectionNamespacedJobWithHttpInfo(String namespace, String pretty, String _continue, String fieldSelector, Boolean includeUninitialized, String labelSelector, Integer limit, String resourceVersion, Integer timeoutSeconds, Boolean watch) throws ApiException {
+    public ApiResponse<V1JobStatus> deleteCollectionNamespacedJobWithHttpInfo(String namespace, String pretty, String _continue, String fieldSelector, Boolean includeUninitialized, String labelSelector, Integer limit, String resourceVersion, Integer timeoutSeconds, Boolean watch) throws ApiException {
         com.squareup.okhttp.Call call = deleteCollectionNamespacedJobValidateBeforeCall(namespace, pretty, _continue, fieldSelector, includeUninitialized, labelSelector, limit, resourceVersion, timeoutSeconds, watch, null, null);
-        Type localVarReturnType = new TypeToken<V1Status>(){}.getType();
+        Type localVarReturnType = new TypeToken<V1JobStatus>(){}.getType();
         return apiClient.execute(call, localVarReturnType);
     }
 
@@ -355,7 +351,7 @@ public class BatchV1Api {
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
      */
-    public com.squareup.okhttp.Call deleteCollectionNamespacedJobAsync(String namespace, String pretty, String _continue, String fieldSelector, Boolean includeUninitialized, String labelSelector, Integer limit, String resourceVersion, Integer timeoutSeconds, Boolean watch, final ApiCallback<V1Status> callback) throws ApiException {
+    public com.squareup.okhttp.Call deleteCollectionNamespacedJobAsync(String namespace, String pretty, String _continue, String fieldSelector, Boolean includeUninitialized, String labelSelector, Integer limit, String resourceVersion, Integer timeoutSeconds, Boolean watch, final ApiCallback<V1JobStatus> callback) throws ApiException {
 
         ProgressResponseBody.ProgressListener progressListener = null;
         ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
@@ -377,7 +373,7 @@ public class BatchV1Api {
         }
 
         com.squareup.okhttp.Call call = deleteCollectionNamespacedJobValidateBeforeCall(namespace, pretty, _continue, fieldSelector, includeUninitialized, labelSelector, limit, resourceVersion, timeoutSeconds, watch, progressListener, progressRequestListener);
-        Type localVarReturnType = new TypeToken<V1Status>(){}.getType();
+        Type localVarReturnType = new TypeToken<V1JobStatus>(){}.getType();
         apiClient.executeAsync(call, localVarReturnType, callback);
         return call;
     }
@@ -484,11 +480,11 @@ public class BatchV1Api {
      * @param gracePeriodSeconds The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately. (optional)
      * @param orphanDependents Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \&quot;orphan\&quot; finalizer will be added to/removed from the object&#39;s finalizers list. Either this field or PropagationPolicy may be set, but not both. (optional)
      * @param propagationPolicy Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: &#39;Orphan&#39; - orphan the dependents; &#39;Background&#39; - allow the garbage collector to delete the dependents in the background; &#39;Foreground&#39; - a cascading policy that deletes all dependents in the foreground. (optional)
-     * @return V1Status
+     * @return V1JobStatus
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public V1Status deleteNamespacedJob(String name, String namespace, V1DeleteOptions body, String pretty, Integer gracePeriodSeconds, Boolean orphanDependents, String propagationPolicy) throws ApiException {
-        ApiResponse<V1Status> resp = deleteNamespacedJobWithHttpInfo(name, namespace, body, pretty, gracePeriodSeconds, orphanDependents, propagationPolicy);
+    public V1JobStatus deleteNamespacedJob(String name, String namespace, V1DeleteOptions body, String pretty, Integer gracePeriodSeconds, Boolean orphanDependents, String propagationPolicy) throws ApiException {
+        ApiResponse<V1JobStatus> resp = deleteNamespacedJobWithHttpInfo(name, namespace, body, pretty, gracePeriodSeconds, orphanDependents, propagationPolicy);
         return resp.getData();
     }
 
@@ -502,12 +498,12 @@ public class BatchV1Api {
      * @param gracePeriodSeconds The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately. (optional)
      * @param orphanDependents Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \&quot;orphan\&quot; finalizer will be added to/removed from the object&#39;s finalizers list. Either this field or PropagationPolicy may be set, but not both. (optional)
      * @param propagationPolicy Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: &#39;Orphan&#39; - orphan the dependents; &#39;Background&#39; - allow the garbage collector to delete the dependents in the background; &#39;Foreground&#39; - a cascading policy that deletes all dependents in the foreground. (optional)
-     * @return ApiResponse&lt;V1Status&gt;
+     * @return ApiResponse&lt;V1JobStatus&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public ApiResponse<V1Status> deleteNamespacedJobWithHttpInfo(String name, String namespace, V1DeleteOptions body, String pretty, Integer gracePeriodSeconds, Boolean orphanDependents, String propagationPolicy) throws ApiException {
+    public ApiResponse<V1JobStatus> deleteNamespacedJobWithHttpInfo(String name, String namespace, V1DeleteOptions body, String pretty, Integer gracePeriodSeconds, Boolean orphanDependents, String propagationPolicy) throws ApiException {
         com.squareup.okhttp.Call call = deleteNamespacedJobValidateBeforeCall(name, namespace, body, pretty, gracePeriodSeconds, orphanDependents, propagationPolicy, null, null);
-        Type localVarReturnType = new TypeToken<V1Status>(){}.getType();
+        Type localVarReturnType = new TypeToken<V1JobStatus>(){}.getType();
         return apiClient.execute(call, localVarReturnType);
     }
 
@@ -525,7 +521,7 @@ public class BatchV1Api {
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
      */
-    public com.squareup.okhttp.Call deleteNamespacedJobAsync(String name, String namespace, V1DeleteOptions body, String pretty, Integer gracePeriodSeconds, Boolean orphanDependents, String propagationPolicy, final ApiCallback<V1Status> callback) throws ApiException {
+    public com.squareup.okhttp.Call deleteNamespacedJobAsync(String name, String namespace, V1DeleteOptions body, String pretty, Integer gracePeriodSeconds, Boolean orphanDependents, String propagationPolicy, final ApiCallback<V1JobStatus> callback) throws ApiException {
 
         ProgressResponseBody.ProgressListener progressListener = null;
         ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
@@ -547,7 +543,7 @@ public class BatchV1Api {
         }
 
         com.squareup.okhttp.Call call = deleteNamespacedJobValidateBeforeCall(name, namespace, body, pretty, gracePeriodSeconds, orphanDependents, propagationPolicy, progressListener, progressRequestListener);
-        Type localVarReturnType = new TypeToken<V1Status>(){}.getType();
+        Type localVarReturnType = new TypeToken<V1JobStatus>(){}.getType();
         apiClient.executeAsync(call, localVarReturnType, callback);
         return call;
     }

--- a/kubernetes/src/test/java/io/kubernetes/client/apis/BatchV1ApiTest.java
+++ b/kubernetes/src/test/java/io/kubernetes/client/apis/BatchV1ApiTest.java
@@ -18,14 +18,9 @@ import io.kubernetes.client.models.V1APIResourceList;
 import io.kubernetes.client.models.V1DeleteOptions;
 import io.kubernetes.client.models.V1Job;
 import io.kubernetes.client.models.V1JobList;
-import io.kubernetes.client.models.V1Status;
-import org.junit.Test;
+import io.kubernetes.client.models.V1JobStatus;
 import org.junit.Ignore;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import org.junit.Test;
 
 /**
  * API tests for BatchV1Api
@@ -74,7 +69,7 @@ public class BatchV1ApiTest {
         String resourceVersion = null;
         Integer timeoutSeconds = null;
         Boolean watch = null;
-        V1Status response = api.deleteCollectionNamespacedJob(namespace, pretty, _continue, fieldSelector, includeUninitialized, labelSelector, limit, resourceVersion, timeoutSeconds, watch);
+        V1JobStatus response = api.deleteCollectionNamespacedJob(namespace, pretty, _continue, fieldSelector, includeUninitialized, labelSelector, limit, resourceVersion, timeoutSeconds, watch);
 
         // TODO: test validations
     }
@@ -96,7 +91,7 @@ public class BatchV1ApiTest {
         Integer gracePeriodSeconds = null;
         Boolean orphanDependents = null;
         String propagationPolicy = null;
-        V1Status response = api.deleteNamespacedJob(name, namespace, body, pretty, gracePeriodSeconds, orphanDependents, propagationPolicy);
+        V1JobStatus response = api.deleteNamespacedJob(name, namespace, body, pretty, gracePeriodSeconds, orphanDependents, propagationPolicy);
 
         // TODO: test validations
     }


### PR DESCRIPTION
`BatchV1Api#deleteNamespacedJob` throws Exception below.
```
com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected a string but was BEGIN_OBJECT at line 67 column 14 path $.status
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:220)
	at com.google.gson.Gson.fromJson(Gson.java:879)
	at com.google.gson.Gson.fromJson(Gson.java:844)
	at com.google.gson.Gson.fromJson(Gson.java:793)
	at io.kubernetes.client.JSON.deserialize(JSON.java:110)
	at io.kubernetes.client.ApiClient.deserialize(ApiClient.java:668)
	at io.kubernetes.client.ApiClient.handleResponse(ApiClient.java:871)
	at io.kubernetes.client.ApiClient.execute(ApiClient.java:798)
	at io.kubernetes.client.apis.BatchV1Api.deleteNamespacedJobWithHttpInfo(BatchV1Api.java:511)
	at io.kubernetes.client.apis.BatchV1Api.deleteNamespacedJob(BatchV1Api.java:491)
	at jp.co.septeni_original.k8sop.CreateJobOperatorFactory.main(CreateJobOperatorFactory.java:99)
Caused by: java.lang.IllegalStateException: Expected a string but was BEGIN_OBJECT at line 67 column 14 path $.status
	at com.google.gson.stream.JsonReader.nextString(JsonReader.java:831)
	at com.google.gson.internal.bind.TypeAdapters$16.read(TypeAdapters.java:422)
	at com.google.gson.internal.bind.TypeAdapters$16.read(TypeAdapters.java:410)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:116)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:216)
	... 10 common frames omitted
```

Maybe K8S returns [V1JobStatus](https://github.com/kubernetes-client/java/blob/master/kubernetes/docs/V1JobStatus.md).(Not [V1Status](https://github.com/kubernetes-client/java/blob/master/kubernetes/docs/V1Status.md))
response example.
```json
{
    ...
    "status": {
        "conditions": [
            {
                "type": "Complete",
                "status": "True",
                "lastProbeTime": "2018-07-10T06:19:46Z",
                "lastTransitionTime": "2018-07-10T06:19:46Z"
            }
        ],
        "startTime": "2018-07-10T06:19:24Z",
        "completionTime": "2018-07-10T06:19:46Z",
        "succeeded": 1
    }
}
```

my test environment(GKE)
```
Client Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.2", GitCommit:"81753b10df112992bf51bbc2c2f85208aad78335", GitTreeState:"clean", BuildDate:"2018-05-12T04:12:12Z", GoVersion:"go1.9.6", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"8+", GitVersion:"v1.8.12-gke.1", GitCommit:"f47fa5292f604d07539ddbf7e5840b77d686051b", GitTreeState:"clean", BuildDate:"2018-05-11T16:56:15Z", GoVersion:"go1.8.3b4", Compiler:"gc", Platform:"linux/amd64"}
```