### PR TITLE
feat (#137): Introduce builder generation.

### DIFF
--- a/kubernetes/build.gradle
+++ b/kubernetes/build.gradle
@@ -99,5 +99,6 @@ dependencies {
     compile 'com.squareup.okhttp:logging-interceptor:2.7.5'
     compile 'com.google.code.gson:gson:2.6.2'
     compile 'joda-time:joda-time:2.9.3'
+    compile 'io.sundr:builder-annotations:0.8.0'
     testCompile 'junit:junit:4.12'
 }

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -130,6 +130,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.sundr</groupId>
+      <artifactId>builder-annotations</artifactId>
+      <version>${sundrio.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-annotations</artifactId>
       <version>${swagger-core-version}</version>
@@ -153,6 +159,11 @@
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
       <version>${jodatime-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.joda</groupId>
+      <artifactId>joda-convert</artifactId>
+      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -183,6 +194,7 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <swagger-core-version>1.5.12</swagger-core-version>
+    <sundrio.version>0.8.0</sundrio.version>
     <okhttp-version>2.7.5</okhttp-version>
     <gson-version>2.6.2</gson-version>
     <jodatime-version>2.9.3</jodatime-version>

--- a/kubernetes/src/main/java/io/kubernetes/client/fluent/Config.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/fluent/Config.java
@@ -5,7 +5,7 @@ import io.sundr.builder.annotations.ExternalBuildables;
 @ExternalBuildables(
         editableEnabled = false,
         generateBuilderPackage = true,
-        builderPackage = "io.kuberntes.client.fluent",
+        builderPackage = "io.kubernetes.client.fluent",
         value = {"io.kubernetes.client.models"}
 )
 public class Config {

--- a/kubernetes/src/main/java/io/kubernetes/client/fluent/Config.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/fluent/Config.java
@@ -1,0 +1,12 @@
+package io.kubernetes.client.fluent;
+
+import io.sundr.builder.annotations.ExternalBuildables;
+
+@ExternalBuildables(
+        editableEnabled = false,
+        generateBuilderPackage = true,
+        builderPackage = "io.kuberntes.client.fluent",
+        value = {"io.kubernetes.client.models"}
+)
+public class Config {
+}

--- a/kubernetes/src/test/java/io/kubernetes/client/models/V1PodBuilderTest.java
+++ b/kubernetes/src/test/java/io/kubernetes/client/models/V1PodBuilderTest.java
@@ -1,0 +1,35 @@
+package io.kubernetes.client.models;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class V1PodBuilderTest {
+
+    @Test
+    public void testBuilder() {
+        V1Pod pod1 = new V1PodBuilder()
+                .withNewMetadata()
+                    .withName("mypod")
+                .endMetadata()
+                .withNewSpec()
+                    .addNewContainer()
+                        .withName("cnt")
+                    .endContainer()
+                .endSpec()
+                .build();
+
+        V1Pod pod2 = new V1Pod()
+                .metadata(new V1ObjectMeta().name("mypod"))
+                .spec(new V1PodSpec()
+                        .containers(Arrays.asList(
+                                new V1Container().name("cnt")
+                                )
+                        )
+                );
+
+
+        Assert.assertEquals(pod1, pod2);
+    }
+}


### PR DESCRIPTION
This pull request introduces fluent builders for all generated types (using [1]).

Swagger generated code still is unaware of these builders and is still using the setters. 
IMHO, it would make sense for the model objects to be immutable (or the builders don't have any real value), but that is something that would require a custom swagger extension/generator.

If there is concensus that this is the way to go, I wouldn't mind adding such a swagger extention/generator to project that generates the builders [1].

[1]: https://github.com/sundrio/sundrio
