### PR TITLE
set content-type to merge-patch+json while building nodePatchCall

### DIFF
--- a/kubernetes/src/main/java/io/kubernetes/client/apis/CoreV1Api.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/apis/CoreV1Api.java
@@ -22610,7 +22610,7 @@ public class CoreV1Api {
         if (localVarAccept != null) localVarHeaderParams.put("Accept", localVarAccept);
 
         final String[] localVarContentTypes = {
-            "application/json-patch+json", "application/merge-patch+json", "application/strategic-merge-patch+json"
+            "application/merge-patch+json", "application/json-patch+json", "application/strategic-merge-patch+json"
         };
         final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
         localVarHeaderParams.put("Content-Type", localVarContentType);


### PR DESCRIPTION
We should set content-type to merge-patch+json while building nodePatchCall.