### PR TITLE
shutdown okhttp client after exec call

### DIFF
--- a/util/src/main/java/io/kubernetes/client/Exec.java
+++ b/util/src/main/java/io/kubernetes/client/Exec.java
@@ -347,6 +347,7 @@ public class Exec {
           log.error("Error on close", ex);
         }
       }
+      apiClient.getHttpClient().getDispatcher().getExecutorService().shutdown();
     }
   }
 }


### PR DESCRIPTION
After exec call there is an idle time because connection pool still persists for some time as it is a async call. 
so it would be better to close connection pool immediately when ExecProcess.destroy() is called.  