### PR TITLE
Update the versions used in the README to latest stable and beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ Add this dependency to your project's POM:
 <dependency>
     <groupId>io.kubernetes</groupId>
     <artifactId>client-java</artifactId>
-    <version>2.0.0-beta1</version>
+    <version>2.0.0</version>
+    <!-- or, for the latest beta version
+    <version>3.0.0-beta2</version>
+    -->
     <scope>compile</scope>
 </dependency>
 ```
@@ -34,7 +37,10 @@ Add this dependency to your project's POM:
 ### Gradle users
 
 ```groovy
-compile 'io.kubernetes:client-java:2.0.0-beta1'
+compile 'io.kubernetes:client-java:2.0.0'
+// or, for the latest beta version
+// compile 'io.kubernetes:client-java:3.0.0-beta2'
+
 ```
 
 ### Others
@@ -44,12 +50,13 @@ At first generate the JAR by executing:
 ```
 git clone --recursive https://github.com/kubernetes-client/java
 cd java
+cd kubernetes
 mvn package
 ```
 
 Then manually install the following JARs:
 
-* target/client-java-2.0.0-beta1-SNAPSHOT.jar
+* target/client-java-api-3.0.0-beta3-SNAPSHOT.jar
 * target/lib/*.jar
 
 ## Example
@@ -132,7 +139,7 @@ All APIs and Models' documentation can be found at the [Generated client's READM
 |  0.2.0           |  +               |  +               |  ✓               |  -               |  -               |  -          |  -         |  -         |
 |  1.0.0           |  +               |  +               |  +               |  +               |  ✓               |  -          |  -         |  -         |
 |  2.0.0           |  +               |  +               |  +               |  +               |  +               |  +          |  ✓         |  -         |
-|  3.0.0-beta1     |  +               |  +               |  +               |  +               |  +               |  +          |  +         |  ✓         |
+|  3.0.0-beta2     |  +               |  +               |  +               |  +               |  +               |  +          |  +         |  ✓         |
 
 Key: 
 


### PR DESCRIPTION
The versions in the README.md which is shown as the top-level document when looking at the repository, were outdated. Users might use those outdated versions and run into problems which have been fixed in the meantime.