### PR TITLE
Invoke async callback on unexpected exceptions

### DIFF
--- a/kubernetes/src/main/java/io/kubernetes/client/ApiClient.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/ApiClient.java
@@ -831,12 +831,15 @@ public class ApiClient {
             }
 
             @Override
-            public void onResponse(Response response) throws IOException {
+            public void onResponse(Response response) {
                 T result;
                 try {
                     result = (T) handleResponse(response, returnType);
                 } catch (ApiException e) {
                     callback.onFailure(e, response.code(), response.headers().toMultimap());
+                    return;
+                } catch (Throwable e) {
+                    callback.onFailure(new ApiException(e), 0, null);
                     return;
                 }
                 callback.onSuccess(result, response.code(), response.headers().toMultimap());

--- a/kubernetes/src/main/java/io/kubernetes/client/ApiClient.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/ApiClient.java
@@ -13,6 +13,7 @@
 
 package io.kubernetes.client;
 
+import com.google.gson.JsonParseException;
 import com.squareup.okhttp.*;
 import com.squareup.okhttp.internal.http.HttpMethod;
 import com.squareup.okhttp.logging.HttpLoggingInterceptor;
@@ -665,7 +666,11 @@ public class ApiClient {
             contentType = "application/json";
         }
         if (isJsonMime(contentType)) {
-            return json.deserialize(respBody, returnType);
+            try {
+                return json.deserialize(respBody, returnType);
+            } catch (JsonParseException e) {
+                throw new ApiException(e);
+            }
         } else if (returnType.equals(String.class)) {
             // Expecting string, return the raw response body.
             return (T) respBody;


### PR DESCRIPTION
Currently e.g. #86 causes an async request's callback to never be called, because deserialization fails with an exception that is not an `ApiException`.

- The first commit ensures the callback is called for any exception.
- The second commit wraps JSON exceptions in an `ApiException`, as the method's javadoc specifies.