### PR TITLE
Add merge in ProtoClient

### DIFF
--- a/util/src/main/java/io/kubernetes/client/ProtoClient.java
+++ b/util/src/main/java/io/kubernetes/client/ProtoClient.java
@@ -131,7 +131,7 @@ public class ProtoClient {
       T obj, String path, String apiVersion, String kind) throws ApiException, IOException {
     return request(obj.newBuilderForType(), path, "PUT", obj, apiVersion, kind);
   }
-  
+
   /**
    * Merge a Kubernetes API object using protocol buffer encoding. Performs a PATCH
    *

--- a/util/src/main/java/io/kubernetes/client/ProtoClient.java
+++ b/util/src/main/java/io/kubernetes/client/ProtoClient.java
@@ -131,6 +131,20 @@ public class ProtoClient {
       T obj, String path, String apiVersion, String kind) throws ApiException, IOException {
     return request(obj.newBuilderForType(), path, "PUT", obj, apiVersion, kind);
   }
+  
+  /**
+   * Merge a Kubernetes API object using protocol buffer encoding. Performs a PATCH
+   *
+   * @param obj The object to merge
+   * @param path The URL path to call
+   * @param apiVersion The api version to use
+   * @param kind The kind of the object
+   * @return An ObjectOrStatus which contains the Object requested, or a Status about the request.
+   */
+  public <T extends Message> ObjectOrStatus<T> merge(
+      T obj, String path, String apiVersion, String kind) throws ApiException, IOException {
+    return request(obj.newBuilderForType(), path, "PATCH", obj, apiVersion, kind);
+  }
 
   /**
    * Delete a kubernetes API object using protocol buffer encoding.


### PR DESCRIPTION
`ProtoClient.update(...)` uses PUT, but really, it replaces the existing resource with the given name by the resource passed as parameter `obj`. It shouldn't have been named `update`, but instead, it should have been named `replace` for clarity. 

[reference](https://kubernetes.io/docs/reference/federation/v1/operations/#_replace_the_specified_service)

I didn't rename it regardless, because it would be a breaking change, but I did add the `merge(...)` method which uses `PATCH`, as I think it would be better to avoid using the `request(...)` method as much as possible for clarity.