### PR TITLE
Remove extra `Quantity.fromString()` call

### DIFF
--- a/kubernetes/src/main/java/io/kubernetes/client/custom/Quantity.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/custom/Quantity.java
@@ -37,8 +37,9 @@ public class Quantity {
   }
 
   public Quantity(final String value) {
-    this.number = fromString(value).number;
-    this.format = fromString(value).format;
+    final Quantity quantity = fromString(value);
+    this.number = quantity.number;
+    this.format = quantity.format;
   }
 
   public BigDecimal getNumber() {


### PR DESCRIPTION
in Quantity constructor. Avoid doing extra work.
We only need to call it once.