### PR TITLE
Fix Quantity serialization

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/Yaml.java
+++ b/util/src/main/java/io/kubernetes/client/util/Yaml.java
@@ -14,6 +14,7 @@ package io.kubernetes.client.util;
 
 import com.google.common.reflect.ClassPath;
 import io.kubernetes.client.custom.IntOrString;
+import io.kubernetes.client.custom.Quantity;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
@@ -356,6 +357,7 @@ public class Yaml {
       this.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
       this.representers.put(IntOrString.class, new RepresentIntOrString());
       this.representers.put(byte[].class, new RepresentByteArray());
+      this.representers.put(Quantity.class, new RepresentQuantity());
     }
 
     private class RepresentIntOrString implements Represent {
@@ -375,6 +377,14 @@ public class Yaml {
       public Node representData(Object data) {
         String value = ByteString.of((byte[]) data).base64();
         return representScalar(Tag.STR, value);
+      }
+    }
+
+    private class RepresentQuantity implements Represent {
+      @Override
+      public Node representData(Object data) {
+        Quantity quantity = (Quantity) data;
+        return representScalar(Tag.STR, quantity.toSuffixedString());
       }
     }
 

--- a/util/src/test/java/io/kubernetes/client/util/YamlTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/YamlTest.java
@@ -12,7 +12,13 @@ limitations under the License.
  */
 package io.kubernetes.client.util;
 
-import static org.junit.Assert.*;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.io.Resources;
 import io.kubernetes.client.models.AppsV1beta1Deployment;
@@ -26,14 +32,17 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.net.URL;
 import java.util.List;
 import org.junit.Test;
 
 public class YamlTest {
-  private static final String TEST_YAML_FILE_PATH = Resources.getResource("test.yaml").getPath();
+
+  private static final URL TEST_YAML_FILE = Resources.getResource("test.yaml");
+  private static final String TEST_YAML_FILE_PATH = TEST_YAML_FILE.getPath();
+
+  private static final URL EXPECTED_YAML_FILE = Resources.getResource("expected.yaml");
+
   private static final String[] kinds =
       new String[] {
         "Pod",
@@ -134,16 +143,14 @@ public class YamlTest {
         assertEquals("Secret", secret.getKind());
         assertEquals("secret", secret.getMetadata().getName());
         assertEquals("Opaque", secret.getType());
-        assertEquals(
-            "hello", new String(secret.getData().get("secret-data"), StandardCharsets.UTF_8));
+        assertEquals("hello", new String(secret.getData().get("secret-data"), UTF_8));
       } else {
         throw new Exception("some thing wrong happened");
       }
     }
     String result = Yaml.dumpAll(list.iterator());
-    String expected =
-        new String(Files.readAllBytes(Paths.get(TEST_YAML_FILE_PATH)), StandardCharsets.UTF_8);
-    assertEquals(expected, result);
+    String expected = Resources.toString(EXPECTED_YAML_FILE, UTF_8);
+    assertThat(result, equalTo(expected));
   }
 
   @Test
@@ -202,7 +209,7 @@ public class YamlTest {
       assertEquals(
           "Incorrect value loaded for Base64 encoded secret",
           "hello",
-          new String(secret.getData().get("hello"), StandardCharsets.UTF_8));
+          new String(secret.getData().get("hello"), UTF_8));
 
     } catch (Exception ex) {
       assertNull("Unexpected exception: " + ex.toString(), ex);
@@ -223,9 +230,7 @@ public class YamlTest {
       assertEquals(
           "Incorrect value loaded for creationTimestamp",
           "2018-09-06T15:12:24.000Z",
-          new String(
-              pod.getMetadata().getCreationTimestamp().toString().getBytes(),
-              StandardCharsets.UTF_8));
+          new String(pod.getMetadata().getCreationTimestamp().toString().getBytes(), UTF_8));
 
     } catch (Exception ex) {
       assertNull("Unexpected exception: " + ex.toString(), ex);

--- a/util/src/test/resources/expected.yaml
+++ b/util/src/test/resources/expected.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: mock
+  name: mock
+spec:
+  ports:
+  - port: 99
+    protocol: TCP
+    targetPort: 9949
+  selector:
+    app: mock
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: helloworld
+  name: helloworld
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: helloworld
+      name: helloworld
+    spec:
+      containers:
+      - args:
+        - -http=127.0.0.1:8080
+        image: gcr.io/hightowerlabs/helloworld:0.0.1
+        imagePullPolicy: Always
+        name: helloworld
+        resources:
+          limits:
+            memory: 1Gi
+            cpu: 500m
+          requests:
+            memory: 4Gi
+            cpu: '2'
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret
+type: Opaque
+data:
+  secret-data: aGVsbG8=

--- a/util/src/test/resources/test.yaml
+++ b/util/src/test/resources/test.yaml
@@ -32,6 +32,13 @@ spec:
         image: gcr.io/hightowerlabs/helloworld:0.0.1
         imagePullPolicy: Always
         name: helloworld
+        resources:
+          limits:
+            memory: 1Gi
+            cpu: 0.5
+          requests:
+            memory: 4Gi
+            cpu: 2
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
Fix failing `YamlTest.testLoadAllFile()`

by adding a `CustomRepresenter` for `Quantity` to `Yaml`.

The serialized Deployment YAML's resource requests won't necessarily be in the
same format as the original. But this PR prevents the serialization from
returning empty maps which is an improvement.

In the future, another PR can be made which could guarantee the original YAML
is returned when serializing Deployment back to YAML.