### PR TITLE
Fix serialization of null quantities

### DIFF
--- a/kubernetes/src/main/java/io/kubernetes/client/custom/Quantity.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/custom/Quantity.java
@@ -84,7 +84,7 @@ public class Quantity {
   public class QuantityAdapter extends TypeAdapter<Quantity> {
     @Override
     public void write(JsonWriter jsonWriter, Quantity quantity) throws IOException {
-      jsonWriter.value(quantity.toSuffixedString());
+      jsonWriter.value(quantity != null ? quantity.toSuffixedString() : null);
     }
 
     @Override


### PR DESCRIPTION
Handles properly null quantities instead of throwing `NullPointerException`s. 
Fixes https://github.com/kubernetes-client/java/issues/441.