### PR TITLE
Mark com.microsoft.azure.adal4j optional

### DIFF
--- a/util/pom.xml
+++ b/util/pom.xml
@@ -70,6 +70,7 @@
             <groupId>com.microsoft.azure</groupId>
             <artifactId>adal4j</artifactId>
             <version>1.6.0</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -102,11 +103,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock</artifactId>
-			<version>2.19.0</version>
-			<scope>test</scope>
-		</dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>2.19.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
I'm trying to use the Java client in an OSGi application, which is failing as the Java client library has a dependency on the `com.microsoft.aad.adal4j` package.  This package cannot be found as `com.microsoft.azure:adal4j` dependency does not carry OSGi metadata.

But since this library is only required to use the Azure authenticator, we should mark this dependency as optional, which also marks the `com.microsoft.aad.adal4j` package dependency as optional too.

(This PR also fixes some stray tabs.)