### PR TITLE
Update Dockerfile

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jre
 
-COPY target/client-java-examples-3.0.0-beta2-SNAPSHOT-jar-with-dependencies.jar /examples.jar
+COPY target/client-java-examples-*-SNAPSHOT-jar-with-dependencies.jar /examples.jar
 
 CMD ["java", "-jar", "/examples.jar"]
 


### PR DESCRIPTION
to always reflect correct version of the jar when copying.