### PR TITLE
#238: support client.authentication.k8s.io/v1beta1 ExecCredential

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.22.0</version>
+          <configuration>
+            <trimStackTrace>false</trimStackTrace> <!-- SUREFIRE-1226 workaround -->
+          </configuration>
         </plugin>
         <plugin>
           <groupId>com.coveo</groupId>

--- a/util/src/main/java/io/kubernetes/client/util/ClientBuilder.java
+++ b/util/src/main/java/io/kubernetes/client/util/ClientBuilder.java
@@ -78,21 +78,23 @@ public class ClientBuilder {
   public static ClientBuilder standard(boolean persistConfig) throws IOException {
     final File kubeConfig = findConfigFromEnv();
     if (kubeConfig != null) {
-      try (FileReader kubeConfigReader = new FileReader(kubeConfig)) {
+      try (FileReader kubeConfigReader = new FileReader(kubeConfig)) { // TODO UTF-8
         KubeConfig kc = KubeConfig.loadKubeConfig(kubeConfigReader);
         if (persistConfig) {
           kc.setPersistConfig(new FilePersister(kubeConfig));
         }
+        kc.setFile(kubeConfig);
         return kubeconfig(kc);
       }
     }
     final File config = findConfigInHomeDir();
     if (config != null) {
-      try (FileReader configReader = new FileReader(config)) {
+      try (FileReader configReader = new FileReader(config)) { // TODO UTF-8
         KubeConfig kc = KubeConfig.loadKubeConfig(configReader);
         if (persistConfig) {
           kc.setPersistConfig(new FilePersister(config));
         }
+        kc.setFile(kubeConfig);
         return kubeconfig(kc);
       }
     }

--- a/util/src/main/java/io/kubernetes/client/util/Config.java
+++ b/util/src/main/java/io/kubernetes/client/util/Config.java
@@ -15,6 +15,7 @@ package io.kubernetes.client.util;
 import io.kubernetes.client.ApiClient;
 import io.kubernetes.client.util.credentials.AccessTokenAuthentication;
 import io.kubernetes.client.util.credentials.UsernamePasswordAuthentication;
+import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -73,11 +74,13 @@ public class Config {
   }
 
   public static ApiClient fromConfig(String fileName) throws IOException {
-    return fromConfig(new FileReader(fileName));
+    KubeConfig config = KubeConfig.loadKubeConfig(new FileReader(fileName)); // TODO UTF-8
+    config.setFile(new File(fileName));
+    return fromConfig(config);
   }
 
   public static ApiClient fromConfig(InputStream stream) throws IOException {
-    return fromConfig(new InputStreamReader(stream));
+    return fromConfig(new InputStreamReader(stream)); // TODO UTF-8
   }
 
   public static ApiClient fromConfig(Reader input) throws IOException {

--- a/util/src/main/java/io/kubernetes/client/util/KubeConfig.java
+++ b/util/src/main/java/io/kubernetes/client/util/KubeConfig.java
@@ -257,8 +257,8 @@ public class KubeConfig {
       return null;
     }
     String apiVersion = (String) execMap.get("apiVersion");
-    if (!"client.authentication.k8s.io/v1beta1".equals(apiVersion)) {
-      // TODO or v1alpha1 is apparently identical and could be supported
+    if (!"client.authentication.k8s.io/v1beta1".equals(apiVersion)
+        && !"client.authentication.k8s.io/v1alpha1".equals(apiVersion)) {
       log.error("Unrecognized user.exec.apiVersion: {}", apiVersion);
       return null;
     }

--- a/util/src/main/java/io/kubernetes/client/util/KubeConfig.java
+++ b/util/src/main/java/io/kubernetes/client/util/KubeConfig.java
@@ -283,6 +283,7 @@ public class KubeConfig {
       log.warn("No token produced by {}", command);
       return null;
     }
+    log.debug("Obtained a token from {}", command);
     return token.getAsString();
     // TODO cache tokens between calls, up to .status.expirationTimestamp
     // TODO a 401 is supposed to force a refresh,

--- a/util/src/main/java/io/kubernetes/client/util/KubeConfig.java
+++ b/util/src/main/java/io/kubernetes/client/util/KubeConfig.java
@@ -222,7 +222,8 @@ public class KubeConfig {
         }
       }
     }
-    String tokenViaExecCredential = tokenViaExecCredential((Map<String, Object>) currentUser.get("exec"));
+    String tokenViaExecCredential =
+        tokenViaExecCredential((Map<String, Object>) currentUser.get("exec"));
     if (tokenViaExecCredential != null) {
       return tokenViaExecCredential;
     }
@@ -243,14 +244,18 @@ public class KubeConfig {
 
   /**
    * Attempt to create an access token by running a configured external program.
-   * @see <a href="https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins">Authenticating » client-go credential plugins</a>
+   *
+   * @see <a
+   *     href="https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins">
+   *     Authenticating » client-go credential plugins</a>
    */
   private String tokenViaExecCredential(Map<String, Object> execMap) {
     if (execMap == null) {
       return null;
     }
     String apiVersion = (String) execMap.get("apiVersion");
-    if (!"client.authentication.k8s.io/v1beta1".equals(apiVersion)) { // TODO or v1alpha1 is apparently identical and could be supported
+    if (!"client.authentication.k8s.io/v1beta1".equals(apiVersion)) {
+      // TODO or v1alpha1 is apparently identical and could be supported
       log.error("Unrecognized user.exec.apiVersion: {}", apiVersion);
       return null;
     }
@@ -272,7 +277,7 @@ public class KubeConfig {
       Process proc = pb.start();
       JsonElement root;
       try (InputStream is = proc.getInputStream();
-           Reader r = new InputStreamReader(is, StandardCharsets.UTF_8)) {
+          Reader r = new InputStreamReader(is, StandardCharsets.UTF_8)) {
         root = new JsonParser().parse(r);
       } catch (JsonParseException x) {
         log.error("Failed to parse output of " + command, x);
@@ -287,7 +292,8 @@ public class KubeConfig {
       JsonObject status = root.getAsJsonObject().get("status").getAsJsonObject();
       JsonElement token = status.get("token");
       if (token == null) {
-        // TODO handle clientCertificateData/clientKeyData (KubeconfigAuthentication is not yet set up for that to be dynamic)
+        // TODO handle clientCertificateData/clientKeyData
+        // (KubeconfigAuthentication is not yet set up for that to be dynamic)
         log.warn("No token produced by {}", command);
         return null;
       }
@@ -297,8 +303,10 @@ public class KubeConfig {
       return null;
     }
     // TODO cache tokens between calls, up to .status.expirationTimestamp
-    // TODO a 401 is supposed to force a refresh, but KubeconfigAuthentication hard-codes AccessTokenAuthentication which does not support that
-    // and anyway ClientBuilder only calls Authenticator.provide once per ApiClient; we would need to do it on every request
+    // TODO a 401 is supposed to force a refresh,
+    // but KubeconfigAuthentication hardcodes AccessTokenAuthentication which does not support that
+    // and anyway ClientBuilder only calls Authenticator.provide once per ApiClient;
+    // we would need to do it on every request
   }
 
   public boolean verifySSL() {

--- a/util/src/main/java/io/kubernetes/client/util/KubeConfig.java
+++ b/util/src/main/java/io/kubernetes/client/util/KubeConfig.java
@@ -267,7 +267,14 @@ public class KubeConfig {
     if (root == null) {
       return null;
     }
-    // TODO verify .apiVersion and .kind = ExecCredential
+    if (!"ExecCredential".equals(root.getAsJsonObject().get("kind").getAsString())) {
+      log.error("Unrecognized kind in response");
+      return null;
+    }
+    if (!apiVersion.equals(root.getAsJsonObject().get("apiVersion").getAsString())) {
+      log.error("Mismatched apiVersion in response");
+      return null;
+    }
     JsonObject status = root.getAsJsonObject().get("status").getAsJsonObject();
     JsonElement token = status.get("token");
     if (token == null) {

--- a/util/src/test/java/io/kubernetes/client/util/KubeConfigTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/KubeConfigTest.java
@@ -273,4 +273,27 @@ public class KubeConfigTest {
     String token = config.getAccessToken();
     assertEquals(token, fake.token);
   }
+
+  private static final String KUBECONFIG_EXEC =
+      "apiVersion: v1\n"
+          + "current-context: c\n"
+          + "contexts:\n"
+          + "- name: c\n"
+          + "  context:\n"
+          + "    user: u\n"
+          + "users:\n"
+          + "- name: u\n"
+          + "  user:\n"
+          + "    exec:\n"
+          + "      apiVersion: client.authentication.k8s.io/v1beta1\n"
+          + "      command: echo\n"
+          + "      args:\n"
+          + "        - >-\n"
+          + "          {\"apiVersion\": \"client.authentication.k8s.io/v1beta1\", \"kind\": \"ExecCredential\", \"status\": {\"token\": \"abc123\"}}\n";
+
+  @Test
+  public void testExecCredentials() throws Exception {
+    KubeConfig kc = KubeConfig.loadKubeConfig(new StringReader(KUBECONFIG_EXEC));
+    assertEquals("abc123", kc.getAccessToken());
+  }
 }

--- a/util/src/test/java/io/kubernetes/client/util/KubeConfigTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/KubeConfigTest.java
@@ -294,6 +294,7 @@ public class KubeConfigTest {
   @Test
   public void testExecCredentials() throws Exception {
     KubeConfig kc = KubeConfig.loadKubeConfig(new StringReader(KUBECONFIG_EXEC));
+    kc.setFile(folder.newFile()); // just making sure it is ignored
     assertEquals("abc123", kc.getAccessToken());
   }
 
@@ -322,5 +323,46 @@ public class KubeConfigTest {
   public void testExecCredentialsEnv() throws Exception {
     KubeConfig kc = KubeConfig.loadKubeConfig(new StringReader(KUBECONFIG_EXEC_ENV));
     assertEquals("abc123", kc.getAccessToken());
+  }
+
+  private static final String KUBECONFIG_EXEC_BASEDIR =
+      "apiVersion: v1\n"
+          + "current-context: c\n"
+          + "contexts:\n"
+          + "- name: c\n"
+          + "  context:\n"
+          + "    user: u\n"
+          + "users:\n"
+          + "- name: u\n"
+          + "  user:\n"
+          + "    exec:\n"
+          + "      apiVersion: client.authentication.k8s.io/v1beta1\n"
+          + "      command: ./bin/authenticate\n";
+
+  private static final String AUTH_SCRIPT =
+      "#!/bin/sh\n"
+          + "echo '{\"apiVersion\": \"client.authentication.k8s.io/v1beta1\", \"kind\": \"ExecCredential\", \"status\": {\"token\": \"abc123\"}}'\n";
+
+  @Test
+  public void testExecCredentialsBasedir() throws Exception {
+    File basedir = folder.newFolder();
+    File config = new File(basedir, ".kubeconfig");
+    try (FileWriter writer = new FileWriter(config)) {
+      writer.write(KUBECONFIG_EXEC_BASEDIR);
+      writer.flush();
+    }
+    File bindir = new File(basedir, "bin");
+    bindir.mkdir();
+    File script = new File(bindir, "authenticate");
+    try (FileWriter writer = new FileWriter(script)) {
+      writer.write(AUTH_SCRIPT);
+      writer.flush();
+    }
+    script.setExecutable(true);
+    try (FileReader reader = new FileReader(config)) {
+      KubeConfig kc = KubeConfig.loadKubeConfig(reader);
+      kc.setFile(config);
+      assertEquals("abc123", kc.getAccessToken());
+    }
   }
 }

--- a/util/src/test/java/io/kubernetes/client/util/KubeConfigTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/KubeConfigTest.java
@@ -296,4 +296,31 @@ public class KubeConfigTest {
     KubeConfig kc = KubeConfig.loadKubeConfig(new StringReader(KUBECONFIG_EXEC));
     assertEquals("abc123", kc.getAccessToken());
   }
+
+  private static final String KUBECONFIG_EXEC_ENV =
+      "apiVersion: v1\n"
+          + "current-context: c\n"
+          + "contexts:\n"
+          + "- name: c\n"
+          + "  context:\n"
+          + "    user: u\n"
+          + "users:\n"
+          + "- name: u\n"
+          + "  user:\n"
+          + "    exec:\n"
+          + "      apiVersion: client.authentication.k8s.io/v1beta1\n"
+          + "      command: sh\n"
+          + "      env:\n"
+          + "        - name: TOK\n"
+          + "          value: abc\n"
+          + "      args:\n"
+          + "        - -c\n"
+          + "        - >-\n"
+          + "          echo '{\"apiVersion\": \"client.authentication.k8s.io/v1beta1\", \"kind\": \"ExecCredential\", \"status\": {\"token\": \"'$TOK'123\"}}'\n";
+
+  @Test
+  public void testExecCredentialsEnv() throws Exception {
+    KubeConfig kc = KubeConfig.loadKubeConfig(new StringReader(KUBECONFIG_EXEC_ENV));
+    assertEquals("abc123", kc.getAccessToken());
+  }
 }

--- a/util/src/test/java/io/kubernetes/client/util/KubeConfigTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/KubeConfigTest.java
@@ -298,6 +298,13 @@ public class KubeConfigTest {
     assertEquals("abc123", kc.getAccessToken());
   }
 
+  @Test
+  public void testExecCredentialsAlpha1() throws Exception {
+    KubeConfig kc =
+        KubeConfig.loadKubeConfig(new StringReader(KUBECONFIG_EXEC.replace("v1beta1", "v1alpha1")));
+    assertEquals("abc123", kc.getAccessToken());
+  }
+
   private static final String KUBECONFIG_EXEC_ENV =
       "apiVersion: v1\n"
           + "current-context: c\n"


### PR DESCRIPTION
Implementation of #238 allowing `~/.kube/config` to use the new generic exec credentials rather than a vendor-specific plugin or hard-coded token.

Planning to do before taking out of “draft” status:

- [X] basic implementation (run a command, get a token)
- [X] observed working with GKE
- [x] `KubeConfigTest` addition
- [x] relativization to basedir
- [x] environment variables
- [x] more robustness against bad inputs, logging, etc.

Other things which I think could be left for follow-ups depending on demand:

- [ ] observed working with EKS (I could make a test cluster if necessary)
- [ ] time-based expiry (see https://github.com/kubernetes-client/java/issues/290#issuecomment-453180074 or inline comments for why this would require broader refactoring)
- [ ] 401-based expiry (even trickier)
- [ ] client certificate support