### PR TITLE
Added support for KUBECONFIG environment variable with multiple paths.

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/ClientBuilder.java
+++ b/util/src/main/java/io/kubernetes/client/util/ClientBuilder.java
@@ -130,7 +130,7 @@ public class ClientBuilder {
       final String[] filePaths = kubeConfigEnv.split(File.pathSeparator);
       final String kubeConfigPath = filePaths[0];
       if (filePaths.length > 1) {
-        log.debug(
+        log.warn(
             "Found multiple kubeconfigs files, $KUBECONFIG: " + kubeConfigEnv + " using first: {}",
             kubeConfigPath);
       }

--- a/util/src/main/java/io/kubernetes/client/util/ClientBuilder.java
+++ b/util/src/main/java/io/kubernetes/client/util/ClientBuilder.java
@@ -104,16 +104,38 @@ public class ClientBuilder {
   }
 
   private static File findConfigFromEnv() {
-    String kubeConfigPath = System.getenv(ENV_KUBECONFIG);
+    final KubeConfigEnvParser kubeConfigEnvParser = new KubeConfigEnvParser();
+
+    final String kubeConfigPath =
+        kubeConfigEnvParser.parseKubeConfigPath(System.getenv(ENV_KUBECONFIG));
     if (kubeConfigPath == null) {
       return null;
     }
+
     final File kubeConfig = new File(kubeConfigPath);
     if (kubeConfig.exists()) {
       return kubeConfig;
     } else {
       log.debug("Could not find file specified in $KUBECONFIG");
       return null;
+    }
+  }
+
+  private static class KubeConfigEnvParser {
+    private String parseKubeConfigPath(String kubeConfigEnv) {
+      if (kubeConfigEnv == null) {
+        return null;
+      }
+
+      final String[] filePaths = kubeConfigEnv.split(File.pathSeparator);
+      final String kubeConfigPath = filePaths[0];
+      if (filePaths.length > 1) {
+        log.info(
+            "Found multiple kubeconfigs files, $KUBECONFIG: " + kubeConfigEnv + " using first: {}",
+            kubeConfigPath);
+      }
+
+      return kubeConfigPath;
     }
   }
 

--- a/util/src/main/java/io/kubernetes/client/util/ClientBuilder.java
+++ b/util/src/main/java/io/kubernetes/client/util/ClientBuilder.java
@@ -130,7 +130,7 @@ public class ClientBuilder {
       final String[] filePaths = kubeConfigEnv.split(File.pathSeparator);
       final String kubeConfigPath = filePaths[0];
       if (filePaths.length > 1) {
-        log.info(
+        log.debug(
             "Found multiple kubeconfigs files, $KUBECONFIG: " + kubeConfigEnv + " using first: {}",
             kubeConfigPath);
       }

--- a/util/src/test/java/io/kubernetes/client/util/ClientBuilderTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/ClientBuilderTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.verify;
 import com.google.common.io.Resources;
 import io.kubernetes.client.ApiClient;
 import io.kubernetes.client.util.credentials.Authentication;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -72,6 +73,14 @@ public class ClientBuilderTest {
   @Test
   public void testDefaultClientReadsKubeConfig() throws Exception {
     environmentVariables.set("KUBECONFIG", KUBECONFIG_FILE_PATH);
+    final ApiClient client = ClientBuilder.defaultClient();
+    assertEquals("http://kubeconfig.dir.com", client.getBasePath());
+  }
+
+  @Test
+  public void testDefaultClientReadsKubeConfigMultiple() throws Exception {
+    final String kubeConfigEnv = KUBECONFIG_FILE_PATH + File.pathSeparator + KUBECONFIG_FILE_PATH;
+    environmentVariables.set("KUBECONFIG", kubeConfigEnv);
     final ApiClient client = ClientBuilder.defaultClient();
     assertEquals("http://kubeconfig.dir.com", client.getBasePath());
   }

--- a/util/src/test/java/io/kubernetes/client/util/ClientBuilderTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/ClientBuilderTest.java
@@ -79,7 +79,7 @@ public class ClientBuilderTest {
 
   @Test
   public void testDefaultClientReadsKubeConfigMultiple() throws Exception {
-    final String kubeConfigEnv = KUBECONFIG_FILE_PATH + File.pathSeparator + KUBECONFIG_FILE_PATH;
+    final String kubeConfigEnv = KUBECONFIG_FILE_PATH + File.pathSeparator + "/non-existent";
     environmentVariables.set("KUBECONFIG", kubeConfigEnv);
     final ApiClient client = ClientBuilder.defaultClient();
     assertEquals("http://kubeconfig.dir.com", client.getBasePath());


### PR DESCRIPTION
Use first kubeconfig file.

Kubectl documentation: 
https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#linux-1