### PR TITLE
Update org.bouncycastle dependency #554

### DIFF
--- a/util/pom.xml
+++ b/util/pom.xml
@@ -59,12 +59,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-ext-jdk15on</artifactId>
-            <version>1.59</version>
+            <version>1.61</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.59</version>
+            <version>1.61</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>


### PR DESCRIPTION
Update org.bouncycastle dependency version to 
Release: 1.61
Date:      2019, February 4th
due to reported security vulnerabilities

See changes in bouncycastle lib here: http://www.bouncycastle.org/releasenotes.html