### PR TITLE
Feat: Provide thread-safety for pager

### DIFF
--- a/util/src/main/java/io/kubernetes/client/pager/Pager.java
+++ b/util/src/main/java/io/kubernetes/client/pager/Pager.java
@@ -15,7 +15,6 @@ package io.kubernetes.client.pager;
 import com.squareup.okhttp.Call;
 import io.kubernetes.client.ApiClient;
 import io.kubernetes.client.ApiException;
-import io.kubernetes.client.models.V1ListMeta;
 import io.kubernetes.client.util.Reflect;
 import io.kubernetes.client.util.exception.ObjectMetaReflectException;
 import java.io.IOException;
@@ -23,17 +22,17 @@ import java.lang.reflect.Type;
 import java.util.Iterator;
 import java.util.function.Function;
 
-public class Pager<ApiType, ApiListType> implements Iterable<ApiType>, Iterator<ApiType> {
-  private String continueToken;
+/*
+ * Pager encapsulates kubernetes limit/continue-based list pagination into an iterator.
+ * Note that pager is thread-safe.
+ */
+public class Pager<ApiType, ApiListType> implements Iterable<ApiType> {
   private Integer limit;
   private ApiClient client;
-  private Call call;
   private Type listType;
   private Function<PagerParams, Call> listFunc;
 
   private ApiListType listObjectCurrentPage;
-  private int offsetCurrentPage;
-  private int currentPageSize;
 
   /**
    * Pagination in kubernetes list call depends on continue and limit variable
@@ -53,88 +52,101 @@ public class Pager<ApiType, ApiListType> implements Iterable<ApiType>, Iterator<
   }
 
   /**
-   * returns false if kubernetes server has exhausted List.
+   * Iterator iterator.
    *
-   * @return
+   * @return the iterator
    */
-  @Override
-  public boolean hasNext() {
-    if (call == null) {
-      // the first time looping over the pager
-      return Boolean.TRUE;
-    }
-    if (continueToken == null && offsetCurrentPage >= currentPageSize) {
-      return Boolean.FALSE;
-    }
-    return Boolean.TRUE;
-  }
-
-  /**
-   * returns next chunk of List. size of list depends on limit set in constructor.
-   *
-   * @return Object
-   */
-  @Override
-  public ApiType next() {
-    try {
-      if (offsetCurrentPage >= currentPageSize) {
-        call = getNextCall(limit);
-        listObjectCurrentPage = executeRequest(call);
-
-        offsetCurrentPage = 0;
-        currentPageSize = Reflect.<ApiType>getItems(listObjectCurrentPage).size();
-      }
-      return Reflect.<ApiType>getItems(listObjectCurrentPage).get(offsetCurrentPage++);
-    } catch (ApiException e) {
-      throw new RuntimeException(e.getResponseBody());
-    } catch (ObjectMetaReflectException | IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
   @Override
   public Iterator<ApiType> iterator() {
-    this.call = null;
-    return this;
+    return new PagerIterator();
   }
 
   /** returns next list call by setting continue variable and limit */
-  private Call getNextCall(Integer nextLimit) {
-    PagerParams params = new PagerParams((nextLimit != null) ? nextLimit : limit);
-    if (continueToken != null) {
-      params.continueToken = continueToken;
-    }
+  private Call getNextCall(Integer nextLimit, String continueToken) {
+    PagerParams params = new PagerParams((nextLimit != null) ? nextLimit : limit, continueToken);
     return listFunc.apply(params);
   }
 
   /** executes the list call and sets the continue variable for next list call */
-  private ApiListType executeRequest(Call call)
-      throws IOException, ApiException, ObjectMetaReflectException {
-    ApiListType data = client.handleResponse(call.execute(), listType);
-    V1ListMeta listMetaData = Reflect.listMetadata(data);
-    continueToken = listMetaData.getContinue();
-    return data;
+  private ApiListType executeRequest(Call call) throws IOException, ApiException {
+    return client.handleResponse(call.execute(), listType);
   }
 
   public static class PagerParams {
-    private Integer limit;
+
     private String continueToken;
+    private Integer limit;
 
-    public PagerParams(Integer limit) {
-      this.limit = limit;
-    }
-
-    public PagerParams(Integer limit, String continueToken) {
+    private PagerParams(Integer limit, String continueToken) {
       this.limit = limit;
       this.continueToken = continueToken;
     }
 
+    /**
+     * Gets get limit.
+     *
+     * @return the get limit
+     */
     public Integer getLimit() {
       return limit;
     }
 
+    /**
+     * Gets get continue token.
+     *
+     * @return the get continue token
+     */
     public String getContinueToken() {
       return continueToken;
+    }
+  }
+
+  private class PagerIterator implements Iterator<ApiType> {
+
+    private boolean started;
+    private String continueToken;
+    private Call call;
+    private int offsetCurrentPage;
+    private int currentPageSize;
+
+    /**
+     * returns false if kubernetes server has exhausted List.
+     *
+     * @return the boolean
+     */
+    @Override
+    public boolean hasNext() {
+      if (!started) {
+        started = true;
+        return Boolean.TRUE;
+      }
+      return !(continueToken == null && offsetCurrentPage >= currentPageSize);
+    }
+
+    /**
+     * returns next chunk of List. size of list depends on limit set in constructor.
+     *
+     * @return the next Object
+     */
+    @Override
+    public ApiType next() {
+      try {
+        if (offsetCurrentPage >= currentPageSize) {
+
+          call = getNextCall(limit, continueToken);
+
+          listObjectCurrentPage = executeRequest(call);
+          continueToken = Reflect.listMetadata(listObjectCurrentPage).getContinue();
+
+          offsetCurrentPage = 0;
+          currentPageSize = Reflect.<ApiType>getItems(listObjectCurrentPage).size();
+        }
+        return Reflect.<ApiType>getItems(listObjectCurrentPage).get(offsetCurrentPage++);
+      } catch (ApiException e) {
+        throw new RuntimeException(e.getResponseBody());
+      } catch (ObjectMetaReflectException | IOException e) {
+        throw new RuntimeException(e);
+      }
     }
   }
 }


### PR DESCRIPTION
/cc @brendandburns 

Before this pull, `Pager` is not thread-safe. By adding a private non-static iterator class to store the pagination progress, the pager can be shared across threads now. Refactored the test a bit for validation.