### PR TITLE
Update Swagger Annotation library to 1.5.22

### DIFF
--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -198,7 +198,7 @@
     <java.version>1.7</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <swagger-core-version>1.5.12</swagger-core-version>
+    <swagger-core-version>1.5.22</swagger-core-version>
     <sundrio.version>0.18.0</sundrio.version>
     <okhttp-version>2.7.5</okhttp-version>
     <gson-version>2.8.0</gson-version>


### PR DESCRIPTION
For a project i'm working on, I need to update Swagger annotation library to 1.5.22.

Let me know if this will be an issue,
Derek  