### PR TITLE
[Refactor] Add Call-generator interface throwing checked ApiException

### DIFF
--- a/examples/src/main/java/io/kubernetes/client/examples/InformerExample.java
+++ b/examples/src/main/java/io/kubernetes/client/examples/InformerExample.java
@@ -1,7 +1,6 @@
 package io.kubernetes.client.examples;
 
 import io.kubernetes.client.ApiClient;
-import io.kubernetes.client.ApiException;
 import io.kubernetes.client.Configuration;
 import io.kubernetes.client.apis.CoreV1Api;
 import io.kubernetes.client.informer.*;
@@ -35,21 +34,17 @@ public class InformerExample {
     SharedIndexInformer<V1Node> nodeInformer =
         factory.sharedIndexInformerFor(
             (CallGeneratorParams params) -> {
-              try {
-                return coreV1Api.listNodeCall(
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    params.resourceVersion,
-                    params.timeoutSeconds,
-                    params.watch,
-                    null,
-                    null);
-              } catch (ApiException e) {
-                throw new RuntimeException(e);
-              }
+              return coreV1Api.listNodeCall(
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  params.resourceVersion,
+                  params.timeoutSeconds,
+                  params.watch,
+                  null,
+                  null);
             },
             V1Node.class,
             V1NodeList.class);

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.13.0</version>
+            <version>2.23.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/util/src/main/java/io/kubernetes/client/util/CallGenerator.java
+++ b/util/src/main/java/io/kubernetes/client/util/CallGenerator.java
@@ -1,0 +1,25 @@
+package io.kubernetes.client.util;
+
+import com.squareup.okhttp.Call;
+import io.kubernetes.client.ApiException;
+
+/**
+ * The interface Call generator. It's for homogenizing client interface so that we can invoke a
+ * generized adaptor interface elsewhere.
+ *
+ * <p>For example, we can adapt list-node interface from CoreV1Api package like:
+ *
+ * <p>(CallGeneratorParams params) -> { return coreV1Api.listNodeCall( null, null, null, null, null,
+ * params.resourceVersion, params.timeoutSeconds, params.watch, null, null); },
+ */
+@FunctionalInterface
+public interface CallGenerator {
+  /**
+   * Generate call.
+   *
+   * @param params the params
+   * @return the call
+   * @throws ApiException the api exception
+   */
+  Call generate(CallGeneratorParams params) throws ApiException;
+}

--- a/util/src/test/java/io/kubernetes/client/informer/SharedInformerFactoryTest.java
+++ b/util/src/test/java/io/kubernetes/client/informer/SharedInformerFactoryTest.java
@@ -1,6 +1,5 @@
 package io.kubernetes.client.informer;
 
-import io.kubernetes.client.ApiException;
 import io.kubernetes.client.apis.CoreV1Api;
 import io.kubernetes.client.models.V1Namespace;
 import io.kubernetes.client.models.V1NamespaceList;
@@ -14,21 +13,17 @@ public class SharedInformerFactoryTest {
     SharedInformerFactory factory = new SharedInformerFactory();
     factory.sharedIndexInformerFor(
         (CallGeneratorParams params) -> {
-          try {
-            return api.listNamespaceCall(
-                null,
-                null,
-                null,
-                null,
-                null,
-                params.resourceVersion,
-                params.timeoutSeconds,
-                params.watch,
-                null,
-                null);
-          } catch (ApiException e) {
-            throw new RuntimeException(e);
-          }
+          return api.listNamespaceCall(
+              null,
+              null,
+              null,
+              null,
+              null,
+              params.resourceVersion,
+              params.timeoutSeconds,
+              params.watch,
+              null,
+              null);
         },
         V1Namespace.class,
         V1NamespaceList.class);


### PR DESCRIPTION
this pull adds a new interface `CallGenerator` replacing `Function<CallGeneratorParam, Call>` to throw a checked `ApiException`. it's meaningless to handle the `ApiException` in the lambda body, the informer will deal w/ that. 

NOTE: this is breaking backward-compatibility a bit, while informer framework is still alpha, it's probably okay to make some minor adjustments.

/cc @brendandburns 