### PR TITLE
Refactor: Add constructor for customizing index funcs

### DIFF
--- a/util/src/main/java/io/kubernetes/client/informer/SharedInformerFactory.java
+++ b/util/src/main/java/io/kubernetes/client/informer/SharedInformerFactory.java
@@ -18,7 +18,7 @@ import java.util.concurrent.Future;
 /** SharedInformerFactory class constructs and caches informers for api types. */
 public class SharedInformerFactory {
 
-  private Map<Type, SharedIndexInformer> informers;
+  protected Map<Type, SharedIndexInformer> informers;
 
   private Map<Type, Future> startedInformers;
 

--- a/util/src/main/java/io/kubernetes/client/informer/cache/Caches.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/Caches.java
@@ -1,0 +1,82 @@
+package io.kubernetes.client.informer.cache;
+
+import com.google.common.base.Strings;
+import io.kubernetes.client.informer.exception.BadObjectException;
+import io.kubernetes.client.models.V1ObjectMeta;
+import io.kubernetes.client.util.Reflect;
+import io.kubernetes.client.util.exception.ObjectMetaReflectException;
+import java.util.Collections;
+import java.util.List;
+
+/** A set of helper utilities for constructing a cache. */
+public class Caches {
+
+  /** NAMESPACE_INDEX is the default index function for caching objects */
+  public static final String NAMESPACE_INDEX = "namespace";
+
+  /**
+   * deletionHandlingMetaNamespaceKeyFunc checks for DeletedFinalStateUnknown objects before calling
+   * metaNamespaceKeyFunc.
+   *
+   * @param <ApiType> the type parameter
+   * @param object specific object
+   * @return the key
+   */
+  public static <ApiType> String deletionHandlingMetaNamespaceKeyFunc(ApiType object) {
+    if (object instanceof DeltaFIFO.DeletedFinalStateUnknown) {
+      DeltaFIFO.DeletedFinalStateUnknown deleteObj = (DeltaFIFO.DeletedFinalStateUnknown) object;
+      return deleteObj.getKey();
+    }
+    return metaNamespaceKeyFunc(object);
+  }
+
+  /**
+   * MetaNamespaceKeyFunc is a convenient default KeyFunc which knows how to make keys for API
+   * objects which implement HasMetadata Interface. The key uses the format <namespace>/<name>
+   * unless <namespace> is empty, then it's just <name>.
+   *
+   * @param obj specific object
+   * @return the key
+   */
+  public static String metaNamespaceKeyFunc(Object obj) {
+    try {
+      V1ObjectMeta metadata;
+      if (obj instanceof String) {
+        return (String) obj;
+      } else if (obj instanceof V1ObjectMeta) {
+        metadata = (V1ObjectMeta) obj;
+      } else {
+        metadata = Reflect.objectMetadata(obj);
+        if (metadata == null) {
+          throw new BadObjectException(obj);
+        }
+      }
+      if (!Strings.isNullOrEmpty(metadata.getNamespace())) {
+        return metadata.getNamespace() + "/" + metadata.getName();
+      }
+      return metadata.getName();
+    } catch (ObjectMetaReflectException e) {
+      // NOTE(yue9944882): might want to handle this as a checked exception
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * metaNamespaceIndexFunc is a default index function that indexes based on an object's namespace.
+   *
+   * @param obj specific object
+   * @return the indexed value
+   */
+  public static List<String> metaNamespaceIndexFunc(Object obj) {
+    try {
+      V1ObjectMeta metadata = Reflect.objectMetadata(obj);
+      if (metadata == null) {
+        return Collections.emptyList();
+      }
+      return Collections.singletonList(metadata.getNamespace());
+    } catch (ObjectMetaReflectException e) {
+      // NOTE(yue9944882): might want to handle this as a checked exception
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/util/src/main/java/io/kubernetes/client/informer/cache/Lister.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/Lister.java
@@ -13,11 +13,11 @@ public class Lister<ApiType> {
   private Indexer<ApiType> indexer;
 
   public Lister(Indexer<ApiType> indexer) {
-    this(indexer, null, Cache.NAMESPACE_INDEX);
+    this(indexer, null, Caches.NAMESPACE_INDEX);
   }
 
   public Lister(Indexer<ApiType> indexer, String namespace) {
-    this(indexer, namespace, Cache.NAMESPACE_INDEX);
+    this(indexer, namespace, Caches.NAMESPACE_INDEX);
   }
 
   public Lister(Indexer<ApiType> indexer, String namespace, String indexName) {

--- a/util/src/main/java/io/kubernetes/client/informer/impl/DefaultSharedIndexInformer.java
+++ b/util/src/main/java/io/kubernetes/client/informer/impl/DefaultSharedIndexInformer.java
@@ -40,18 +40,37 @@ public class DefaultSharedIndexInformer<ApiType, ApiListType>
 
   public DefaultSharedIndexInformer(
       Class<ApiType> apiTypeClass, ListerWatcher listerWatcher, long resyncPeriod) {
+    this(apiTypeClass, listerWatcher, resyncPeriod, new Cache<>());
+  }
+
+  public DefaultSharedIndexInformer(
+      Class<ApiType> apiTypeClass,
+      ListerWatcher listerWatcher,
+      long resyncPeriod,
+      Cache<ApiType> cache) {
+    this(
+        apiTypeClass,
+        listerWatcher,
+        resyncPeriod,
+        new DeltaFIFO<>(cache.getKeyFunc(), cache),
+        cache);
+  }
+
+  public DefaultSharedIndexInformer(
+      Class<ApiType> apiTypeClass,
+      ListerWatcher<ApiType, ApiListType> listerWatcher,
+      long resyncPeriod,
+      DeltaFIFO<ApiType> deltaFIFO,
+      Indexer<ApiType> indexer) {
     this.resyncCheckPeriodMillis = resyncPeriod;
     this.defaultEventHandlerResyncPeriod = resyncPeriod;
 
     this.processor = new SharedProcessor<>();
-    this.indexer = new Cache();
-
-    DeltaFIFO<ApiType> fifo = new DeltaFIFO<ApiType>(Cache::metaNamespaceKeyFunc, this.indexer);
-
+    this.indexer = indexer;
     this.controller =
         new Controller<ApiType, ApiListType>(
             apiTypeClass,
-            fifo,
+            deltaFIFO,
             listerWatcher,
             this::handleDeltas,
             processor::shouldResync,

--- a/util/src/test/java/io/kubernetes/client/informer/cache/CachesTest.java
+++ b/util/src/test/java/io/kubernetes/client/informer/cache/CachesTest.java
@@ -1,0 +1,28 @@
+package io.kubernetes.client.informer.cache;
+
+import static org.junit.Assert.assertEquals;
+
+import io.kubernetes.client.models.V1ObjectMeta;
+import io.kubernetes.client.models.V1Pod;
+import java.util.List;
+import org.junit.Test;
+
+public class CachesTest {
+
+  @Test
+  public void testDefaultNamespaceNameKey() {
+    String testName = "test-name";
+    String testNamespace = "test-namespace";
+    V1Pod pod = new V1Pod().metadata(new V1ObjectMeta().name(testName).namespace(testNamespace));
+    assertEquals(testNamespace + "/" + testName, Caches.metaNamespaceKeyFunc(pod));
+  }
+
+  @Test
+  public void testDefaultNamespaceIndex() {
+    String testName = "test-name";
+    String testNamespace = "test-namespace";
+    V1Pod pod = new V1Pod().metadata(new V1ObjectMeta().name(testName).namespace(testNamespace));
+    List<String> indices = Caches.metaNamespaceIndexFunc(pod);
+    assertEquals(pod.getMetadata().getNamespace(), indices.get(0));
+  }
+}


### PR DESCRIPTION
for now, we are only allowed to use `<namespace>` index funcs, this pull enables users to add customized index func. e.g. (as the test shown), for indexing pods, not only we can index by pod's namespace but also pod's nodeName from the spec:

1. Moves static helpers from `Cache` to `Caches`. note that we're deprecating the former and left a `TODO` noting it's gonna be removed after 7.0.0 release
2. Add more constructors to informer so that we can inject customized cache.