### PR TITLE
show exception message when failing to acquire or renew election lock

### DIFF
--- a/examples/src/main/java/io/kubernetes/client/examples/LeaderElectionExample.java
+++ b/examples/src/main/java/io/kubernetes/client/examples/LeaderElectionExample.java
@@ -24,7 +24,7 @@ public class LeaderElectionExample {
     EndpointsLock lock = new EndpointsLock("kube-system", "leader-election", "foo");
 
     LeaderElectionConfig leaderElectionConfig =
-        new LeaderElectionConfig(lock, Duration.ofMillis(10000), null, Duration.ofMillis(5000));
+        new LeaderElectionConfig(lock, Duration.ofMillis(10000), null, Duration.ofMillis(2000));
     LeaderElector leaderElector = new LeaderElector(leaderElectionConfig);
 
     leaderElector.run(

--- a/extended/src/main/java/io/kubernetes/client/extended/leaderelection/LeaderElector.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/leaderelection/LeaderElector.java
@@ -69,6 +69,7 @@ public class LeaderElector {
               } catch (CancellationException e) {
                 log.info("Processing tryAcquireOrRenew successfully canceled");
               } catch (Throwable t) {
+                log.error("Error processing tryAcquireOrRenew as {}", t.getMessage());
                 future.cancel(true);
               }
             },

--- a/extended/src/main/java/io/kubernetes/client/extended/leaderelection/resourcelock/ConfigMapLock.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/leaderelection/resourcelock/ConfigMapLock.java
@@ -96,6 +96,7 @@ public class ConfigMapLock implements Lock {
           .putAnnotationsItem(
               LeaderElectionRecordAnnotationKey,
               coreV1Client.getApiClient().getJSON().serialize(record));
+      // TODO consider to retry if receiving a 409 code
       V1ConfigMap replacedConfigMap =
           coreV1Client.replaceNamespacedConfigMap(name, namespace, configMap, null, null, null);
       configMapRefer.set(replacedConfigMap);

--- a/extended/src/main/java/io/kubernetes/client/extended/leaderelection/resourcelock/EndpointsLock.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/leaderelection/resourcelock/EndpointsLock.java
@@ -96,6 +96,7 @@ public class EndpointsLock implements Lock {
           .putAnnotationsItem(
               LeaderElectionRecordAnnotationKey,
               coreV1Client.getApiClient().getJSON().serialize(record));
+      // TODO consider to retry if receiving a 409 code
       V1Endpoints replacedEndpoints =
           coreV1Client.replaceNamespacedEndpoints(name, namespace, endpoints, null, null, null);
       endpointsRefer.set(replacedEndpoints);


### PR DESCRIPTION
1. Show exception message when failing to acquire or renew election lock. Recently an exception thrown from the `tryAcquireOrRenew` is not logged.
2. Improve the argument of leader election example.
3. Add a TODO to remind to update lock with retry.