### PR TITLE
Magic exception message update + FileInputStream closing in SSLUtils 

### DIFF
--- a/util/src/main/java/io/kubernetes/client/ProtoClient.java
+++ b/util/src/main/java/io/kubernetes/client/ProtoClient.java
@@ -29,6 +29,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import org.apache.commons.codec.binary.Hex;
 
 public class ProtoClient {
   /**
@@ -314,7 +315,7 @@ public class ProtoClient {
     byte[] magic = new byte[4];
     ByteStreams.readFully(stream, magic);
     if (!Arrays.equals(magic, MAGIC)) {
-      throw new ApiException("Unexpected magic number: " + magic);
+      throw new ApiException("Unexpected magic number: " + Hex.encodeHexString(magic));
     }
     return Unknown.parseFrom(stream);
   }

--- a/util/src/main/java/io/kubernetes/client/util/SSLUtils.java
+++ b/util/src/main/java/io/kubernetes/client/util/SSLUtils.java
@@ -316,7 +316,9 @@ public class SSLUtils {
   private static boolean loadDefaultStoreFile(KeyStore keyStore, File fileToLoad, char[] passphrase)
       throws CertificateException, NoSuchAlgorithmException, IOException {
     if (fileToLoad.exists() && fileToLoad.isFile() && fileToLoad.length() > 0) {
-      keyStore.load(new FileInputStream(fileToLoad), passphrase);
+      try (FileInputStream inputStream = new FileInputStream(fileToLoad)) {
+        keyStore.load(inputStream, passphrase);
+      }
       return true;
     }
     return false;


### PR DESCRIPTION
Hello,
updated ProtoClient to encode in hex not equal magic value, direct concatenation will lead to values like "I@4fee666" which aren't very helpful.

Noticed that in SSLUtils.loadDefaultStoreFile file input stream is not closed after loading of the file to keystore - added java 8 file closing.

