### PR TITLE
Bugfix(informer): DeltaFIFO Replace method to prevent SharedIndexInformers from missing notifications

### DIFF
--- a/util/src/main/java/io/kubernetes/client/informer/cache/DeltaFIFO.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/DeltaFIFO.java
@@ -337,13 +337,6 @@ public class DeltaFIFO<ApiType> implements Store<Object> {
   private void queueActionLocked(DeltaType actionType, Object obj) {
     String id = this.keyOf(obj);
 
-    // If object is supposed to be deleted (last event is Deleted),
-    // then we should ignore Sync events, because it would result in
-    // recreation of this object.
-    if (actionType == DeltaType.Sync && this.willObjectBeDeletedLocked(id)) {
-      return;
-    }
-
     Deque<MutablePair<DeltaType, Object>> deltas = items.get(id);
     if (deltas == null) {
       Deque<MutablePair<DeltaType, Object>> deltaList = new LinkedList<>();
@@ -367,19 +360,6 @@ public class DeltaFIFO<ApiType> implements Store<Object> {
     } else {
       this.items.remove(id);
     }
-  }
-
-  /**
-   * willObjectBeDeletedLocked returns true only if the last delta for the give object is Deleted.
-   * Caller must hold the lock.
-   */
-  private boolean willObjectBeDeletedLocked(String id) {
-    if (!this.items.containsKey(id)) {
-      return false;
-    }
-    Deque<MutablePair<DeltaType, Object>> deltas = this.items.get(id);
-    return !(Collections.isEmptyCollection(deltas))
-        && deltas.peekLast().getLeft().equals(DeltaType.Deleted);
   }
 
   // KeyOf exposes f's keyFunc, but also detects the key of a Deltas object or


### PR DESCRIPTION
picking the informer fix from https://github.com/kubernetes/kubernetes/pull/83911 