### PR TITLE
Generic kubernetes api client

### DIFF
--- a/extended/src/main/java/io/kubernetes/client/extended/generic/GenericKubernetesApi.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/generic/GenericKubernetesApi.java
@@ -1,0 +1,686 @@
+package io.kubernetes.client.extended.generic;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Strings;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.reflect.TypeToken;
+import io.kubernetes.client.custom.V1Patch;
+import io.kubernetes.client.extended.generic.options.CreateOptions;
+import io.kubernetes.client.extended.generic.options.DeleteOptions;
+import io.kubernetes.client.extended.generic.options.GetOptions;
+import io.kubernetes.client.extended.generic.options.ListOptions;
+import io.kubernetes.client.extended.generic.options.PatchOptions;
+import io.kubernetes.client.extended.generic.options.UpdateOptions;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.Configuration;
+import io.kubernetes.client.openapi.apis.CustomObjectsApi;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Status;
+import io.kubernetes.client.util.PatchUtils;
+import io.kubernetes.client.util.Reflect;
+import io.kubernetes.client.util.Watch;
+import io.kubernetes.client.util.Watchable;
+import io.kubernetes.client.util.exception.ObjectMetaReflectException;
+import java.net.SocketTimeoutException;
+import okhttp3.Call;
+
+/**
+ * The Generic kubernetes api provides a unified client interface for not only the non-core-group
+ * built-in resources from kuberntes but also the custom-resources models meet the following
+ * requirements:
+ *
+ * <p>1. there's a `V1ObjectMeta` field in the model along with its getter/setter. 2. there's a
+ * `V1ListMeta` field in the list model along with its getter/setter. - supports Gson
+ * serialization/deserialization. 3. the generic kubernetes api covers all the basic operations over
+ * the custom resources including {get, list, watch, create, update, patch, delete}.
+ *
+ * @param <ApiType> the api type parameter
+ * @param <ApiListType> the api list type parameter
+ */
+@Beta
+public class GenericKubernetesApi<ApiType, ApiListType> {
+
+  // TODO(yue9944882): supports status operations..
+  // TODO(yue9944882): supports generic sub-resoruce operations..
+  // TODO(yue9944882): supports delete-collections..
+
+  private Class<ApiType> apiTypeClass;
+  private Class<ApiListType> apiListTypeClass;
+  private String apiGroup;
+  private String apiVersion;
+  private String resourcePlural;
+  private CustomObjectsApi customObjectsApi;
+
+  /**
+   * Instantiates a new Generic kubernetes api.
+   *
+   * @param apiTypeClass the api type class
+   * @param apiListTypeClass the api list type class
+   * @param apiGroup the api group
+   * @param apiVersion the api version
+   * @param resourcePlural the resource plural
+   */
+  public GenericKubernetesApi(
+      Class<ApiType> apiTypeClass,
+      Class<ApiListType> apiListTypeClass,
+      String apiGroup,
+      String apiVersion,
+      String resourcePlural) {
+    this(
+        apiTypeClass,
+        apiListTypeClass,
+        apiGroup,
+        apiVersion,
+        resourcePlural,
+        new CustomObjectsApi(Configuration.getDefaultApiClient()));
+  }
+
+  /**
+   * Instantiates a new Generic kubernetes api.
+   *
+   * @param apiTypeClass the api type class, e.g. V1Job.class
+   * @param apiListTypeClass the api list type class e.g V1JobList.class
+   * @param apiGroup the api group
+   * @param apiVersion the api version
+   * @param resourcePlural the resource plural, e.g. "jobs"
+   * @param apiClient the api client
+   */
+  public GenericKubernetesApi(
+      Class<ApiType> apiTypeClass,
+      Class<ApiListType> apiListTypeClass,
+      String apiGroup,
+      String apiVersion,
+      String resourcePlural,
+      ApiClient apiClient) {
+    this(
+        apiTypeClass,
+        apiListTypeClass,
+        apiGroup,
+        apiVersion,
+        resourcePlural,
+        new CustomObjectsApi(apiClient));
+  }
+
+  /**
+   * Instantiates a new Generic kubernetes api with the ApiClient specified.
+   *
+   * @param apiTypeClass the api type class, e.g. V1Job.class
+   * @param apiListTypeClass the api list type class e.g V1JobList.class
+   * @param apiGroup the api group
+   * @param apiVersion the api version
+   * @param resourcePlural the resource plural, e.g. "jobs"
+   * @param customObjectsApi the custom objects api
+   */
+  public GenericKubernetesApi(
+      Class<ApiType> apiTypeClass,
+      Class<ApiListType> apiListTypeClass,
+      String apiGroup,
+      String apiVersion,
+      String resourcePlural,
+      CustomObjectsApi customObjectsApi) {
+    if ("".equals(apiGroup)) {
+      throw new IllegalArgumentException(
+          "core group (\"v1\") api not supported, use CoreV1Api instead");
+    }
+    this.apiGroup = apiGroup;
+    this.apiVersion = apiVersion;
+    this.resourcePlural = resourcePlural;
+    this.apiTypeClass = apiTypeClass;
+    this.apiListTypeClass = apiListTypeClass;
+    this.customObjectsApi = customObjectsApi;
+  }
+
+  /**
+   * Get kubernetes api response.
+   *
+   * @param name the name
+   * @return the kubernetes api response
+   */
+  public KubernetesApiResponse<ApiType> get(String name) {
+    return get(name, new GetOptions());
+  }
+
+  /**
+   * Get kubernetes api response under the namespace.
+   *
+   * @param namespace the namespace
+   * @param name the name
+   * @return the kubernetes api response
+   */
+  public KubernetesApiResponse<ApiType> get(String namespace, String name) {
+    return get(namespace, name, new GetOptions());
+  }
+
+  /**
+   * List kubernetes api response cluster-scoped.
+   *
+   * @return the kubernetes api response
+   */
+  public KubernetesApiResponse<ApiListType> list() {
+    return list(new ListOptions());
+  }
+
+  /**
+   * List kubernetes api response under the namespace.
+   *
+   * @param namespace the namespace
+   * @return the kubernetes api response
+   */
+  public KubernetesApiResponse<ApiListType> list(String namespace) {
+    return list(namespace, new ListOptions());
+  }
+
+  /**
+   * Create kubernetes api response, if the namespace in the object is present, it will send a
+   * namespace-scoped requests, vice versa.
+   *
+   * @param object the object
+   * @return the kubernetes api response
+   */
+  public KubernetesApiResponse<ApiType> create(ApiType object) {
+    return create(object, new CreateOptions());
+  }
+
+  /**
+   * Create kubernetes api response, if the namespace in the object is present, it will send a
+   * namespace-scoped requests, vice versa.
+   *
+   * @param object the object
+   * @return the kubernetes api response
+   */
+  public KubernetesApiResponse<ApiType> update(ApiType object) {
+    return update(object, new UpdateOptions());
+  }
+
+  /**
+   * Patch kubernetes api response.
+   *
+   * @param name the name
+   * @param patchType the patch type, supported values defined in V1Patch
+   * @param patch the string patch content
+   * @return the kubernetes api response
+   */
+  public KubernetesApiResponse<ApiType> patch(String name, String patchType, V1Patch patch) {
+    return patch(name, patchType, patch, new PatchOptions());
+  }
+
+  /**
+   * Patch kubernetes api response under the namespace.
+   *
+   * @param namespace the namespace
+   * @param name the name
+   * @param patchType the patch type, supported values defined in V1Patch
+   * @param patch the string patch content
+   * @return the kubernetes api response
+   */
+  public KubernetesApiResponse<ApiType> patch(
+      String namespace, String name, String patchType, V1Patch patch) {
+    return patch(namespace, name, patchType, patch, new PatchOptions());
+  }
+
+  /**
+   * Delete kubernetes api response.
+   *
+   * @param name the name
+   * @return the kubernetes api response
+   */
+  public KubernetesApiResponse<ApiType> delete(String name) {
+    return delete(name, new DeleteOptions());
+  }
+
+  /**
+   * Delete kubernetes api response under the namespace.
+   *
+   * @param namespace the namespace
+   * @param name the name
+   * @return the kubernetes api response
+   */
+  public KubernetesApiResponse<ApiType> delete(String namespace, String name) {
+    return delete(namespace, name, new DeleteOptions());
+  }
+
+  /**
+   * Creates a cluster-scoped Watch on the resource.
+   *
+   * @return the watchable
+   * @throws ApiException the api exception
+   */
+  public Watchable<ApiType> watch() throws ApiException {
+    return watch(new ListOptions());
+  }
+
+  /**
+   * Creates a namespace-scoped Watch on the resource.
+   *
+   * @param namespace the namespace
+   * @return the watchable
+   * @throws ApiException the api exception
+   */
+  public Watchable<ApiType> watch(String namespace) throws ApiException {
+    return watch(namespace, new ListOptions());
+  }
+
+  // TODO(yue9944882): watch one resource?
+
+  /**
+   * Get kubernetes api response.
+   *
+   * @param name the name
+   * @param getOptions the get options
+   * @return the kubernetes api response
+   */
+  public KubernetesApiResponse<ApiType> get(String name, final GetOptions getOptions) {
+    if (Strings.isNullOrEmpty(name)) {
+      throw new IllegalArgumentException("invalid namespace");
+    }
+    CustomObjectsApi customObjectsApi = new CustomObjectsApi();
+    return executeCall(
+        customObjectsApi.getApiClient(),
+        apiTypeClass,
+        () -> {
+          return customObjectsApi.getClusterCustomObjectCall(
+              this.apiGroup, this.apiVersion, this.resourcePlural, name, null);
+        });
+  }
+
+  /**
+   * Get kubernetes api response.
+   *
+   * @param namespace the namespace
+   * @param name the name
+   * @param getOptions the get options
+   * @return the kubernetes api response
+   */
+  public KubernetesApiResponse<ApiType> get(
+      String namespace, String name, final GetOptions getOptions) {
+    if (Strings.isNullOrEmpty(name)) {
+      throw new IllegalArgumentException("invalid name");
+    }
+    if (Strings.isNullOrEmpty(namespace)) {
+      throw new IllegalArgumentException("invalid namespace");
+    }
+    return executeCall(
+        customObjectsApi.getApiClient(),
+        apiTypeClass,
+        () -> {
+          return customObjectsApi.getNamespacedCustomObjectCall(
+              this.apiGroup, this.apiVersion, namespace, this.resourcePlural, name, null);
+        });
+  }
+
+  /**
+   * List kubernetes api response.
+   *
+   * @param listOptions the list options
+   * @return the kubernetes api response
+   */
+  public KubernetesApiResponse<ApiListType> list(final ListOptions listOptions) {
+    return executeCall(
+        customObjectsApi.getApiClient(),
+        apiListTypeClass,
+        () -> {
+          return customObjectsApi.listClusterCustomObjectCall(
+              this.apiGroup,
+              this.apiVersion,
+              this.resourcePlural,
+              null,
+              listOptions.getContinue(),
+              listOptions.getFieldSelector(),
+              listOptions.getLabelSelector(),
+              listOptions.getLimit(),
+              listOptions.getResourceVersion(),
+              listOptions.getTimeoutSeconds(),
+              null,
+              null);
+        });
+  }
+
+  /**
+   * List kubernetes api response.
+   *
+   * @param namespace the namespace
+   * @param listOptions the list options
+   * @return the kubernetes api response
+   */
+  public KubernetesApiResponse<ApiListType> list(String namespace, final ListOptions listOptions) {
+    if (Strings.isNullOrEmpty(namespace)) {
+      throw new IllegalArgumentException("invalid namespace");
+    }
+    return executeCall(
+        customObjectsApi.getApiClient(),
+        apiListTypeClass,
+        () -> {
+          return customObjectsApi.listNamespacedCustomObjectCall(
+              this.apiGroup,
+              this.apiVersion,
+              namespace,
+              this.resourcePlural,
+              null,
+              listOptions.getContinue(),
+              listOptions.getFieldSelector(),
+              listOptions.getLabelSelector(),
+              listOptions.getLimit(),
+              listOptions.getResourceVersion(),
+              listOptions.getTimeoutSeconds(),
+              null,
+              null);
+        });
+  }
+
+  /**
+   * Create kubernetes api response.
+   *
+   * @param object the object
+   * @param createOptions the create options
+   * @return the kubernetes api response
+   */
+  public KubernetesApiResponse<ApiType> create(ApiType object, final CreateOptions createOptions) {
+    V1ObjectMeta objectMeta;
+    try {
+      objectMeta = Reflect.objectMetadata(object);
+    } catch (ObjectMetaReflectException e) {
+      throw new IllegalArgumentException("fail to extract object metadata");
+    }
+
+    return executeCall(
+        customObjectsApi.getApiClient(),
+        apiTypeClass,
+        () -> {
+          // TODO(yue9944882): judge namespaced object via api discovery
+          boolean isNamespaced = !Strings.isNullOrEmpty(objectMeta.getNamespace());
+          if (isNamespaced) {
+            return customObjectsApi.createNamespacedCustomObjectCall(
+                this.apiGroup,
+                this.apiVersion,
+                objectMeta.getNamespace(),
+                this.resourcePlural,
+                object,
+                null,
+                null);
+          } else {
+            return customObjectsApi.createClusterCustomObjectCall(
+                this.apiGroup, this.apiVersion, this.resourcePlural, object, null, null);
+          }
+        });
+  }
+
+  /**
+   * Update kubernetes api response.
+   *
+   * @param object the object
+   * @param updateOptions the update options
+   * @return the kubernetes api response
+   */
+  public KubernetesApiResponse<ApiType> update(ApiType object, final UpdateOptions updateOptions) {
+    V1ObjectMeta objectMeta;
+    try {
+      objectMeta = Reflect.objectMetadata(object);
+    } catch (ObjectMetaReflectException e) {
+      throw new IllegalArgumentException("fail to extract object metadata");
+    }
+    return executeCall(
+        customObjectsApi.getApiClient(),
+        apiTypeClass,
+        () -> {
+          //// TODO(yue9944882): judge namespaced object via api discovery
+          boolean isNamespaced = !Strings.isNullOrEmpty(objectMeta.getNamespace());
+          if (isNamespaced) {
+            return customObjectsApi.replaceNamespacedCustomObjectCall(
+                this.apiGroup,
+                this.apiVersion,
+                objectMeta.getNamespace(),
+                this.resourcePlural,
+                objectMeta.getName(),
+                object,
+                null);
+          } else {
+            return customObjectsApi.replaceClusterCustomObjectCall(
+                this.apiGroup,
+                this.apiVersion,
+                this.resourcePlural,
+                objectMeta.getName(),
+                object,
+                null);
+          }
+        });
+  }
+
+  /**
+   * Patch kubernetes api response.
+   *
+   * @param name the name
+   * @param patchType the patch type
+   * @param patch the patch
+   * @param patchOptions the patch options
+   * @return the kubernetes api response
+   */
+  public KubernetesApiResponse<ApiType> patch(
+      String name, String patchType, V1Patch patch, final PatchOptions patchOptions) {
+    if (Strings.isNullOrEmpty(name)) {
+      throw new IllegalArgumentException("invalid name");
+    }
+    return executeCall(
+        customObjectsApi.getApiClient(),
+        apiTypeClass,
+        () -> {
+          return customObjectsApi.patchClusterCustomObjectCall(
+              this.apiGroup, this.apiVersion, this.resourcePlural, name, patch, null);
+        });
+  }
+
+  /**
+   * Patch kubernetes api response.
+   *
+   * @param namespace the namespace
+   * @param name the name
+   * @param patchType the patch type
+   * @param patch the patch
+   * @param patchOptions the patch options
+   * @return the kubernetes api response
+   */
+  public KubernetesApiResponse<ApiType> patch(
+      String namespace,
+      String name,
+      String patchType,
+      V1Patch patch,
+      final PatchOptions patchOptions) {
+    if (Strings.isNullOrEmpty(namespace)) {
+      throw new IllegalArgumentException("invalid namespace");
+    }
+    if (Strings.isNullOrEmpty(name)) {
+      throw new IllegalArgumentException("invalid name");
+    }
+    try {
+      ApiType object =
+          PatchUtils.patch(
+              apiTypeClass,
+              () -> {
+                return customObjectsApi.patchNamespacedCustomObjectCall(
+                    this.apiGroup,
+                    this.apiVersion,
+                    namespace,
+                    this.resourcePlural,
+                    name,
+                    patch,
+                    null);
+              },
+              patchType);
+      return new KubernetesApiResponse<ApiType>(object);
+    } catch (ApiException e) {
+      V1Status status =
+          customObjectsApi
+              .getApiClient()
+              .getJSON()
+              .deserialize(e.getResponseBody(), V1Status.class);
+      return new KubernetesApiResponse<>(status, e.getCode());
+    }
+  }
+
+  /**
+   * Delete kubernetes api response.
+   *
+   * @param name the name
+   * @param deleteOptions the delete options
+   * @return the kubernetes api response
+   */
+  public KubernetesApiResponse<ApiType> delete(String name, final DeleteOptions deleteOptions) {
+    if (Strings.isNullOrEmpty(name)) {
+      throw new IllegalArgumentException("invalid name");
+    }
+    return executeCall(
+        customObjectsApi.getApiClient(),
+        apiTypeClass,
+        () -> {
+          return customObjectsApi.deleteClusterCustomObjectCall(
+              this.apiGroup,
+              this.apiVersion,
+              this.resourcePlural,
+              name,
+              null,
+              null,
+              null,
+              deleteOptions, // TODO: fill/convert the option
+              null);
+        });
+  }
+
+  /**
+   * Delete kubernetes api response.
+   *
+   * @param namespace the namespace
+   * @param name the name
+   * @param deleteOptions the delete options
+   * @return the kubernetes api response
+   */
+  public KubernetesApiResponse<ApiType> delete(
+      String namespace, String name, final DeleteOptions deleteOptions) {
+    if (Strings.isNullOrEmpty(namespace)) {
+      throw new IllegalArgumentException("invalid namespace");
+    }
+    if (Strings.isNullOrEmpty(name)) {
+      throw new IllegalArgumentException("invalid name");
+    }
+    return executeCall(
+        customObjectsApi.getApiClient(),
+        apiTypeClass,
+        () -> {
+          return customObjectsApi.deleteNamespacedCustomObjectCall(
+              this.apiGroup,
+              this.apiVersion,
+              namespace,
+              this.resourcePlural,
+              name,
+              null,
+              null,
+              null,
+              deleteOptions, // TODO: fill/convert the option
+              null);
+        });
+  }
+
+  /**
+   * Watch watchable.
+   *
+   * @param listOptions the list options
+   * @return the watchable
+   * @throws ApiException the api exception
+   */
+  public Watchable<ApiType> watch(final ListOptions listOptions) throws ApiException {
+    Call call =
+        customObjectsApi.listClusterCustomObjectCall(
+            this.apiGroup,
+            this.apiVersion,
+            this.resourcePlural,
+            null,
+            listOptions.getContinue(),
+            listOptions.getFieldSelector(),
+            listOptions.getLabelSelector(),
+            listOptions.getLimit(),
+            listOptions.getResourceVersion(),
+            listOptions.getTimeoutSeconds(),
+            null,
+            null);
+
+    return Watch.createWatch(
+        customObjectsApi.getApiClient(),
+        call,
+        TypeToken.getParameterized(Watch.Response.class, apiTypeClass).getType());
+  }
+
+  /**
+   * Watch watchable.
+   *
+   * @param namespace the namespace
+   * @param listOptions the list options
+   * @return the watchable
+   * @throws ApiException the api exception
+   */
+  public Watchable<ApiType> watch(String namespace, final ListOptions listOptions)
+      throws ApiException {
+    if (Strings.isNullOrEmpty(namespace)) {
+      throw new IllegalArgumentException("invalid namespace");
+    }
+    Call call =
+        customObjectsApi.listClusterCustomObjectCall(
+            this.apiGroup,
+            this.apiVersion,
+            this.resourcePlural,
+            null,
+            listOptions.getContinue(),
+            listOptions.getFieldSelector(),
+            listOptions.getLabelSelector(),
+            listOptions.getLimit(),
+            listOptions.getResourceVersion(),
+            listOptions.getTimeoutSeconds(),
+            null,
+            null);
+
+    return Watch.createWatch(
+        customObjectsApi.getApiClient(),
+        call,
+        TypeToken.getParameterized(Watch.Response.class, apiTypeClass).getType());
+  }
+
+  private static <DataType> KubernetesApiResponse<DataType> getKubernetesApiResponse(
+      Class<DataType> dataClass, JsonElement element, Gson gson) {
+    return getKubernetesApiResponse(dataClass, element, gson, 200);
+  }
+
+  private static <DataType> KubernetesApiResponse<DataType> getKubernetesApiResponse(
+      Class<DataType> dataClass, JsonElement element, Gson gson, int httpStatusCode) {
+    JsonElement kindElement = element.getAsJsonObject().get("kind");
+    boolean isStatus = kindElement != null && "Status".equals(kindElement.getAsString());
+    if (isStatus) {
+      return new KubernetesApiResponse<>(gson.fromJson(element, V1Status.class), httpStatusCode);
+    }
+    return new KubernetesApiResponse<>(gson.fromJson(element, dataClass));
+  }
+
+  private static <DataType> KubernetesApiResponse<DataType> executeCall(
+      ApiClient apiClient, Class<DataType> dataClass, CallBuilder callBuilder) {
+    try {
+      Call call = callBuilder.build();
+      JsonElement element = apiClient.<JsonElement>execute(call, JsonElement.class).getData();
+      return getKubernetesApiResponse(dataClass, element, apiClient.getJSON().getGson());
+    } catch (ApiException e) {
+      if (e.getCause() instanceof SocketTimeoutException) {
+        throw new IllegalStateException(e.getCause()); // make this a checked exception?
+      }
+      V1Status status = apiClient.getJSON().deserialize(e.getResponseBody(), V1Status.class);
+      return new KubernetesApiResponse<>(status, e.getCode());
+    }
+  }
+
+  // CallBuilder builds a call and throws ApiException otherwise.
+  private interface CallBuilder {
+    /**
+     * Build call.
+     *
+     * @return the call
+     * @throws ApiException the api exception
+     */
+    Call build() throws ApiException;
+  }
+}

--- a/extended/src/main/java/io/kubernetes/client/extended/generic/KubernetesApiResponse.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/generic/KubernetesApiResponse.java
@@ -1,0 +1,38 @@
+package io.kubernetes.client.extended.generic;
+
+import io.kubernetes.client.openapi.models.V1Status;
+
+public class KubernetesApiResponse<DataType> {
+
+  private final DataType object;
+  private final V1Status status;
+  private final int httpStatusCode;
+
+  public KubernetesApiResponse(DataType object) {
+    this.object = object;
+    this.status = null;
+    this.httpStatusCode = -1;
+  }
+
+  public KubernetesApiResponse(V1Status status, int httpStatusCode) {
+    this.object = null;
+    this.status = status;
+    this.httpStatusCode = httpStatusCode;
+  }
+
+  public DataType getObject() {
+    return object;
+  }
+
+  public V1Status getStatus() {
+    return status;
+  }
+
+  public int getHttpStatusCode() {
+    return httpStatusCode;
+  }
+
+  public boolean isSuccess() {
+    return this.httpStatusCode < 400;
+  }
+}

--- a/extended/src/main/java/io/kubernetes/client/extended/generic/options/CreateOptions.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/generic/options/CreateOptions.java
@@ -1,0 +1,7 @@
+package io.kubernetes.client.extended.generic.options;
+
+public class CreateOptions {
+  private Boolean dryRun;
+  // TODO: structured field-manager for better server-side apply integeration
+  private Object fieldManager;
+}

--- a/extended/src/main/java/io/kubernetes/client/extended/generic/options/DeleteOptions.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/generic/options/DeleteOptions.java
@@ -1,0 +1,5 @@
+package io.kubernetes.client.extended.generic.options;
+
+import io.kubernetes.client.openapi.models.V1DeleteOptions;
+
+public class DeleteOptions extends V1DeleteOptions {}

--- a/extended/src/main/java/io/kubernetes/client/extended/generic/options/GetOptions.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/generic/options/GetOptions.java
@@ -1,0 +1,3 @@
+package io.kubernetes.client.extended.generic.options;
+
+public class GetOptions {}

--- a/extended/src/main/java/io/kubernetes/client/extended/generic/options/ListOptions.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/generic/options/ListOptions.java
@@ -1,0 +1,71 @@
+package io.kubernetes.client.extended.generic.options;
+
+import com.google.gson.annotations.SerializedName;
+
+public class ListOptions {
+  @SerializedName("fieldSelector")
+  private String fieldSelector;
+
+  @SerializedName("labelSelector")
+  private String labelSelector;
+
+  @SerializedName("resourceVersion")
+  private String resourceVersion;
+
+  @SerializedName("timeoutSeconds")
+  private Integer timeoutSeconds;
+
+  @SerializedName("limit")
+  private Integer limit;
+
+  @SerializedName("continue")
+  private String _continue;
+
+  public String getFieldSelector() {
+    return fieldSelector;
+  }
+
+  public void setFieldSelector(String fieldSelector) {
+    this.fieldSelector = fieldSelector;
+  }
+
+  public String getLabelSelector() {
+    return labelSelector;
+  }
+
+  public void setLabelSelector(String labelSelector) {
+    this.labelSelector = labelSelector;
+  }
+
+  public String getResourceVersion() {
+    return resourceVersion;
+  }
+
+  public void setResourceVersion(String resourceVersion) {
+    this.resourceVersion = resourceVersion;
+  }
+
+  public Integer getLimit() {
+    return limit;
+  }
+
+  public void setLimit(Integer limit) {
+    this.limit = limit;
+  }
+
+  public String getContinue() {
+    return _continue;
+  }
+
+  public void setContinue(String _continue) {
+    this._continue = _continue;
+  }
+
+  public Integer getTimeoutSeconds() {
+    return timeoutSeconds;
+  }
+
+  public void setTimeoutSeconds(Integer timeoutSeconds) {
+    this.timeoutSeconds = timeoutSeconds;
+  }
+}

--- a/extended/src/main/java/io/kubernetes/client/extended/generic/options/PatchOptions.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/generic/options/PatchOptions.java
@@ -1,0 +1,3 @@
+package io.kubernetes.client.extended.generic.options;
+
+public class PatchOptions {}

--- a/extended/src/main/java/io/kubernetes/client/extended/generic/options/UpdateOptions.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/generic/options/UpdateOptions.java
@@ -1,0 +1,3 @@
+package io.kubernetes.client.extended.generic.options;
+
+public class UpdateOptions {}

--- a/extended/src/test/java/io/kubernetes/client/extended/generic/FooCustomResource.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/generic/FooCustomResource.java
@@ -1,0 +1,30 @@
+package io.kubernetes.client.extended.generic;
+
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+
+public class FooCustomResource {
+  private V1ObjectMeta metadata;
+
+  public V1ObjectMeta getMetadata() {
+    return metadata;
+  }
+
+  public void setMetadata(V1ObjectMeta metadata) {
+    this.metadata = metadata;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    FooCustomResource that = (FooCustomResource) o;
+
+    return metadata != null ? metadata.equals(that.metadata) : that.metadata == null;
+  }
+
+  @Override
+  public int hashCode() {
+    return metadata != null ? metadata.hashCode() : 0;
+  }
+}

--- a/extended/src/test/java/io/kubernetes/client/extended/generic/FooCustomResourceList.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/generic/FooCustomResourceList.java
@@ -1,0 +1,43 @@
+package io.kubernetes.client.extended.generic;
+
+import io.kubernetes.client.openapi.models.V1ListMeta;
+import java.util.List;
+
+public class FooCustomResourceList {
+  private V1ListMeta metadata;
+  private List<FooCustomResource> items;
+
+  public V1ListMeta getMetadata() {
+    return metadata;
+  }
+
+  public void setMetadata(V1ListMeta metadata) {
+    this.metadata = metadata;
+  }
+
+  public List<FooCustomResource> getItems() {
+    return items;
+  }
+
+  public void setItems(List<FooCustomResource> items) {
+    this.items = items;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    FooCustomResourceList that = (FooCustomResourceList) o;
+
+    if (metadata != null ? !metadata.equals(that.metadata) : that.metadata != null) return false;
+    return items != null ? items.equals(that.items) : that.items == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = metadata != null ? metadata.hashCode() : 0;
+    result = 31 * result + (items != null ? items.hashCode() : 0);
+    return result;
+  }
+}

--- a/extended/src/test/java/io/kubernetes/client/extended/generic/GenericKubernetesApiTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/generic/GenericKubernetesApiTest.java
@@ -1,0 +1,173 @@
+package io.kubernetes.client.extended.generic;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.Assert.*;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.google.gson.Gson;
+import io.kubernetes.client.custom.V1Patch;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.models.*;
+import io.kubernetes.client.util.ClientBuilder;
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class GenericKubernetesApiTest {
+
+  @Rule public WireMockRule wireMockRule = new WireMockRule(8181);
+
+  private GenericKubernetesApi<V1Job, V1JobList> jobClient;
+
+  @Before
+  public void setup() throws IOException {
+    ApiClient apiClient = new ClientBuilder().setBasePath("http://localhost:" + 8181).build();
+    jobClient =
+        new GenericKubernetesApi<>(V1Job.class, V1JobList.class, "batch", "v1", "jobs", apiClient);
+  }
+
+  // test delete
+  @Test
+  public void deleteNamespacedJobReturningStatus() {
+    V1Status status = new V1Status().kind("Status").code(200).message("good!");
+    stubFor(
+        delete(urlEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1"))
+            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(status))));
+
+    KubernetesApiResponse<V1Job> deleteJobResp = jobClient.delete("default", "foo1", null);
+    assertTrue(deleteJobResp.isSuccess());
+    assertEquals(status, deleteJobResp.getStatus());
+    assertNull(deleteJobResp.getObject());
+    verify(1, deleteRequestedFor(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1")));
+  }
+
+  @Test
+  public void deleteNamespacedJobReturningDeletedObject() {
+    V1Job foo1 =
+        new V1Job().kind("Job").metadata(new V1ObjectMeta().namespace("default").name("foo1"));
+
+    stubFor(
+        delete(urlEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1"))
+            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(foo1))));
+
+    KubernetesApiResponse<V1Job> deleteJobResp = jobClient.delete("default", "foo1");
+    assertTrue(deleteJobResp.isSuccess());
+    assertEquals(foo1, deleteJobResp.getObject());
+    assertNull(deleteJobResp.getStatus());
+    verify(1, deleteRequestedFor(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1")));
+  }
+
+  @Test
+  public void deleteNamespacedJobReturningForbiddenStatus() {
+    V1Status status = new V1Status().kind("Status").code(403).message("good!");
+
+    stubFor(
+        delete(urlEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1"))
+            .willReturn(aResponse().withStatus(403).withBody(new Gson().toJson(status))));
+
+    KubernetesApiResponse<V1Job> deleteJobResp = jobClient.delete("default", "foo1");
+    assertFalse(deleteJobResp.isSuccess());
+    assertEquals(status, deleteJobResp.getStatus());
+    assertNull(deleteJobResp.getObject());
+    verify(1, deleteRequestedFor(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1")));
+  }
+
+  @Test
+  public void listNamespacedJobReturningObject() {
+    V1JobList jobList = new V1JobList().kind("JobList").metadata(new V1ListMeta());
+
+    stubFor(
+        get(urlEqualTo("/apis/batch/v1/namespaces/default/jobs"))
+            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(jobList))));
+    KubernetesApiResponse<V1JobList> jobListResp = jobClient.list("default");
+    assertTrue(jobListResp.isSuccess());
+    assertEquals(jobList, jobListResp.getObject());
+    assertNull(jobListResp.getStatus());
+    verify(1, getRequestedFor(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs")));
+  }
+
+  @Test
+  public void listClusterJobReturningObject() {
+    V1JobList jobList = new V1JobList().kind("JobList").metadata(new V1ListMeta());
+
+    stubFor(
+        get(urlEqualTo("/apis/batch/v1/jobs"))
+            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(jobList))));
+    KubernetesApiResponse<V1JobList> jobListResp = jobClient.list();
+    assertTrue(jobListResp.isSuccess());
+    assertEquals(jobList, jobListResp.getObject());
+    assertNull(jobListResp.getStatus());
+    verify(1, getRequestedFor(urlPathEqualTo("/apis/batch/v1/jobs")));
+  }
+
+  @Test
+  public void createNamespacedJobReturningObject() {
+    V1Job foo1 =
+        new V1Job().kind("Job").metadata(new V1ObjectMeta().namespace("default").name("foo1"));
+
+    stubFor(
+        post(urlEqualTo("/apis/batch/v1/namespaces/default/jobs"))
+            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(foo1))));
+    KubernetesApiResponse<V1Job> jobListResp = jobClient.create(foo1);
+    assertTrue(jobListResp.isSuccess());
+    assertEquals(foo1, jobListResp.getObject());
+    assertNull(jobListResp.getStatus());
+    verify(1, postRequestedFor(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs")));
+  }
+
+  @Test
+  public void updateNamespacedJobReturningObject() {
+    V1Job foo1 =
+        new V1Job().kind("Job").metadata(new V1ObjectMeta().namespace("default").name("foo1"));
+
+    stubFor(
+        put(urlEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1"))
+            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(foo1))));
+    KubernetesApiResponse<V1Job> jobListResp = jobClient.update(foo1);
+    assertTrue(jobListResp.isSuccess());
+    assertEquals(foo1, jobListResp.getObject());
+    assertNull(jobListResp.getStatus());
+    verify(1, putRequestedFor(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1")));
+  }
+
+  @Test
+  public void patchNamespacedJobReturningObject() {
+    V1Patch v1Patch = new V1Patch("{}");
+    V1Job foo1 =
+        new V1Job().kind("Job").metadata(new V1ObjectMeta().namespace("default").name("foo1"));
+    stubFor(
+        patch(urlEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1"))
+            .withHeader("Content-Type", containing(V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH))
+            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(foo1))));
+    KubernetesApiResponse<V1Job> jobPatchResp =
+        jobClient.patch("default", "foo1", V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH, v1Patch);
+
+    assertTrue(jobPatchResp.isSuccess());
+    assertEquals(foo1, jobPatchResp.getObject());
+    assertNull(jobPatchResp.getStatus());
+    verify(1, patchRequestedFor(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1")));
+  }
+
+  @Test
+  public void testReadTimeoutShouldThrowException() {
+    ApiClient apiClient = new ClientBuilder().setBasePath("http://localhost:" + 8181).build();
+    apiClient.setHttpClient(
+        apiClient
+            .getHttpClient()
+            .newBuilder()
+            .readTimeout(1, TimeUnit.MILLISECONDS) // timeout everytime
+            .build());
+    jobClient =
+        new GenericKubernetesApi<>(V1Job.class, V1JobList.class, "batch", "v1", "jobs", apiClient);
+    try {
+      KubernetesApiResponse<V1Job> response = jobClient.get("foo", "test");
+    } catch (Throwable t) {
+      assertTrue(t.getCause() instanceof SocketTimeoutException);
+      return;
+    }
+    fail("no exception happened");
+  }
+}

--- a/extended/src/test/java/io/kubernetes/client/extended/generic/GenericKubernetesGetApiTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/generic/GenericKubernetesGetApiTest.java
@@ -1,0 +1,82 @@
+package io.kubernetes.client.extended.generic;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.Assert.*;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.google.gson.Gson;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.models.*;
+import io.kubernetes.client.util.ClientBuilder;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author zuoxiu.jm
+ * @version : GenericKubernetesGetApiTest.java, v 0.1 2019年10月18日 1:52 PM zuoxiu.jm Exp $
+ */
+public class GenericKubernetesGetApiTest {
+
+  @Rule public WireMockRule wireMockRule = new WireMockRule(8181);
+
+  private GenericKubernetesApi<V1Job, V1JobList> jobClient; // non-core built-in resource
+  private GenericKubernetesApi<FooCustomResource, FooCustomResourceList>
+      fooClient; // custom resource
+
+  @Before
+  public void setup() {
+    ApiClient apiClient = new ClientBuilder().setBasePath("http://localhost:" + 8181).build();
+    jobClient =
+        new GenericKubernetesApi<>(V1Job.class, V1JobList.class, "batch", "v1", "jobs", apiClient);
+    fooClient =
+        new GenericKubernetesApi<>(
+            FooCustomResource.class,
+            FooCustomResourceList.class,
+            "example.io",
+            "v1",
+            "foos",
+            apiClient);
+  }
+
+  @Test
+  public void returningNormalObjectShouldWork() {
+    V1Job job = new V1Job().kind("Job");
+    FooCustomResource foo = new FooCustomResource();
+
+    stubFor(
+        get(urlEqualTo("/apis/batch/v1/namespaces/default/jobs/noxu"))
+            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(job))));
+    stubFor(
+        get(urlEqualTo("/apis/example.io/v1/namespaces/default/foos/noxu"))
+            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(foo))));
+
+    KubernetesApiResponse<V1Job> jobResp = jobClient.get("default", "noxu");
+    KubernetesApiResponse<FooCustomResource> fooResp = fooClient.get("default", "noxu");
+
+    assertEquals(job, jobResp.getObject());
+    assertEquals(foo, fooResp.getObject());
+    assertNull(jobResp.getStatus());
+    assertNull(fooResp.getStatus());
+  }
+
+  @Test
+  public void returningStatusShouldWork() {
+    V1Status forbiddenStatus = new V1Status().kind("Status");
+
+    stubFor(
+        get(urlEqualTo("/apis/batch/v1/namespaces/default/jobs/noxu"))
+            .willReturn(aResponse().withStatus(403).withBody(new Gson().toJson(forbiddenStatus))));
+    stubFor(
+        get(urlEqualTo("/apis/example.io/v1/namespaces/default/foos/noxu"))
+            .willReturn(aResponse().withStatus(403).withBody(new Gson().toJson(forbiddenStatus))));
+
+    KubernetesApiResponse<V1Job> jobResp = jobClient.get("default", "noxu");
+    KubernetesApiResponse<FooCustomResource> fooResp = fooClient.get("default", "noxu");
+
+    assertEquals(forbiddenStatus, jobResp.getStatus());
+    assertEquals(forbiddenStatus, fooResp.getStatus());
+    assertNull(jobResp.getObject());
+    assertNull(fooResp.getObject());
+  }
+}


### PR DESCRIPTION
@brendandburns 

NOTE: i will sanitize the pull l8r (the license, formatting, etc..).. 

it's neat and simple. w/ the help of this generic client, what we only need is the generated model. i just drafted initial version of code and test, it already covers all the api paths on the kubernetes apiserver.

the general idea is to make use of CustomObjectApi as best as we can, this will help us access custom resources in kubernetes in an easier way. appreciated if you feel like shed some light on it