### PR TITLE
Dedicated OSGi bundle merging both `client-java` and `client-java-api`

### DIFF
--- a/client-java-osgi/bnd.bnd
+++ b/client-java-osgi/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-SymbolicName: io.kubernetes.client.java.osgi
 
--includeresource \
+-includeresource: \
 	@client-java-api-${project.version}.jar, \
 	@client-java-${project.version}.jar
 

--- a/client-java-osgi/bnd.bnd
+++ b/client-java-osgi/bnd.bnd
@@ -1,0 +1,15 @@
+Bundle-SymbolicName: io.kubernetes.client.java.osgi
+
+-includeresource \
+	@client-java-api-${project.version}.jar, \
+	@client-java-${project.version}.jar
+
+Import-Package: \
+	io.kubernetes.client.proto, \
+	com.microsoft.aad.adal4j;resolution:=optional, \
+	*
+			
+Export-Package: \
+	!io.kubernetes.client.informer.impl, \
+	!io.kubernetes.client.proto, \
+	io.kubernetes.client.*;-split-package:=merge-first

--- a/client-java-osgi/pom.xml
+++ b/client-java-osgi/pom.xml
@@ -35,6 +35,7 @@
 				<version>4.3.0</version>
 				<executions>
 					<execution>
+						<phase>prepare-package</phase>
 						<goals>
 							<goal>bnd-process</goal>
 						</goals>

--- a/client-java-osgi/pom.xml
+++ b/client-java-osgi/pom.xml
@@ -1,0 +1,55 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>io.kubernetes</groupId>
+		<artifactId>client-java-parent</artifactId>
+		<version>7.0.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>client-java-osgi</artifactId>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>io.kubernetes</groupId>
+			<artifactId>client-java-api</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.kubernetes</groupId>
+			<artifactId>client-java</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<version>4.3.0</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>bnd-process</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+					</archive>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <module>kubernetes</module>
     <module>proto</module>
     <module>extended</module>
+    <module>client-java-osgi</module>
   </modules>
 
   <scm>


### PR DESCRIPTION
This is simple workaround for #737 
It adds new module that basically merges the two modules currently containing the split package.

This is not a fix but workaround that allows to use the client in OSGi environment wile waiting for the proper fix in 7. 

I'm sending this to `master` only because I couldn't find a `6.0.1` branch. It would be awesome if you can merge it to `6.0.1` code _(only new files here so there should be no conflicts)_ and release the `io.kubernetes:client-java-osgi:6.0.1` artifact to maven central.   