### PR TITLE
Resetting wiremock to fix flakiness in build

### DIFF
--- a/util/src/test/java/io/kubernetes/client/CopyTest.java
+++ b/util/src/test/java/io/kubernetes/client/CopyTest.java
@@ -20,6 +20,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.models.V1Pod;
@@ -29,7 +30,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Paths;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -50,6 +50,7 @@ public class CopyTest {
 
     namespace = "default";
     podName = "apod";
+    WireMock.resetToDefault();
   }
 
   @Test
@@ -80,8 +81,6 @@ public class CopyTest {
   }
 
   @Test
-  @Ignore // TODO(yue9944882): this test leads to flakiness in the test infra, revert this after the
-  // root cause is located
   public void testCopyFileToPod() throws IOException, ApiException, InterruptedException {
 
     File testFile = File.createTempFile("testfile", null);


### PR DESCRIPTION
Fixes #743 . I was able to repro the build failure with Open JDK 11.0.5. Tests don't fail when you just run tests in CopyTest. However if you try to run mvn test on entire Util module it fails. I was able to run mvn test on Util module successfully after resetting WireMock. Please take a look at it.