### PR TITLE
Pin commons-collections dependency 

### DIFF
--- a/extended/pom.xml
+++ b/extended/pom.xml
@@ -70,7 +70,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
-            <version>4.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,11 @@
         <artifactId>commons-lang3</artifactId>
         <version>3.7</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-collections4</artifactId>
+        <version>4.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -77,6 +77,10 @@
             <artifactId>protobuf-java</artifactId>
             <version>3.4.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+        </dependency>
         <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
otherwise dependent will have trouble hitting exception:

```
Exception in thread "main" java.lang.NoClassDefFoundError: org/apache/commons/collections4/MapUtils
Caused by: java.lang.ClassNotFoundException: org.apache.commons.collections4.MapUtils
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 2 more

```
