### PR TITLE
Chore: Split reflect utils to [Object|List]accessor for clarification

### DIFF
--- a/extended/src/main/java/io/kubernetes/client/extended/controller/Controllers.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/controller/Controllers.java
@@ -3,7 +3,7 @@ package io.kubernetes.client.extended.controller;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.kubernetes.client.extended.controller.reconciler.Request;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import io.kubernetes.client.util.Reflect;
+import io.kubernetes.client.util.ObjectAccessor;
 import io.kubernetes.client.util.exception.ObjectMetaReflectException;
 import java.util.concurrent.ThreadFactory;
 import java.util.function.Function;
@@ -25,7 +25,7 @@ public class Controllers {
   public static <ApiType> Function<ApiType, Request> defaultReflectiveKeyFunc() {
     return (ApiType obj) -> {
       try {
-        V1ObjectMeta objectMeta = Reflect.objectMetadata(obj);
+        V1ObjectMeta objectMeta = ObjectAccessor.objectMetadata(obj);
         return new Request(objectMeta.getNamespace(), objectMeta.getName());
       } catch (ObjectMetaReflectException e) {
         log.error("Fail to access object-meta from {}..", obj.getClass());

--- a/extended/src/main/java/io/kubernetes/client/extended/pager/Pager.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/pager/Pager.java
@@ -14,7 +14,7 @@ package io.kubernetes.client.extended.pager;
 
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.util.Reflect;
+import io.kubernetes.client.util.ListAccessor;
 import io.kubernetes.client.util.exception.ObjectMetaReflectException;
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -136,12 +136,12 @@ public class Pager<ApiType, ApiListType> implements Iterable<ApiType> {
           call = getNextCall(limit, continueToken);
 
           listObjectCurrentPage = executeRequest(call);
-          continueToken = Reflect.listMetadata(listObjectCurrentPage).getContinue();
+          continueToken = ListAccessor.listMetadata(listObjectCurrentPage).getContinue();
 
           offsetCurrentPage = 0;
-          currentPageSize = Reflect.<ApiType>getItems(listObjectCurrentPage).size();
+          currentPageSize = ListAccessor.<ApiType>getItems(listObjectCurrentPage).size();
         }
-        return Reflect.<ApiType>getItems(listObjectCurrentPage).get(offsetCurrentPage++);
+        return ListAccessor.<ApiType>getItems(listObjectCurrentPage).get(offsetCurrentPage++);
       } catch (ApiException e) {
         throw new RuntimeException(e.getResponseBody());
       } catch (ObjectMetaReflectException | IOException e) {

--- a/util/src/main/java/io/kubernetes/client/informer/cache/Caches.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/Caches.java
@@ -3,7 +3,7 @@ package io.kubernetes.client.informer.cache;
 import com.google.common.base.Strings;
 import io.kubernetes.client.informer.exception.BadObjectException;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import io.kubernetes.client.util.Reflect;
+import io.kubernetes.client.util.ObjectAccessor;
 import io.kubernetes.client.util.exception.ObjectMetaReflectException;
 import java.util.Collections;
 import java.util.List;
@@ -46,7 +46,7 @@ public class Caches {
       } else if (obj instanceof V1ObjectMeta) {
         metadata = (V1ObjectMeta) obj;
       } else {
-        metadata = Reflect.objectMetadata(obj);
+        metadata = ObjectAccessor.objectMetadata(obj);
         if (metadata == null) {
           throw new BadObjectException(obj);
         }
@@ -69,7 +69,7 @@ public class Caches {
    */
   public static List<String> metaNamespaceIndexFunc(Object obj) {
     try {
-      V1ObjectMeta metadata = Reflect.objectMetadata(obj);
+      V1ObjectMeta metadata = ObjectAccessor.objectMetadata(obj);
       if (metadata == null) {
         return Collections.emptyList();
       }

--- a/util/src/main/java/io/kubernetes/client/informer/cache/ReflectorRunnable.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/ReflectorRunnable.java
@@ -4,9 +4,7 @@ import io.kubernetes.client.informer.EventType;
 import io.kubernetes.client.informer.ListerWatcher;
 import io.kubernetes.client.openapi.models.V1ListMeta;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import io.kubernetes.client.util.CallGeneratorParams;
-import io.kubernetes.client.util.Reflect;
-import io.kubernetes.client.util.Watchable;
+import io.kubernetes.client.util.*;
 import io.kubernetes.client.util.exception.ObjectMetaReflectException;
 import java.net.ConnectException;
 import java.time.Duration;
@@ -46,9 +44,9 @@ public class ReflectorRunnable<ApiType, ApiListType> implements Runnable {
 
       ApiListType list = listerWatcher.list(new CallGeneratorParams(Boolean.FALSE, null, null));
 
-      V1ListMeta listMeta = Reflect.listMetadata(list);
+      V1ListMeta listMeta = ListAccessor.listMetadata(list);
       String resourceVersion = listMeta.getResourceVersion();
-      List<ApiType> items = Reflect.getItems(list);
+      List<ApiType> items = ListAccessor.getItems(list);
 
       if (log.isDebugEnabled()) {
         log.debug("{}#Extract resourceVersion {} list meta", apiTypeClass, resourceVersion);
@@ -144,7 +142,7 @@ public class ReflectorRunnable<ApiType, ApiListType> implements Runnable {
 
       V1ObjectMeta meta;
       try {
-        meta = Reflect.objectMetadata(obj);
+        meta = ObjectAccessor.objectMetadata(obj);
       } catch (ObjectMetaReflectException e) {
         log.error("malformed watch event {}", item);
         continue;

--- a/util/src/main/java/io/kubernetes/client/util/ListAccessor.java
+++ b/util/src/main/java/io/kubernetes/client/util/ListAccessor.java
@@ -1,0 +1,32 @@
+package io.kubernetes.client.util;
+
+import io.kubernetes.client.openapi.models.V1ListMeta;
+import io.kubernetes.client.util.exception.ObjectMetaReflectException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+
+/** ListAccessor is a set of utils which accesses common fields from list objects dynamically */
+public class ListAccessor {
+
+  private static final String METHOD_NAME_GET_ITEMS = "getItems";
+  private static final String METHOD_NAME_GET_LIST_METADATA = "getMetadata";
+
+  public static V1ListMeta listMetadata(Object listObj) throws ObjectMetaReflectException {
+    try {
+      Method mdField = listObj.getClass().getMethod(METHOD_NAME_GET_LIST_METADATA);
+      return (V1ListMeta) mdField.invoke(listObj);
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      throw new ObjectMetaReflectException(e);
+    }
+  }
+
+  public static <ApiType> List<ApiType> getItems(Object listObj) throws ObjectMetaReflectException {
+    try {
+      Method getItemsMethod = listObj.getClass().getMethod(METHOD_NAME_GET_ITEMS);
+      return (List<ApiType>) getItemsMethod.invoke(listObj);
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      throw new ObjectMetaReflectException(e);
+    }
+  }
+}

--- a/util/src/main/java/io/kubernetes/client/util/ObjectAccessor.java
+++ b/util/src/main/java/io/kubernetes/client/util/ObjectAccessor.java
@@ -1,0 +1,29 @@
+package io.kubernetes.client.util;
+
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.util.exception.ObjectMetaReflectException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/** ObjectAccessor is a set of utils which accesses common fields from objects dynamically */
+public class ObjectAccessor {
+
+  private static final String METHOD_NAME_GET_METADATA = "getMetadata";
+
+  public static V1ObjectMeta objectMetadata(Object obj) throws ObjectMetaReflectException {
+    try {
+      Method mdField = obj.getClass().getMethod(METHOD_NAME_GET_METADATA);
+      return (V1ObjectMeta) mdField.invoke(obj);
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      throw new ObjectMetaReflectException(e);
+    }
+  }
+
+  public static String namespace(Object obj) throws ObjectMetaReflectException {
+    return objectMetadata(obj).getNamespace();
+  }
+
+  public static String name(Object obj) throws ObjectMetaReflectException {
+    return objectMetadata(obj).getName();
+  }
+}

--- a/util/src/main/java/io/kubernetes/client/util/Reflect.java
+++ b/util/src/main/java/io/kubernetes/client/util/Reflect.java
@@ -3,41 +3,25 @@ package io.kubernetes.client.util;
 import io.kubernetes.client.openapi.models.V1ListMeta;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.util.exception.ObjectMetaReflectException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.List;
 
 /** Reflect is a set of utils which extracts metadata from objects dynamically */
+@Deprecated
 public class Reflect {
 
   public static V1ObjectMeta objectMetadata(Object obj) throws ObjectMetaReflectException {
-    try {
-      Method mdField = obj.getClass().getMethod("getMetadata");
-      return (V1ObjectMeta) mdField.invoke(obj);
-    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-      throw new ObjectMetaReflectException(e);
-    }
+    return ObjectAccessor.objectMetadata(obj);
   }
 
   public static String namespace(Object obj) throws ObjectMetaReflectException {
-    return objectMetadata(obj).getNamespace();
+    return ObjectAccessor.namespace(obj);
   }
 
   public static V1ListMeta listMetadata(Object listObj) throws ObjectMetaReflectException {
-    try {
-      Method mdField = listObj.getClass().getMethod("getMetadata");
-      return (V1ListMeta) mdField.invoke(listObj);
-    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-      throw new ObjectMetaReflectException(e);
-    }
+    return ListAccessor.listMetadata(listObj);
   }
 
   public static <ApiType> List<ApiType> getItems(Object listObj) throws ObjectMetaReflectException {
-    try {
-      Method getItemsMethod = listObj.getClass().getMethod("getItems");
-      return (List<ApiType>) getItemsMethod.invoke(listObj);
-    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-      throw new ObjectMetaReflectException(e);
-    }
+    return ListAccessor.getItems(listObj);
   }
 }


### PR DESCRIPTION
separating these util functions helps us sorting them by their usages. and also this aligns w/ the naming from upstream client-go so that users can find them more easily.