### PR TITLE
Extract thread pool shutdown to a separate method

### DIFF
--- a/util/src/main/java/io/kubernetes/client/informer/SharedInformerFactory.java
+++ b/util/src/main/java/io/kubernetes/client/informer/SharedInformerFactory.java
@@ -178,8 +178,17 @@ public class SharedInformerFactory {
         });
   }
 
-  /** Stop all registered informers. */
+  /** Stop all registered informers and shut down the thread pool. */
   public synchronized void stopAllRegisteredInformers() {
+    stopAllRegisteredInformers(true);
+  }
+
+  /**
+   * Stop all registered informers.
+   *
+   * @param shutdownThreadPool whether or not to shut down the thread pool.
+   */
+  public synchronized void stopAllRegisteredInformers(boolean shutdownThreadPool) {
     if (MapUtils.isEmpty(informers)) {
       return;
     }
@@ -190,6 +199,8 @@ public class SharedInformerFactory {
             informer.stop();
           }
         });
-    informerExecutor.shutdown();
+    if (shutdownThreadPool) {
+      informerExecutor.shutdown();
+    }
   }
 }


### PR DESCRIPTION
The current API of SharedInformerFactory supports two cases
in regards to the thread pool it uses inside:
1. Default thread pool - if no thread pool is specified, a new
thread pool is instantiated internally.
2. Provided thread pool - if a thread pool is specified, it
is the one used internally by this class.

Seems that the purpose of (2) is to enable users to provide
their own thread pool, configured the way they want rather than
relying on the thread pool that is instantiated internally.

However, one may think that (2) also enables the caller to pass
a thread pool that is shared among other components in their
application. The issue is that when calling the method
stopAllRegisteredInformers, it shuts down the thread pool and
that may not necessarily be the desired behavior in this case.

This patch introduces a way to signal that the thread pool should
not be shut down when removing all the registered informers.