### PR TITLE
declare QuantityAdapter static

### DIFF
--- a/kubernetes/src/main/java/io/kubernetes/client/custom/Quantity.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/custom/Quantity.java
@@ -81,7 +81,7 @@ public class Quantity {
            Objects.equals(this.format, otherQuantity.format);
   }
 
-  public class QuantityAdapter extends TypeAdapter<Quantity> {
+  public static class QuantityAdapter extends TypeAdapter<Quantity> {
     @Override
     public void write(JsonWriter jsonWriter, Quantity quantity) throws IOException {
       jsonWriter.value(quantity != null ? quantity.toSuffixedString() : null);


### PR DESCRIPTION
This fix addresses #809 by declaring the inner class `QuanitytAdapter` static, similar to how `IntOrString` does. This allows it to be referenced in the GraalVM native-image reflection configuration in the same way.

Built and tested using `mvn install`. All tests passed (or were skipped):

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Kubernetes Client API 7.0.0-SNAPSHOT:
[INFO] 
[INFO] Kubernetes Client API .............................. SUCCESS [  0.092 s]
[INFO] client-java-api .................................... SUCCESS [08:28 min]
[INFO] client-java-proto .................................. SUCCESS [ 25.205 s]
[INFO] client-java ........................................ SUCCESS [03:39 min]
[INFO] client-java-extended ............................... SUCCESS [01:58 min]
[INFO] client-java-examples ............................... SUCCESS [ 12.925 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  14:45 min
[INFO] Finished at: 2019-11-22T13:40:32-05:00
[INFO] ------------------------------------------------------------------------
```

Updated the test application in #809 and was able to build it successfully with this addition to `reflect-config.json`:

```
  {
    "name":"io.kubernetes.client.custom.Quantity$QuantityAdapter",
    "methods":[{"name":"<init>","parameterTypes":[] }]
  }
```

Running the resulting application generates the expected results:

```
$ java -jar ./target/app-1.0-SNAPSHOT-jar-with-dependencies.jar 
intOrString = 4
quanitity = 1Gi
$ ./target/io.titandata.app.app 
intOrString = 4
quanitity = 1Gi
```
