### PR TITLE
update snakeyaml to 1.25

### DIFF
--- a/util/pom.xml
+++ b/util/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.19</version>
+            <version>1.25</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>


### PR DESCRIPTION
Fixes #811. Build and test using `mvn install`:

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Kubernetes Client API 7.0.0-SNAPSHOT:
[INFO] 
[INFO] Kubernetes Client API .............................. SUCCESS [  0.137 s]
[INFO] client-java-api .................................... SUCCESS [08:28 min]
[INFO] client-java-proto .................................. SUCCESS [ 30.305 s]
[INFO] client-java ........................................ SUCCESS [07:44 min]
[INFO] client-java-extended ............................... SUCCESS [01:59 min]
[INFO] client-java-examples ............................... SUCCESS [ 10.398 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  18:54 min
[INFO] Finished at: 2019-11-22T19:59:13-05:00
[INFO] ------------------------------------------------------------------------
```

Using program from #811 , what was previously failing now gets further, to the point of requiring additional reflect config:

```
$ ./target/io.titandata.app.app 
Exception in thread "main" java.lang.ExceptionInInitializerError
	at com.oracle.svm.core.hub.ClassInitializationInfo.initialize(ClassInitializationInfo.java:290)
	at java.lang.Class.ensureInitialized(DynamicHub.java:467)
	at okhttp3.OkHttpClient.<clinit>(OkHttpClient.java:124)
	at com.oracle.svm.core.hub.ClassInitializationInfo.invokeClassInitializer(ClassInitializationInfo.java:350)
	at com.oracle.svm.core.hub.ClassInitializationInfo.initialize(ClassInitializationInfo.java:270)
	at java.lang.Class.ensureInitialized(DynamicHub.java:467)
	at okhttp3.OkHttpClient$Builder.<init>(OkHttpClient.java:449)
	at io.kubernetes.client.openapi.ApiClient.init(ApiClient.java:91)
	at io.kubernetes.client.openapi.ApiClient.<init>(ApiClient.java:82)
	at io.kubernetes.client.util.ClientBuilder.build(ClientBuilder.java:295)
	at io.kubernetes.client.util.Config.defaultClient(Config.java:113)
	at io.titandata.app.App.main(App.java:14)
Caused by: java.nio.charset.UnsupportedCharsetException: UTF-32BE
	at java.nio.charset.Charset.forName(Charset.java:531)
	at okhttp3.internal.Util.<clinit>(Util.java:81)
	at com.oracle.svm.core.hub.ClassInitializationInfo.invokeClassInitializer(ClassInitializationInfo.java:350)
	at com.oracle.svm.core.hub.ClassInitializationInfo.initialize(ClassInitializationInfo.java:270)
```

In addition, we've been using this version of snakeyaml with the client in our testing for a while now without issue.