### PR TITLE
enhance informer

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ We prepared a few examples for common use-cases which are shown below:
   Build an informer which list-watches resources and reflects the notifications to a local cache.
   - ([5.0.0+](https://github.com/kubernetes-client/java/tree/client-java-parent-5.0.0)) [PagerExample](https://github.com/kubernetes-client/java/blob/master/examples/src/main/java/io/kubernetes/client/examples/PagerExample.java): 
   Support Pagination (only for the list request) to ease server-side loads/network congestion.
+  - ([5.0.0+](https://github.com/kubernetes-client/java/tree/client-java-parent-5.0.0)) [PageInformerExample](https://github.com/kubernetes-client/java/blob/master/examples/src/main/java/io/kubernetes/client/examples/PageInformerExample.java): 
+  Build an informer which list-watches resources, and informer list request support pagination like client-go(default limit 500).
+  - ([5.0.0+](https://github.com/kubernetes-client/java/tree/client-java-parent-5.0.0)) [FieldFilterPageInformerExample](https://github.com/kubernetes-client/java/blob/master/examples/src/main/java/io/kubernetes/client/examples/FieldFilterPageInformerExample.java): 
+  Like PageInformerExample, but informer local-cache filter resource fields which customer definition，to ease server-side JVM memory usage，avoid oom.
   - ([6.0.0+](https://github.com/kubernetes-client/java/tree/client-java-parent-6.0.0)) [ControllerExample](https://github.com/kubernetes-client/java/blob/master/examples/src/main/java/io/kubernetes/client/examples/ControllerExample.java): 
   Build a controller reconciling the state of world by list-watching one or multiple resources.
   - ([6.0.0+](https://github.com/kubernetes-client/java/tree/client-java-parent-6.0.0)) [LeaderElectionExample](https://github.com/kubernetes-client/java/blob/master/examples/src/main/java/io/kubernetes/client/examples/LeaderElectionExample.java): 

--- a/examples/src/main/java/io/kubernetes/client/examples/FieldFilterPageInformerExample.java
+++ b/examples/src/main/java/io/kubernetes/client/examples/FieldFilterPageInformerExample.java
@@ -1,0 +1,188 @@
+package io.kubernetes.client.examples;
+
+import static java.util.stream.Collectors.toList;
+
+import com.google.common.collect.Sets;
+import com.google.gson.annotations.SerializedName;
+import io.kubernetes.client.extended.informer.FilterField;
+import io.kubernetes.client.extended.informer.PageSharedInformerFactory;
+import io.kubernetes.client.extended.informer.PagerCallGeneratorParams;
+import io.kubernetes.client.extended.informer.SerializeFilterJSON;
+import io.kubernetes.client.informer.ResourceEventHandler;
+import io.kubernetes.client.informer.SharedIndexInformer;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.GzipRequestInterceptor;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1Container;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodList;
+import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.kubernetes.client.openapi.models.V1PodStatus;
+import io.kubernetes.client.util.CallGenerator;
+import io.kubernetes.client.util.Config;
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import org.apache.commons.collections4.ListUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Created by 烛坤 on 2019/12/2.
+ *
+ * @author 烛坤
+ * @date 2019/12/02
+ */
+public class FieldFilterPageInformerExample {
+
+  private static final Logger log = LoggerFactory.getLogger(FieldFilterPageInformerExample.class);
+
+  private static final Function<Class<?>, List<FilterField>> LIST_FILTER_FIELD_FUNCTION =
+      clazz ->
+          Arrays.stream(clazz.getDeclaredFields())
+              .filter(f -> !Modifier.isStatic(f.getModifiers()))
+              .map(
+                  f ->
+                      new FilterField()
+                          .setSerializedName(f.getAnnotation(SerializedName.class).value())
+                          .setDeclaringClass(clazz))
+              .collect(toList());
+
+  private static final List<FilterField> V1ObjectMeta_ALL_FILTER_FIELD =
+      LIST_FILTER_FIELD_FUNCTION.apply(V1ObjectMeta.class);
+
+  private static final List<FilterField> V1PodSpec_ALL_FILTER_FIELD =
+      LIST_FILTER_FIELD_FUNCTION.apply(V1PodSpec.class);
+
+  private static final List<FilterField> V1PodStatus_ALL_FILTER_FIELD =
+      LIST_FILTER_FIELD_FUNCTION.apply(V1PodStatus.class);
+
+  private static final List<FilterField> V1Container_ALL_FILTER_FIELD =
+      LIST_FILTER_FIELD_FUNCTION.apply(V1Container.class);
+
+  private static final ResourceEventHandler<V1Pod> FILTER_FIELD_EVENT_HANDLER =
+      new ResourceEventHandler<V1Pod>() {
+
+        @Override
+        public void onAdd(V1Pod pod) {
+
+          log.info("{} pod add!", pod.getMetadata().getName());
+        }
+
+        @Override
+        public void onUpdate(V1Pod oldPod, V1Pod newPod) {
+
+          log.info(
+              "{} => {} pod updated!",
+              oldPod.getMetadata().getName(),
+              newPod.getMetadata().getName());
+        }
+
+        @Override
+        public void onDelete(V1Pod pod, boolean deletedFinalStateUnknown) {
+
+          log.info("{} pod deleted!", pod.getMetadata().getName());
+        }
+      };
+
+  public static void main(String[] args) throws IOException, InterruptedException {
+
+    ApiClient client = Config.defaultClient();
+
+    client.setHttpClient(
+        client
+            .getHttpClient()
+            .newBuilder()
+            .readTimeout(0, TimeUnit.MINUTES)
+            .addInterceptor(new GzipRequestInterceptor())
+            .build());
+
+    CoreV1Api coreV1Api = new CoreV1Api(client);
+
+    CallGenerator<PagerCallGeneratorParams> callGenerator =
+        params ->
+            coreV1Api.listPodForAllNamespacesCall(
+                null,
+                params.getContinueToken(),
+                null,
+                null,
+                params.getLimit(),
+                null,
+                params.resourceVersion,
+                params.timeoutSeconds,
+                params.watch,
+                null);
+
+    List<FilterField> filterFields = listFilterField();
+
+    client.setJSON(new SerializeFilterJSON(filterFields));
+
+    PageSharedInformerFactory factory = new PageSharedInformerFactory(client);
+
+    SharedIndexInformer<V1Pod> podInformer =
+        factory.sharedIndexInformerFor(callGenerator, V1Pod.class, V1PodList.class);
+
+    podInformer.addEventHandler(FILTER_FIELD_EVENT_HANDLER);
+
+    factory.startAllRegisteredInformers();
+
+    while (!podInformer.hasSynced()) {
+      TimeUnit.SECONDS.sleep(1);
+    }
+
+    System.out.println(podInformer.getIndexer().size());
+  }
+
+  private static List<FilterField> listFilterField() {
+
+    Set<String> podMetaNeed =
+        Sets.newHashSet(
+            V1ObjectMeta.SERIALIZED_NAME_NAME,
+            V1ObjectMeta.SERIALIZED_NAME_NAMESPACE,
+            V1ObjectMeta.SERIALIZED_NAME_RESOURCE_VERSION,
+            V1ObjectMeta.SERIALIZED_NAME_CREATION_TIMESTAMP,
+            V1ObjectMeta.SERIALIZED_NAME_LABELS);
+
+    List<FilterField> podMetaFilterFields =
+        V1ObjectMeta_ALL_FILTER_FIELD.stream()
+            .filter(f -> !podMetaNeed.contains(f.getSerializedName()))
+            .collect(toList());
+
+    Set<String> podSpecNeed =
+        Sets.newHashSet(
+            V1PodSpec.SERIALIZED_NAME_CONTAINERS,
+            V1PodSpec.SERIALIZED_NAME_NODE_NAME,
+            V1PodSpec.SERIALIZED_NAME_AFFINITY,
+            V1PodSpec.SERIALIZED_NAME_TOLERATIONS);
+
+    List<FilterField> podSpecFilterFields =
+        V1PodSpec_ALL_FILTER_FIELD.stream()
+            .filter(f -> !podSpecNeed.contains(f.getSerializedName()))
+            .collect(toList());
+
+    Set<String> podSpecV1ContainerNeed =
+        Sets.newHashSet(V1Container.SERIALIZED_NAME_NAME, V1Container.SERIALIZED_NAME_RESOURCES);
+
+    List<FilterField> podSpecV1ContainerFilterFields =
+        V1Container_ALL_FILTER_FIELD.stream()
+            .filter(f -> !podSpecV1ContainerNeed.contains(f.getSerializedName()))
+            .collect(toList());
+
+    Set<String> podStatusNeed =
+        Sets.newHashSet(V1PodStatus.SERIALIZED_NAME_PHASE, V1PodStatus.SERIALIZED_NAME_CONDITIONS);
+
+    List<FilterField> podStatusFilterFields =
+        V1PodStatus_ALL_FILTER_FIELD.stream()
+            .filter(f -> !podStatusNeed.contains(f.getSerializedName()))
+            .collect(toList());
+
+    return ListUtils.union(
+        ListUtils.union(podMetaFilterFields, podSpecFilterFields),
+        ListUtils.union(podSpecV1ContainerFilterFields, podStatusFilterFields));
+  }
+}

--- a/examples/src/main/java/io/kubernetes/client/examples/InformerExample.java
+++ b/examples/src/main/java/io/kubernetes/client/examples/InformerExample.java
@@ -1,6 +1,8 @@
 package io.kubernetes.client.examples;
 
-import io.kubernetes.client.informer.*;
+import io.kubernetes.client.informer.ResourceEventHandler;
+import io.kubernetes.client.informer.SharedIndexInformer;
+import io.kubernetes.client.informer.SharedInformerFactory;
 import io.kubernetes.client.informer.cache.Lister;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.apis.CoreV1Api;

--- a/examples/src/main/java/io/kubernetes/client/examples/PageInformerExample.java
+++ b/examples/src/main/java/io/kubernetes/client/examples/PageInformerExample.java
@@ -1,0 +1,76 @@
+package io.kubernetes.client.examples;
+
+import io.kubernetes.client.extended.informer.PageSharedInformerFactory;
+import io.kubernetes.client.extended.informer.PagerCallGeneratorParams;
+import io.kubernetes.client.informer.ResourceEventHandler;
+import io.kubernetes.client.informer.SharedIndexInformer;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.Configuration;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1Node;
+import io.kubernetes.client.openapi.models.V1NodeList;
+import io.kubernetes.client.util.CallGenerator;
+import io.kubernetes.client.util.Config;
+import java.util.concurrent.TimeUnit;
+
+public class PageInformerExample {
+
+  private static final ResourceEventHandler<V1Node> RESOURCE_EVENT_HANDLER =
+      new ResourceEventHandler<V1Node>() {
+
+        @Override
+        public void onAdd(V1Node node) {
+          System.out.printf("%s node added!\n", node.getMetadata().getName());
+        }
+
+        @Override
+        public void onUpdate(V1Node oldNode, V1Node newNode) {
+          System.out.printf(
+              "%s => %s node updated!\n",
+              oldNode.getMetadata().getName(), newNode.getMetadata().getName());
+        }
+
+        @Override
+        public void onDelete(V1Node node, boolean deletedFinalStateUnknown) {
+          System.out.printf("%s node deleted!\n", node.getMetadata().getName());
+        }
+      };
+
+  public static void main(String[] args) throws Exception {
+
+    ApiClient client = Config.defaultClient();
+
+    Configuration.setDefaultApiClient(client);
+
+    CoreV1Api coreV1Api = new CoreV1Api(client);
+
+    CallGenerator<PagerCallGeneratorParams> callGenerator =
+        params ->
+            coreV1Api.listNodeCall(
+                null,
+                null,
+                params.getContinueToken(),
+                null,
+                null,
+                params.getLimit(),
+                params.resourceVersion,
+                params.timeoutSeconds,
+                params.watch,
+                null);
+
+    PageSharedInformerFactory factory = new PageSharedInformerFactory();
+
+    SharedIndexInformer<V1Node> nodeInformer =
+        factory.sharedIndexInformerFor(callGenerator, V1Node.class, V1NodeList.class);
+
+    nodeInformer.addEventHandler(RESOURCE_EVENT_HANDLER);
+
+    factory.startAllRegisteredInformers();
+
+    while (!nodeInformer.hasSynced()) {
+      TimeUnit.SECONDS.sleep(1);
+    }
+
+    System.out.println(nodeInformer.getIndexer().size());
+  }
+}

--- a/examples/src/main/java/io/kubernetes/client/examples/SimpleFieldFilterPageInformerExample.java
+++ b/examples/src/main/java/io/kubernetes/client/examples/SimpleFieldFilterPageInformerExample.java
@@ -1,0 +1,99 @@
+package io.kubernetes.client.examples;
+
+import com.google.common.collect.Lists;
+import io.kubernetes.client.extended.informer.FilterField;
+import io.kubernetes.client.extended.informer.PageSharedInformerFactory;
+import io.kubernetes.client.extended.informer.PagerCallGeneratorParams;
+import io.kubernetes.client.extended.informer.SerializeFilterJSON;
+import io.kubernetes.client.informer.ResourceEventHandler;
+import io.kubernetes.client.informer.SharedIndexInformer;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.Configuration;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1Node;
+import io.kubernetes.client.openapi.models.V1NodeList;
+import io.kubernetes.client.openapi.models.V1NodeStatus;
+import io.kubernetes.client.util.CallGenerator;
+import io.kubernetes.client.util.Config;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.collections4.CollectionUtils;
+
+public class SimpleFieldFilterPageInformerExample {
+
+  private static final ResourceEventHandler<V1Node> RESOURCE_EVENT_HANDLER =
+      new ResourceEventHandler<V1Node>() {
+
+        @Override
+        public void onAdd(V1Node node) {
+
+          assert CollectionUtils.isEmpty(node.getStatus().getImages());
+
+          System.out.printf("%s node added!\n", node.getMetadata().getName());
+        }
+
+        @Override
+        public void onUpdate(V1Node oldNode, V1Node newNode) {
+
+          assert CollectionUtils.isEmpty(oldNode.getStatus().getImages());
+
+          assert CollectionUtils.isEmpty(newNode.getStatus().getImages());
+
+          System.out.printf(
+              "%s => %s node updated!\n",
+              oldNode.getMetadata().getName(), newNode.getMetadata().getName());
+        }
+
+        @Override
+        public void onDelete(V1Node node, boolean deletedFinalStateUnknown) {
+
+          assert CollectionUtils.isEmpty(node.getStatus().getImages());
+
+          System.out.printf("%s node deleted!\n", node.getMetadata().getName());
+        }
+      };
+
+  public static void main(String[] args) throws Exception {
+
+    ApiClient client = Config.defaultClient();
+
+    Configuration.setDefaultApiClient(client);
+
+    CoreV1Api coreV1Api = new CoreV1Api(client);
+
+    CallGenerator<PagerCallGeneratorParams> callGenerator =
+        params ->
+            coreV1Api.listNodeCall(
+                null,
+                null,
+                params.getContinueToken(),
+                null,
+                null,
+                params.getLimit(),
+                params.resourceVersion,
+                params.timeoutSeconds,
+                params.watch,
+                null);
+
+    List<FilterField> filterFields =
+        Lists.newArrayList(
+            new FilterField().setSerializedName("images").setDeclaringClass(V1NodeStatus.class));
+
+    client.setJSON(new SerializeFilterJSON(filterFields));
+
+    PageSharedInformerFactory factory = new PageSharedInformerFactory();
+
+    SharedIndexInformer<V1Node> nodeInformer =
+        factory.sharedIndexInformerFor(callGenerator, V1Node.class, V1NodeList.class);
+
+    nodeInformer.addEventHandler(RESOURCE_EVENT_HANDLER);
+
+    factory.startAllRegisteredInformers();
+
+    while (!nodeInformer.hasSynced()) {
+      TimeUnit.SECONDS.sleep(1);
+    }
+
+    System.out.println(nodeInformer.getIndexer().size());
+  }
+}

--- a/extended/pom.xml
+++ b/extended/pom.xml
@@ -42,6 +42,12 @@
             <artifactId>bucket4j-core</artifactId>
             <version>${bucket4jVersion}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>${commons-collections4.version}</version>
+        </dependency>
+
         <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>
@@ -67,15 +73,25 @@
             <version>2.19.0</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-            <scope>test</scope>
-        </dependency>
+
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <configuration>
+                    <attach>true</attach>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
@@ -136,10 +152,14 @@
         </plugins>
     </build>
     <properties>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
         <java.version>1.7</java.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
         <slf4jVersion>1.7.7</slf4jVersion>
         <bucket4jVersion>4.4.1</bucket4jVersion>
+        <commons-collections4.version>4.1</commons-collections4.version>
     </properties>
 </project>

--- a/extended/pom.xml
+++ b/extended/pom.xml
@@ -152,9 +152,9 @@
         </plugins>
     </build>
     <properties>
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <maven.compiler.source>1.7</maven.compiler.source>
         <java.version>1.7</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/extended/src/main/java/io/kubernetes/client/extended/informer/FilterField.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/informer/FilterField.java
@@ -1,0 +1,49 @@
+package io.kubernetes.client.extended.informer;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class FilterField {
+
+  private String name;
+
+  private Class<?> declaringClass;
+
+  private String serializedName;
+
+  public FilterField setName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public FilterField setDeclaringClass(Class<?> declaringClass) {
+    this.declaringClass = declaringClass;
+    return this;
+  }
+
+  public FilterField setSerializedName(String serializedName) {
+    this.serializedName = serializedName;
+    return this;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Class<?> getDeclaringClass() {
+    return declaringClass;
+  }
+
+  public String getSerializedName() {
+    return serializedName;
+  }
+
+  public boolean isNotEmpty() {
+    return StringUtils.isNotEmpty(name)
+        || declaringClass != null
+        || StringUtils.isNotEmpty(serializedName);
+  }
+
+  public boolean isEmpty() {
+    return !isNotEmpty();
+  }
+}

--- a/extended/src/main/java/io/kubernetes/client/extended/informer/FilterField.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/informer/FilterField.java
@@ -5,9 +5,7 @@ import org.apache.commons.lang3.StringUtils;
 public class FilterField {
 
   private String name;
-
   private Class<?> declaringClass;
-
   private String serializedName;
 
   public FilterField setName(String name) {

--- a/extended/src/main/java/io/kubernetes/client/extended/informer/PageSharedInformerFactory.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/informer/PageSharedInformerFactory.java
@@ -1,0 +1,118 @@
+package io.kubernetes.client.extended.informer;
+
+import com.google.common.collect.Lists;
+import com.google.gson.reflect.TypeToken;
+import io.kubernetes.client.extended.pager.Pager;
+import io.kubernetes.client.extended.pager.Pager.PagerParams;
+import io.kubernetes.client.informer.ListerWatcher;
+import io.kubernetes.client.informer.SharedInformerFactory;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.util.CallGenerator;
+import io.kubernetes.client.util.CallGeneratorParams;
+import io.kubernetes.client.util.Watch;
+import io.kubernetes.client.util.exception.ObjectMetaReflectException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** informer list request support pagination like client-go(default limit 500). */
+public class PageSharedInformerFactory extends SharedInformerFactory {
+
+  private static final Logger log = LoggerFactory.getLogger(PageSharedInformerFactory.class);
+
+  public PageSharedInformerFactory() {
+    super();
+  }
+
+  public PageSharedInformerFactory(ApiClient apiClient) {
+    super(apiClient);
+  }
+
+  public PageSharedInformerFactory(ApiClient client, ExecutorService threadPool) {
+    super(client, threadPool);
+  }
+
+  protected <ApiType, ApiListType> ListerWatcher<ApiType, ApiListType> listerWatcherFor(
+      final CallGenerator callGenerator,
+      final Class<ApiType> apiTypeClass,
+      final Class<ApiListType> apiListTypeClass) {
+
+    if (apiClient.getHttpClient().readTimeoutMillis() > 0) {
+      // set read timeout zero to ensure client doesn't time out
+      OkHttpClient httpClient =
+          apiClient.getHttpClient().newBuilder().readTimeout(0, TimeUnit.MILLISECONDS).build();
+      apiClient.setHttpClient(httpClient);
+    }
+
+    return new ListerWatcher<ApiType, ApiListType>() {
+
+      @Override
+      public ApiListType list(CallGeneratorParams callGeneratorParams) {
+
+        PagerCallGeneratorParams params = PagerCallGeneratorParams.to(callGeneratorParams);
+
+        Type type = com.google.common.reflect.TypeToken.of(apiListTypeClass).getType();
+
+        Function<PagerParams, Call> listFunc =
+            pagerParams -> {
+              PagerCallGeneratorParams copy = PagerCallGeneratorParams.copy(params, pagerParams);
+              log.info(
+                  "list param:[type: {} , resourceVersion: {} , continue: {} , limit: {}] ",
+                  type.getTypeName(),
+                  copy.resourceVersion,
+                  copy.getContinueToken(),
+                  copy.getLimit());
+              try {
+                return callGenerator.generate(copy);
+              } catch (ApiException e) {
+                throw new RuntimeException(e);
+              }
+            };
+
+        Pager<ApiType, ApiListType> pager =
+            new Pager<>(listFunc, apiClient, params.getDefaultLimit(), type);
+
+        List<ApiType> list = Lists.newArrayList(pager);
+
+        log.info("list items: [type: {} , total count: {}]", type.getTypeName(), list.size());
+
+        try {
+          setItems(pager.getListObjectCurrentPage(), list);
+        } catch (ObjectMetaReflectException e) {
+          throw new RuntimeException(e);
+        }
+
+        return pager.getListObjectCurrentPage();
+      }
+
+      @Override
+      public Watch<ApiType> watch(CallGeneratorParams callGeneratorParams) throws ApiException {
+
+        Call call = callGenerator.generate(PagerCallGeneratorParams.to(callGeneratorParams));
+
+        Type watchType = TypeToken.getParameterized(Watch.Response.class, apiTypeClass).getType();
+
+        return Watch.createWatch(apiClient, call, watchType);
+      }
+    };
+  }
+
+  private static <ApiType, ApiListType> void setItems(ApiListType listObj, List<ApiType> list)
+      throws ObjectMetaReflectException {
+    try {
+      Method setItemsMethod = listObj.getClass().getMethod("setItems", List.class);
+      setItemsMethod.invoke(listObj, list);
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      throw new ObjectMetaReflectException(e);
+    }
+  }
+}

--- a/extended/src/main/java/io/kubernetes/client/extended/informer/PagerCallGeneratorParams.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/informer/PagerCallGeneratorParams.java
@@ -1,0 +1,53 @@
+package io.kubernetes.client.extended.informer;
+
+import io.kubernetes.client.extended.pager.Pager;
+import io.kubernetes.client.util.CallGeneratorParams;
+
+/** page params */
+public class PagerCallGeneratorParams extends CallGeneratorParams {
+
+  private static final int DEFAULT_PAGE_SIZE = 500;
+
+  private Pager.PagerParams pagerParams;
+
+  public PagerCallGeneratorParams(Boolean watch, String resourceVersion, Integer timeoutSeconds) {
+    super(watch, resourceVersion, timeoutSeconds);
+  }
+
+  public PagerCallGeneratorParams(
+      Boolean watch,
+      String resourceVersion,
+      Integer timeoutSeconds,
+      Pager.PagerParams pagerParams) {
+    this(watch, resourceVersion, timeoutSeconds);
+    this.pagerParams = pagerParams;
+  }
+
+  public static PagerCallGeneratorParams to(CallGeneratorParams params) {
+    return new PagerCallGeneratorParams(
+        params.watch, params.resourceVersion, params.timeoutSeconds);
+  }
+
+  public static PagerCallGeneratorParams copy(
+      CallGeneratorParams params, Pager.PagerParams pagerParams) {
+
+    return new PagerCallGeneratorParams(
+        params.watch, params.resourceVersion, params.timeoutSeconds, pagerParams);
+  }
+
+  public Pager.PagerParams getPagerParams() {
+    return pagerParams;
+  }
+
+  public Integer getLimit() {
+    return getPagerParams() == null ? null : getPagerParams().getLimit();
+  }
+
+  public String getContinueToken() {
+    return getPagerParams() == null ? null : getPagerParams().getContinueToken();
+  }
+
+  public int getDefaultLimit() {
+    return DEFAULT_PAGE_SIZE;
+  }
+}

--- a/extended/src/main/java/io/kubernetes/client/extended/informer/SerializeFilterJSON.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/informer/SerializeFilterJSON.java
@@ -1,0 +1,143 @@
+package io.kubernetes.client.extended.informer;
+
+import static java.util.stream.Collectors.toList;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
+import io.kubernetes.client.openapi.JSON;
+import java.lang.reflect.Type;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiPredicate;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+
+/**
+ * enhance default JSON，which serialize list/watch objects，SerializeFilterJSON enhance common object
+ * fields unserialize capability which customer use FilterField definition。
+ */
+public class SerializeFilterJSON extends JSON {
+
+  private List<FilterField> filterFields;
+
+  private final Map<Type, Object> typeAdapterMap =
+      ImmutableMap.of(
+          Date.class, new DateTypeAdapter(),
+          java.sql.Date.class, new SqlDateTypeAdapter(),
+          DateTime.class, new DateTimeTypeAdapter(),
+          LocalDate.class, new LocalDateTypeAdapter(),
+          byte[].class, new ByteArrayAdapter());
+
+  /** some with io.kubernetes.client.JSON */
+  public SerializeFilterJSON() {
+    this(Lists.newArrayList());
+  }
+
+  /**
+   * when serialize object, use filterFields to unserialize some object fields;
+   *
+   * @param filterFields
+   */
+  public SerializeFilterJSON(List<FilterField> filterFields) {
+
+    this.filterFields =
+        ListUtils.emptyIfNull(filterFields)
+            .stream()
+            .filter(FilterField::isNotEmpty)
+            .collect(toList());
+
+    GsonBuilder builder = new GsonBuilder();
+
+    getTypeAdapterMap().forEach(builder::registerTypeAdapter);
+
+    ExclusionStrategy strategy = getStrategy(getFilterFields());
+
+    if (strategy != null) {
+      builder.addDeserializationExclusionStrategy(strategy);
+    }
+
+    setGson(builder.create());
+  }
+
+  /**
+   * A customer definition strategy (use filterFields ) that is used to decide whether or not a
+   * field or top-level class should be serialized
+   *
+   * <p>like: new FilterField().setSerializedName("images").setDeclaringClass(V1NodeStatus.class)。
+   * should be unserialize V1NodeStatus object "images" field
+   *
+   * @param filterFields customer definition
+   * @return
+   */
+  private ExclusionStrategy getStrategy(List<FilterField> filterFields) {
+
+    if (CollectionUtils.isEmpty(filterFields)) {
+      return null;
+    }
+
+    return new ExclusionStrategy() {
+
+      @Override
+      public boolean shouldSkipField(FieldAttributes f) {
+
+        SerializedName serialized = f.getAnnotation(SerializedName.class);
+
+        FilterField filterField =
+            new FilterField()
+                .setName(f.getName())
+                .setDeclaringClass(f.getDeclaringClass())
+                .setSerializedName(serialized != null ? serialized.value() : null);
+
+        return filterFields
+                .stream()
+                .filter(ff -> MATCH_PREDICATE.test(ff, filterField))
+                .findFirst()
+                .orElse(null)
+            != null;
+      }
+
+      @Override
+      public boolean shouldSkipClass(Class<?> clazz) {
+        return false;
+      }
+    };
+  }
+
+  /** check customer definition */
+  private static final BiPredicate<FilterField, FilterField> MATCH_PREDICATE =
+      (customer, system) -> {
+        if (customer.isEmpty()) { // double check
+          return false;
+        }
+
+        boolean isSameName =
+            StringUtils.isEmpty(customer.getName())
+                || StringUtils.equals(customer.getName(), system.getName());
+
+        boolean isSameDeclaringClass =
+            customer.getDeclaringClass() == null
+                || customer.getDeclaringClass().equals(system.getDeclaringClass());
+
+        boolean isSameSerializedName =
+            StringUtils.isEmpty(customer.getSerializedName())
+                || StringUtils.equals(customer.getSerializedName(), system.getSerializedName());
+
+        return isSameName && isSameDeclaringClass && isSameSerializedName;
+      };
+
+  public Map<Type, Object> getTypeAdapterMap() {
+    return typeAdapterMap;
+  }
+
+  public List<FilterField> getFilterFields() {
+    return filterFields;
+  }
+}

--- a/extended/src/main/java/io/kubernetes/client/extended/pager/Pager.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/pager/Pager.java
@@ -34,6 +34,10 @@ public class Pager<ApiType, ApiListType> implements Iterable<ApiType> {
 
   private ApiListType listObjectCurrentPage;
 
+  public ApiListType getListObjectCurrentPage() {
+    return listObjectCurrentPage;
+  }
+
   /**
    * Pagination in kubernetes list call depends on continue and limit variable
    *

--- a/extended/src/test/java/io/kubernetes/client/extended/informer/PageSharedInformerFactoryTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/informer/PageSharedInformerFactoryTest.java
@@ -1,0 +1,87 @@
+package io.kubernetes.client.extended.informer;
+
+import com.google.common.collect.Lists;
+import io.kubernetes.client.informer.SharedIndexInformer;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.Configuration;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1Namespace;
+import io.kubernetes.client.openapi.models.V1NamespaceList;
+import io.kubernetes.client.openapi.models.V1Node;
+import io.kubernetes.client.openapi.models.V1NodeList;
+import io.kubernetes.client.openapi.models.V1NodeStatus;
+import io.kubernetes.client.util.CallGenerator;
+import io.kubernetes.client.util.Config;
+import java.io.IOException;
+import java.util.List;
+import org.junit.Test;
+
+public class PageSharedInformerFactoryTest {
+
+  @Test
+  public void shutdownPageInformerFactoryInstantlyAfterStarting() {
+
+    CoreV1Api api = new CoreV1Api();
+
+    PageSharedInformerFactory factory = new PageSharedInformerFactory();
+
+    CallGenerator<PagerCallGeneratorParams> callGenerator =
+        params ->
+            api.listNamespaceCall(
+                null,
+                null,
+                params.getContinueToken(),
+                null,
+                null,
+                params.getLimit(),
+                params.resourceVersion,
+                params.timeoutSeconds,
+                params.watch,
+                null);
+
+    factory.sharedIndexInformerFor(callGenerator, V1Namespace.class, V1NamespaceList.class);
+
+    factory.startAllRegisteredInformers();
+
+    factory.stopAllRegisteredInformers();
+  }
+
+  @Test
+  public void shutdownFieldFilterPageInformerFactoryInstantlyAfterStarting() throws IOException {
+
+    ApiClient client = Config.defaultClient();
+
+    Configuration.setDefaultApiClient(client);
+
+    CoreV1Api coreV1Api = new CoreV1Api(client);
+
+    CallGenerator<PagerCallGeneratorParams> callGenerator =
+        params ->
+            coreV1Api.listNodeCall(
+                null,
+                null,
+                params.getContinueToken(),
+                null,
+                null,
+                params.getLimit(),
+                params.resourceVersion,
+                params.timeoutSeconds,
+                params.watch,
+                null);
+
+    List<FilterField> filterFields =
+        Lists.newArrayList(
+            new FilterField().setSerializedName("images").setDeclaringClass(V1NodeStatus.class));
+
+    client.setJSON(new SerializeFilterJSON(filterFields));
+
+    PageSharedInformerFactory factory = new PageSharedInformerFactory();
+
+    SharedIndexInformer<V1Node> nodeInformer =
+        factory.sharedIndexInformerFor(callGenerator, V1Node.class, V1NodeList.class);
+
+    factory.startAllRegisteredInformers();
+
+    factory.stopAllRegisteredInformers();
+  }
+}

--- a/kubernetes/src/main/java/io/kubernetes/client/openapi/GzipRequestInterceptor.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/openapi/GzipRequestInterceptor.java
@@ -26,7 +26,7 @@ import java.io.IOException;
  *
  * Taken from https://github.com/square/okhttp/issues/350
  */
-class GzipRequestInterceptor implements Interceptor {
+public class GzipRequestInterceptor implements Interceptor {
     @Override
     public Response intercept(Chain chain) throws IOException {
         Request originalRequest = chain.request();

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -110,6 +110,20 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <configuration>
+                    <attach>true</attach>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.2</version>

--- a/util/src/main/java/io/kubernetes/client/informer/SharedInformerFactory.java
+++ b/util/src/main/java/io/kubernetes/client/informer/SharedInformerFactory.java
@@ -1,7 +1,6 @@
 package io.kubernetes.client.informer;
 
 import com.google.gson.reflect.TypeToken;
-import io.kubernetes.client.*;
 import io.kubernetes.client.informer.impl.DefaultSharedIndexInformer;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
@@ -29,7 +28,7 @@ public class SharedInformerFactory {
 
   private ExecutorService informerExecutor;
 
-  private ApiClient apiClient;
+  protected ApiClient apiClient;
 
   /** Constructor w/ default thread pool. */
   public SharedInformerFactory() {
@@ -124,7 +123,7 @@ public class SharedInformerFactory {
     return informer;
   }
 
-  private <ApiType, ApiListType> ListerWatcher<ApiType, ApiListType> listerWatcherFor(
+  protected <ApiType, ApiListType> ListerWatcher<ApiType, ApiListType> listerWatcherFor(
       CallGenerator callGenerator,
       Class<ApiType> apiTypeClass,
       Class<ApiListType> apiListTypeClass) {

--- a/util/src/main/java/io/kubernetes/client/informer/cache/Cache.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/Cache.java
@@ -210,6 +210,21 @@ public class Cache<ApiType> implements Indexer<ApiType> {
   }
 
   /**
+   * size of all objects in the cache.
+   *
+   * @return the list size
+   */
+  @Override
+  public int size() {
+    lock.lock();
+    try {
+      return this.items.size();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /**
    * Gets get by key.
    *
    * @param key the key

--- a/util/src/main/java/io/kubernetes/client/informer/cache/DeltaFIFO.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/DeltaFIFO.java
@@ -292,6 +292,21 @@ public class DeltaFIFO<ApiType> implements Store<Object> {
   }
 
   /**
+   * size of list.
+   *
+   * @return the list size
+   */
+  @Override
+  public int size() {
+    lock.readLock().lock();
+    try {
+      return items.size();
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  /**
    * Pop deltas.
    *
    * @param func the func

--- a/util/src/main/java/io/kubernetes/client/informer/cache/Store.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/Store.java
@@ -65,4 +65,11 @@ public interface Store<ApiType> {
    * @return list of all the items
    */
   List<ApiType> list();
+
+  /**
+   * size of all objects in the cache.
+   *
+   * @return the list size
+   */
+  int size();
 }

--- a/util/src/main/java/io/kubernetes/client/util/CallGenerator.java
+++ b/util/src/main/java/io/kubernetes/client/util/CallGenerator.java
@@ -13,7 +13,7 @@ import okhttp3.Call;
  * params.resourceVersion, params.timeoutSeconds, params.watch, null, null); },
  */
 @FunctionalInterface
-public interface CallGenerator {
+public interface CallGenerator<T extends CallGeneratorParams> {
   /**
    * Generate call.
    *
@@ -21,5 +21,5 @@ public interface CallGenerator {
    * @return the call
    * @throws ApiException the api exception
    */
-  Call generate(CallGeneratorParams params) throws ApiException;
+  Call generate(T params) throws ApiException;
 }


### PR DESCRIPTION
1. informer list request support pagination like client-go(default limit 500).  

    eg: PageInformerExample.java

    fix issue : https://github.com/kubernetes-client/java/issues/628

2. informer local-cache filter resource fields which customer definition，to ease server-side JVM memory usage，avoid oom.

    eg: FieldFilterPageInformerExample.java

