### PR TITLE
V1PatchAdapter should be declared static

### DIFF
--- a/kubernetes/src/main/java/io/kubernetes/client/custom/V1Patch.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/custom/V1Patch.java
@@ -26,7 +26,7 @@ public class V1Patch {
     return value;
   }
 
-  public class V1PatchAdapter extends TypeAdapter<V1Patch> {
+  public static class V1PatchAdapter extends TypeAdapter<V1Patch> {
     @Override
     public void write(JsonWriter jsonWriter, V1Patch patch) throws IOException {
       jsonWriter.jsonValue(patch.getValue());


### PR DESCRIPTION
Fixes #832 

This is a mirror of PR #810, which addressed a similar issue (#809) In the QuanittyAdapter. I missed that the same issue affected V1PatchAdapter as well. This applies the same fix and was verified with a modified version of the test program from #809. I grepped for any other instances of "extends TypeAdapter" without the static declaration and found none in the client code (there are some in the OpenAPI generated files types not used by Kubernetes AFAICT, which would have to be addressed upstream).

Build and test results:

```[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Kubernetes Client API 8.0.1-SNAPSHOT:
[INFO] 
[INFO] Kubernetes Client API .............................. SUCCESS [  0.123 s]
[INFO] client-java-api .................................... SUCCESS [02:18 min]
[INFO] client-java-proto .................................. SUCCESS [ 25.848 s]
[INFO] client-java ........................................ SUCCESS [03:38 min]
[INFO] client-java-extended ............................... SUCCESS [01:58 min]
[INFO] client-java-examples ............................... SUCCESS [ 10.886 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  08:33 min
[INFO] Finished at: 2019-12-13T10:51:52-05:00
[INFO] ------------------------------------------------------------------------
```