### PR TITLE
Implement DefaultSharedIndexInformer#addIndexers

### DIFF
--- a/util/src/main/java/io/kubernetes/client/informer/cache/Cache.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/Cache.java
@@ -320,6 +320,38 @@ public class Cache<ApiType> implements Indexer<ApiType> {
   }
 
   /**
+   * Return the indexers registered with the cache.
+   *
+   * @return registered indexers
+   */
+  @Override
+  public Map<String, Function<ApiType, List<String>>> getIndexers() {
+    return indexers;
+  }
+
+  /**
+   * Add additional indexers to the cache.
+   *
+   * @param newIndexers indexers to add
+   */
+  @Override
+  public void addIndexers(Map<String, Function<ApiType, List<String>>> newIndexers) {
+    if (!items.isEmpty()) {
+      throw new IllegalStateException("cannot add indexers to a non-empty cache");
+    }
+    Set<String> oldKeys = indexers.keySet();
+    Set<String> newKeys = newIndexers.keySet();
+    Set<String> intersection = new HashSet<>(oldKeys);
+    intersection.retainAll(newKeys);
+    if (!intersection.isEmpty()) {
+      throw new IllegalArgumentException("indexer conflict: " + intersection);
+    }
+    for (Map.Entry<String, Function<ApiType, List<String>>> indexEntry : newIndexers.entrySet()) {
+      addIndexFunc(indexEntry.getKey(), indexEntry.getValue());
+    }
+  }
+
+  /**
    * updateIndices modifies the objects location in the managed indexes, if this is an update, you
    * must provide an oldObj.
    *
@@ -381,13 +413,8 @@ public class Cache<ApiType> implements Indexer<ApiType> {
     }
   }
 
-  /**
-   * Add index func.
-   *
-   * @param indexName the index name
-   * @param indexFunc the index func
-   */
-  public void addIndexFunc(String indexName, Function<ApiType, List<String>> indexFunc) {
+  /** Protected for testing. */
+  protected void addIndexFunc(String indexName, Function<ApiType, List<String>> indexFunc) {
     this.indices.put(indexName, new HashMap<>());
     this.indexers.put(indexName, indexFunc);
   }

--- a/util/src/main/java/io/kubernetes/client/informer/cache/Cache.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/Cache.java
@@ -413,8 +413,13 @@ public class Cache<ApiType> implements Indexer<ApiType> {
     }
   }
 
-  /** Protected for testing. */
-  protected void addIndexFunc(String indexName, Function<ApiType, List<String>> indexFunc) {
+  /**
+   * Add index func.
+   *
+   * @param indexName the index name
+   * @param indexFunc the index func
+   */
+  public void addIndexFunc(String indexName, Function<ApiType, List<String>> indexFunc) {
     this.indices.put(indexName, new HashMap<>());
     this.indexers.put(indexName, indexFunc);
   }

--- a/util/src/main/java/io/kubernetes/client/informer/cache/Indexer.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/Indexer.java
@@ -1,6 +1,8 @@
 package io.kubernetes.client.informer.cache;
 
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 
 /** Indexer extends Store interface and adds index/de-index methods. */
 public interface Indexer<ApiType> extends Store<ApiType> {
@@ -30,4 +32,18 @@ public interface Indexer<ApiType> extends Store<ApiType> {
    * @return matched objects
    */
   List<ApiType> byIndex(String indexName, String indexKey);
+
+  /**
+   * Return the indexers registered with the store.
+   *
+   * @return registered indexers
+   */
+  Map<String, Function<ApiType, List<String>>> getIndexers();
+
+  /**
+   * Add additional indexers to the store.
+   *
+   * @param indexers indexers to add
+   */
+  void addIndexers(Map<String, Function<ApiType, List<String>>> indexers);
 }

--- a/util/src/main/java/io/kubernetes/client/informer/impl/DefaultSharedIndexInformer.java
+++ b/util/src/main/java/io/kubernetes/client/informer/impl/DefaultSharedIndexInformer.java
@@ -12,6 +12,7 @@ import io.kubernetes.client.informer.cache.SharedProcessor;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.slf4j.Logger;
@@ -223,8 +224,11 @@ public class DefaultSharedIndexInformer<ApiType, ApiListType>
   }
 
   @Override
-  public void addIndexers(Map indexers) {
-    throw new RuntimeException("unimplemented!");
+  public void addIndexers(Map<String, Function<ApiType, List<String>>> indexers) {
+    if (started) {
+      throw new IllegalStateException("cannot add indexers to a running informer");
+    }
+    indexer.addIndexers(indexers);
   }
 
   @Override


### PR DESCRIPTION
Implements `addIndexers` by modifying the `Indexer` interface to match `client-go`.  The semantics of `addIndexers` remains consistent with `client-go` as well.

References:
1) https://github.com/kubernetes/client-go/blob/master/tools/cache/shared_informer.go#L362
2) https://github.com/kubernetes/client-go/blob/master/tools/cache/index.go#L48
3) https://github.com/kubernetes/client-go/blob/master/tools/cache/thread_safe_store.go#L228