### PR TITLE
Builder-modes for attach() and exec()

### DIFF
--- a/util/src/main/java/io/kubernetes/client/Attach.java
+++ b/util/src/main/java/io/kubernetes/client/Attach.java
@@ -57,18 +57,14 @@ public class Attach {
     this.apiClient = apiClient;
   }
 
-  private String makePath(
-      String namespace, String name, String container, boolean stdin, boolean tty) {
-    return "/api/v1/namespaces/"
-        + namespace
-        + "/pods/"
-        + name
-        + "/attach?"
-        + "stdin="
-        + stdin
-        + "&tty="
-        + tty
-        + (container != null ? "&container=" + container : "");
+  /**
+   * Setup a Builder for the given namespace and name
+   *
+   * @param namespace The namespace of the Pod
+   * @param name The name of the Pod
+   */
+  public ConnectionBuilder newConnectionBuilder(String namespace, String name) {
+    return new ConnectionBuilder(namespace, name);
   }
 
   /**
@@ -136,13 +132,107 @@ public class Attach {
   public AttachResult attach(
       String namespace, String name, String container, boolean stdin, boolean tty)
       throws ApiException, IOException {
-    String path = makePath(namespace, name, container, stdin, tty);
+    return newConnectionBuilder(namespace, name)
+        .setContainer(container)
+        .setStdin(stdin)
+        .setTty(tty)
+        .connect();
+  }
 
-    WebSocketStreamHandler handler = new WebSocketStreamHandler();
-    AttachResult result = new AttachResult(handler);
-    WebSockets.stream(path, "GET", apiClient, handler);
+  public final class ConnectionBuilder {
+    private final String namespace;
+    private final String name;
 
-    return result;
+    private String container;
+
+    private boolean stdin;
+    private boolean stdout;
+    private boolean stderr;
+    private boolean tty;
+
+    private ConnectionBuilder(String namespace, String name) {
+      this.namespace = namespace;
+      this.name = name;
+      this.stdin = true;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getNamespace() {
+      return namespace;
+    }
+
+    public String getContainer() {
+      return container;
+    }
+
+    public ConnectionBuilder setContainer(String container) {
+      this.container = container;
+      return this;
+    }
+
+    public boolean getStdin() {
+      return stdin;
+    }
+
+    public ConnectionBuilder setStdin(boolean stdin) {
+      this.stdin = stdin;
+      return this;
+    }
+
+    public boolean getStdout() {
+      return stdout;
+    }
+
+    public ConnectionBuilder setStdout(boolean stdout) {
+      this.stdout = stdout;
+      return this;
+    }
+
+    public boolean getStderr() {
+      return stderr;
+    }
+
+    public ConnectionBuilder setStderr(boolean stderr) {
+      this.stderr = stderr;
+      return this;
+    }
+
+    public boolean getTty() {
+      return tty;
+    }
+
+    public ConnectionBuilder setTty(boolean tty) {
+      this.tty = tty;
+      return this;
+    }
+
+    private String makePath() {
+      return "/api/v1/namespaces/"
+          + namespace
+          + "/pods/"
+          + name
+          + "/attach?"
+          + "stdin="
+          + stdin
+          + "&stdout="
+          + stdout
+          + "&stderr="
+          + stderr
+          + "&tty="
+          + tty
+          + (container != null ? "&container=" + container : "");
+    }
+
+    public AttachResult connect() throws ApiException, IOException {
+      WebSocketStreamHandler handler = new WebSocketStreamHandler();
+      AttachResult result = new AttachResult(handler);
+      WebSockets.stream(makePath(), "GET", apiClient, handler);
+
+      return result;
+    }
   }
 
   /**

--- a/util/src/test/java/io/kubernetes/client/AttachTest.java
+++ b/util/src/test/java/io/kubernetes/client/AttachTest.java
@@ -64,6 +64,13 @@ public class AttachTest {
 
     AttachResult res1 = attach.attach(namespace, podName, container, false, false);
     AttachResult res2 = attach.attach(namespace, podName, true);
+    AttachResult res3 =
+        attach
+            .newConnectionBuilder(namespace, podName)
+            .setContainer(container)
+            .setStdin(false)
+            .setStdout(true)
+            .connect();
 
     // TODO: Kill this sleep, the trouble is that the test tries to validate before the connection
     // event has happened
@@ -71,11 +78,14 @@ public class AttachTest {
 
     res1.close();
     res2.close();
+    res3.close();
 
     verify(
         getRequestedFor(
                 urlPathEqualTo("/api/v1/namespaces/" + namespace + "/pods/" + podName + "/attach"))
             .withQueryParam("stdin", equalTo("false"))
+            .withQueryParam("stdout", equalTo("false"))
+            .withQueryParam("stderr", equalTo("false"))
             .withQueryParam("tty", equalTo("false"))
             .withQueryParam("container", equalTo(container)));
 
@@ -83,6 +93,17 @@ public class AttachTest {
         getRequestedFor(
                 urlPathEqualTo("/api/v1/namespaces/" + namespace + "/pods/" + podName + "/attach"))
             .withQueryParam("stdin", equalTo("true"))
+            .withQueryParam("stdout", equalTo("false"))
+            .withQueryParam("stderr", equalTo("false"))
             .withQueryParam("tty", equalTo("false")));
+
+    verify(
+        getRequestedFor(
+                urlPathEqualTo("/api/v1/namespaces/" + namespace + "/pods/" + podName + "/attach"))
+            .withQueryParam("stdin", equalTo("false"))
+            .withQueryParam("stdout", equalTo("true"))
+            .withQueryParam("stderr", equalTo("false"))
+            .withQueryParam("tty", equalTo("false"))
+            .withQueryParam("container", equalTo(container)));
   }
 }

--- a/util/src/test/java/io/kubernetes/client/ExecTest.java
+++ b/util/src/test/java/io/kubernetes/client/ExecTest.java
@@ -145,12 +145,30 @@ public class ExecTest {
     Process p = exec.exec(pod, cmd, "container", true, false);
     p.waitFor();
 
+    exec.newExecutionBuilder(pod.getMetadata().getNamespace(), pod.getMetadata().getName(), cmd)
+        .setContainer("container")
+        .setStdin(false)
+        .setStderr(false)
+        .execute()
+        .waitFor();
+
     verify(
         getRequestedFor(
                 urlPathEqualTo("/api/v1/namespaces/" + namespace + "/pods/" + podName + "/exec"))
             .withQueryParam("stdin", equalTo("true"))
             .withQueryParam("stdout", equalTo("true"))
             .withQueryParam("stderr", equalTo("true"))
+            .withQueryParam("container", equalTo("container"))
+            .withQueryParam("tty", equalTo("false"))
+            .withQueryParam("command", equalTo("cmd")));
+
+    verify(
+        getRequestedFor(
+                urlPathEqualTo("/api/v1/namespaces/" + namespace + "/pods/" + podName + "/exec"))
+            .withQueryParam("stdin", equalTo("false"))
+            .withQueryParam("stdout", equalTo("true"))
+            .withQueryParam("stderr", equalTo("false"))
+            .withQueryParam("container", equalTo("container"))
             .withQueryParam("tty", equalTo("false"))
             .withQueryParam("command", equalTo("cmd")));
 


### PR DESCRIPTION
Resolves #847.

The basic idea is to express options for Attach and Exec like:

```
attach
  .prepare(namespace, name)
  .setStdout(true)
  .setTty(true)
  .connect();
```