### PR TITLE
Update maven/gradle examples to 7.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add this dependency to your project's POM:
 <dependency>
     <groupId>io.kubernetes</groupId>
     <artifactId>client-java</artifactId>
-    <version>5.0.0</version>
+    <version>7.0.0</version>
     <scope>compile</scope>
 </dependency>
 ```
@@ -40,7 +40,7 @@ Add this dependency to your project's POM:
 ### Gradle users
 
 ```groovy
-compile 'io.kubernetes:client-java:5.0.0'
+compile 'io.kubernetes:client-java:7.0.0'
 ```
 
 ### Others


### PR DESCRIPTION
Update maven/gradle example dependencies to the latest release for the code samples to work.