### PR TITLE
Simplify usage of Bucket4j via using new API method consumeIgnoringRateLimits which was added in the version 4.8.0

### DIFF
--- a/extended/pom.xml
+++ b/extended/pom.xml
@@ -140,6 +140,6 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <slf4jVersion>1.7.7</slf4jVersion>
-        <bucket4jVersion>4.4.1</bucket4jVersion>
+        <bucket4jVersion>4.8.0</bucket4jVersion>
     </properties>
 </project>


### PR DESCRIPTION
Hello guys,

As the author of Bucket4j, I had done review the usage of my library in the kubernatess-client/java and me found that code can be reduced a lot if upgrade from ```4.4.1``` to ```4.8.0```.