### PR TITLE
Feat: Implementing resizable/error exec stream

### DIFF
--- a/util/src/main/java/io/kubernetes/client/Exec.java
+++ b/util/src/main/java/io/kubernetes/client/Exec.java
@@ -349,7 +349,7 @@ public class Exec {
     return -1;
   }
 
-  protected static class ExecProcess extends Process {
+  public static class ExecProcess extends Process {
     private final WebSocketStreamHandler streamHandler;
     private int statusCode = -1;
     private boolean isAlive = true;
@@ -423,6 +423,14 @@ public class Exec {
     @Override
     public InputStream getErrorStream() {
       return getInputStream(2);
+    }
+
+    public InputStream getConnectionErrorStream() {
+      return getInputStream(3);
+    }
+
+    public OutputStream getResizeStream() {
+      return streamHandler.getOutputStream(4);
     }
 
     private synchronized InputStream getInputStream(int stream) {


### PR DESCRIPTION
Kubelet is actually exposing a set of channels in the exec webconnection:

0. stdin
1. stdout
2. stderr
3. kubelet connection error
4. resizing 

this pull adds access for the last two channel

/cc @brendandburns 