### PR TITLE
Issue:#845, added 'null' string check to allow to pass null value in yaml files.

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/Yaml.java
+++ b/util/src/main/java/io/kubernetes/client/util/Yaml.java
@@ -350,6 +350,7 @@ public class Yaml {
     }
 
     private Object constructDateTime(ScalarNode node) {
+    	// Issue:#845.
     	if(node.getValue() == null || "null".equalsIgnoreCase(node.getValue())) {
     		return null;
     	}else {

--- a/util/src/main/java/io/kubernetes/client/util/Yaml.java
+++ b/util/src/main/java/io/kubernetes/client/util/Yaml.java
@@ -350,7 +350,11 @@ public class Yaml {
     }
 
     private Object constructDateTime(ScalarNode node) {
-      return new DateTime(((ScalarNode) node).getValue(), DateTimeZone.UTC);
+    	if(node.getValue() == null || "null".equalsIgnoreCase(node.getValue())) {
+    		return null;
+    	}else {
+    		return new DateTime(node.getValue(), DateTimeZone.UTC);
+    	}
     }
   }
 


### PR DESCRIPTION
null values are supported in the used snakeyaml(1.25) library.
The problematic code was this 
**new DateTime("null", DateTimeZone.UTC);** 
where "null" string was getting passed to the DateTime() constructor and hence throwing invalid date format exception.