### PR TITLE
Fix for non closure of input stream for Copy utility

### DIFF
--- a/examples/src/main/java/io/kubernetes/client/examples/ExecExample.java
+++ b/examples/src/main/java/io/kubernetes/client/examples/ExecExample.java
@@ -98,6 +98,19 @@ public class ExecExample {
             });
     out.start();
 
+    Thread error =
+        new Thread(
+            new Runnable() {
+              public void run() {
+                try {
+                  ByteStreams.copy(proc.getErrorStream(), System.err);
+                } catch (IOException ex) {
+                  ex.printStackTrace();
+                }
+              }
+            });
+    error.start();
+
     proc.waitFor();
 
     // wait for any last output; no need to wait for input thread

--- a/util/src/main/java/io/kubernetes/client/Copy.java
+++ b/util/src/main/java/io/kubernetes/client/Copy.java
@@ -150,14 +150,6 @@ public class Copy extends Exec {
         }
       }
     }
-    try {
-      int status = proc.waitFor();
-      if (status != 0) {
-        throw new IOException("Copy command failed with status " + status);
-      }
-    } catch (InterruptedException ex) {
-      throw new IOException(ex);
-    }
   }
 
   public static void copyFileFromPod(String namespace, String pod, String srcPath, Path dest)

--- a/util/src/main/java/io/kubernetes/client/Exec.java
+++ b/util/src/main/java/io/kubernetes/client/Exec.java
@@ -371,6 +371,8 @@ public class Exec {
                   }
                 }
                 inStream.close();
+                // The websocket needs to be closed.
+                this.close();
               } else super.handleMessage(stream, inStream);
             }
 

--- a/util/src/test/java/io/kubernetes/client/ExecTest.java
+++ b/util/src/test/java/io/kubernetes/client/ExecTest.java
@@ -109,13 +109,14 @@ public class ExecTest {
 
     process.getHandler().bytesMessage(makeStream(1, msgData.getBytes(StandardCharsets.UTF_8)));
     process.getHandler().bytesMessage(makeStream(2, errData.getBytes(StandardCharsets.UTF_8)));
-    process.getHandler().bytesMessage(makeStream(3, OUTPUT_EXIT0.getBytes(StandardCharsets.UTF_8)));
 
     final ByteArrayOutputStream stdout = new ByteArrayOutputStream();
     final ByteArrayOutputStream stderr = new ByteArrayOutputStream();
 
     Thread t1 = asyncCopy(process.getInputStream(), stdout);
     Thread t2 = asyncCopy(process.getErrorStream(), stderr);
+
+    process.getHandler().bytesMessage(makeStream(3, OUTPUT_EXIT0.getBytes(StandardCharsets.UTF_8)));
 
     // TODO: Fix this asap!
     Thread.sleep(1000);


### PR DESCRIPTION
Fix for Issues #861 and #908
Closing the exec process (or WebSocket) post receiving the exit message (i.e. when stream == 3). 