### PR TITLE
For Quantity class adding a no-arg constructor

### DIFF
--- a/kubernetes/src/main/java/io/kubernetes/client/custom/Quantity.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/custom/Quantity.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.ObjectUtils;
 @JsonAdapter(Quantity.QuantityAdapter.class)
 public class Quantity {
 
-  private final BigDecimal number;
+  private BigDecimal number;
   private Format format;
 
   public enum Format {
@@ -29,6 +29,9 @@ public class Quantity {
     public int getBase() {
       return base;
     }
+  }
+
+  public Quantity() {
   }
 
   public Quantity(final BigDecimal number, final Format format) {


### PR DESCRIPTION
I want to use reflection to parse the content in Yaml into the Quantity class, but I always get an error, so I want to add a parameterless constructor to this class

**demo.yaml**
```
limits:
  cpu:
    number: 0.005
    format: DECIMAL_SI
```
**DemoYaml.java**

```
package com.example.springdemo.utils;

import java.io.FileReader;

import com.esotericsoftware.yamlbeans.YamlReader;

import io.kubernetes.client.custom.Quantity;
import io.kubernetes.client.models.V1ResourceRequirements;


public class DemoYaml {
    public void transYaml() throws Exception{

        YamlReader reader = new YamlReader(new FileReader("demo.yaml"));
        V1ResourceRequirements demo = reader.read(V1ResourceRequirements.class);
        System.out.println(demo);
    }
    public static void main(String[] args) {

        Quantity x = new Quantity("5m");
        System.out.println(x);
        DemoYaml demoYaml = new DemoYaml();
        try {
            demoYaml.transYaml();
        } catch (Exception e) {
            e.printStackTrace();
        }

    }
}
```
**exception**

```
Caused by: java.lang.reflect.InvocationTargetException: Unable to find a no-arg constructor for class: io.kubernetes.client.custom.Quantity

```