### PR TITLE
Fixes generic kubernetes api patches

### DIFF
--- a/extended/src/main/java/io/kubernetes/client/extended/generic/GenericKubernetesApi.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/generic/GenericKubernetesApi.java
@@ -508,7 +508,8 @@ public class GenericKubernetesApi<ApiType, ApiListType> {
                         null);
                 return tweakCallForCoreV1Group(call);
               },
-              patchType);
+              patchType,
+              this.customObjectsApi.getApiClient());
       return new KubernetesApiResponse<ApiType>(object);
     } catch (ApiException e) {
       V1Status status =
@@ -673,6 +674,9 @@ public class GenericKubernetesApi<ApiType, ApiListType> {
         throw new IllegalStateException(e.getCause()); // make this a checked exception?
       }
       V1Status status = apiClient.getJSON().deserialize(e.getResponseBody(), V1Status.class);
+      if (null == status) { // the response body can be something unexpected sometimes..
+        throw new RuntimeException(e.getCause());
+      }
       return new KubernetesApiResponse<>(status, e.getCode());
     }
   }


### PR DESCRIPTION
1. fixes a bug that patch method on generic kubernetes api doesn't receive custom apicilent properly
2. fall-fast (throw a runtimeexception) on unrecognized exception.