### PR TITLE
Defaulting okhttp client protocols to HTTP1.1

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/ClientBuilder.java
+++ b/util/src/main/java/io/kubernetes/client/util/ClientBuilder.java
@@ -12,11 +12,7 @@ limitations under the License.
  */
 package io.kubernetes.client.util;
 
-import static io.kubernetes.client.util.Config.ENV_KUBECONFIG;
-import static io.kubernetes.client.util.Config.ENV_SERVICE_HOST;
-import static io.kubernetes.client.util.Config.ENV_SERVICE_PORT;
-import static io.kubernetes.client.util.Config.SERVICEACCOUNT_CA_PATH;
-import static io.kubernetes.client.util.Config.SERVICEACCOUNT_TOKEN_PATH;
+import static io.kubernetes.client.util.Config.*;
 import static io.kubernetes.client.util.KubeConfig.ENV_HOME;
 import static io.kubernetes.client.util.KubeConfig.KUBECONFIG;
 import static io.kubernetes.client.util.KubeConfig.KUBEDIR;
@@ -31,12 +27,15 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.Reader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import okhttp3.Protocol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -291,6 +290,10 @@ public class ClientBuilder {
 
   public ApiClient build() {
     final ApiClient client = new ApiClient();
+
+    // defaulting client protocols to HTTP1.1
+    client.setHttpClient(
+        client.getHttpClient().newBuilder().protocols(Arrays.asList(Protocol.HTTP_1_1)).build());
 
     if (basePath != null) {
       if (basePath.endsWith("/")) {


### PR DESCRIPTION
defaulting protocols in the client builder to HTTP1.1 otherwise when connecting latest kubernetes apiservers all the examples will fail w/ the following traces:

```
Exception in thread "main" io.kubernetes.client.openapi.ApiException: okhttp3.internal.http2.ConnectionShutdownException
	at io.kubernetes.client.openapi.ApiClient.execute(ApiClient.java:898)
	at io.kubernetes.client.openapi.apis.CoreV1Api.listPodForAllNamespacesWithHttpInfo(CoreV1Api.java:18981)
	at io.kubernetes.client.openapi.apis.CoreV1Api.listPodForAllNamespaces(CoreV1Api.java:18953)
	at io.kubernetes.client.examples.Example.main(Example.java:39)
Caused by: okhttp3.internal.http2.ConnectionShutdownException
	at okhttp3.internal.http2.Http2Connection.newStream(Http2Connection.java:242)
	at okhttp3.internal.http2.Http2Connection.newStream(Http2Connection.java:225)
	at okhttp3.internal.http2.Http2ExchangeCodec.writeRequestHeaders(Http2ExchangeCodec.java:116)
	at okhttp3.internal.connection.Exchange.writeRequestHeaders(Exchange.java:72)
	at okhttp3.internal.http.CallServerInterceptor.intercept(CallServerInterceptor.java:43)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117)
```
/cc @brendandburns 