### PR TITLE
Adding a check to test if Tar utility is present in the target container

### DIFF
--- a/examples/src/main/java/io/kubernetes/client/examples/CopyExample.java
+++ b/examples/src/main/java/io/kubernetes/client/examples/CopyExample.java
@@ -18,6 +18,7 @@ import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.Configuration;
 import io.kubernetes.client.util.Config;
+import io.kubernetes.client.util.exception.CopyNotSupportedException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Paths;
@@ -31,7 +32,8 @@ import java.nio.file.Paths;
  * <p>From inside $REPO_DIR/examples
  */
 public class CopyExample {
-  public static void main(String[] args) throws IOException, ApiException, InterruptedException {
+  public static void main(String[] args)
+      throws IOException, ApiException, InterruptedException, CopyNotSupportedException {
     String podName = "kube-addon-manager-minikube";
     String namespace = "kube-system";
 

--- a/util/src/main/java/io/kubernetes/client/Copy.java
+++ b/util/src/main/java/io/kubernetes/client/Copy.java
@@ -115,48 +115,51 @@ public class Copy extends Exec {
   public void copyDirectoryFromPod(
       String namespace, String pod, String container, String srcPath, Path destination)
       throws ApiException, IOException {
-    // TODO: Test that 'tar' is present in the container?
-    final Process proc =
-        this.exec(
-            namespace,
-            pod,
-            new String[] {"sh", "-c", "tar cz - " + srcPath + " | base64"},
-            container,
-            false,
-            false);
-    try (InputStream is = new Base64InputStream(new BufferedInputStream(proc.getInputStream()));
-        ArchiveInputStream archive = new TarArchiveInputStream(new GzipCompressorInputStream(is))) {
-      for (ArchiveEntry entry = archive.getNextEntry();
-          entry != null;
-          entry = archive.getNextEntry()) {
-        if (!archive.canReadEntryData(entry)) {
-          log.error("Can't read: " + entry);
-          continue;
-        }
-        File f = new File(destination.toFile(), entry.getName());
-        if (entry.isDirectory()) {
-          if (!f.isDirectory() && !f.mkdirs()) {
-            throw new IOException("create directory failed: " + f);
+    // Test that 'tar' is present in the container?
+    if (isTarPresentInContainer(namespace, pod, container)) {
+      final Process proc =
+          this.exec(
+              namespace,
+              pod,
+              new String[] {"sh", "-c", "tar cz - " + srcPath + " | base64"},
+              container,
+              false,
+              false);
+      try (InputStream is = new Base64InputStream(new BufferedInputStream(proc.getInputStream()));
+          ArchiveInputStream archive =
+              new TarArchiveInputStream(new GzipCompressorInputStream(is))) {
+        for (ArchiveEntry entry = archive.getNextEntry();
+            entry != null;
+            entry = archive.getNextEntry()) {
+          if (!archive.canReadEntryData(entry)) {
+            log.error("Can't read: " + entry);
+            continue;
           }
-        } else {
-          File parent = f.getParentFile();
-          if (!parent.isDirectory() && !parent.mkdirs()) {
-            throw new IOException("create directory failed: " + parent);
-          }
-          try (OutputStream fs = new FileOutputStream(f)) {
-            ByteStreams.copy(archive, fs);
-            fs.flush();
+          File f = new File(destination.toFile(), entry.getName());
+          if (entry.isDirectory()) {
+            if (!f.isDirectory() && !f.mkdirs()) {
+              throw new IOException("create directory failed: " + f);
+            }
+          } else {
+            File parent = f.getParentFile();
+            if (!parent.isDirectory() && !parent.mkdirs()) {
+              throw new IOException("create directory failed: " + parent);
+            }
+            try (OutputStream fs = new FileOutputStream(f)) {
+              ByteStreams.copy(archive, fs);
+              fs.flush();
+            }
           }
         }
       }
-    }
-    try {
-      int status = proc.waitFor();
-      if (status != 0) {
-        throw new IOException("Copy command failed with status " + status);
+      try {
+        int status = proc.waitFor();
+        if (status != 0) {
+          throw new IOException("Copy command failed with status " + status);
+        }
+      } catch (InterruptedException ex) {
+        throw new IOException(ex);
       }
-    } catch (InterruptedException ex) {
-      throw new IOException(ex);
     }
   }
 
@@ -201,5 +204,18 @@ public class Copy extends Exec {
     }
 
     return;
+  }
+
+  private boolean isTarPresentInContainer(String namespace, String pod, String container)
+      throws ApiException, IOException {
+    final Process proc =
+        this.exec(
+            namespace, pod, new String[] {"sh", "-c", "tar --version"}, container, false, false);
+    // This will work for POSIX based operating systems
+    if (proc.exitValue() == 127) {
+      return false;
+    }
+    proc.destroy();
+    return true;
   }
 }

--- a/util/src/main/java/io/kubernetes/client/Copy.java
+++ b/util/src/main/java/io/kubernetes/client/Copy.java
@@ -213,8 +213,13 @@ public class Copy extends Exec {
         this.exec(
             namespace, pod, new String[] {"sh", "-c", "tar --version"}, container, false, false);
     // This will work for POSIX based operating systems
-    boolean isTarPresent = proc.exitValue() == 127 ? false : true;
-    proc.destroy();
-    return isTarPresent;
+    try {
+      int status = proc.waitFor();
+      return status == 127 ? false : true;
+    } catch (InterruptedException ex) {
+      throw new IOException(ex);
+    } finally {
+      proc.destroy();
+    }
   }
 }

--- a/util/src/main/java/io/kubernetes/client/Copy.java
+++ b/util/src/main/java/io/kubernetes/client/Copy.java
@@ -212,10 +212,8 @@ public class Copy extends Exec {
         this.exec(
             namespace, pod, new String[] {"sh", "-c", "tar --version"}, container, false, false);
     // This will work for POSIX based operating systems
-    if (proc.exitValue() == 127) {
-      return false;
-    }
+    boolean isTarPresent = proc.exitValue() == 127 ? false : true;
     proc.destroy();
-    return true;
+    return isTarPresent;
   }
 }

--- a/util/src/main/java/io/kubernetes/client/util/exception/CopyNotSupportedException.java
+++ b/util/src/main/java/io/kubernetes/client/util/exception/CopyNotSupportedException.java
@@ -1,0 +1,8 @@
+package io.kubernetes.client.util.exception;
+
+public class CopyNotSupportedException extends Exception {
+
+  public CopyNotSupportedException(String errorMessage) {
+    super(errorMessage);
+  }
+}


### PR DESCRIPTION
Right now copy method throws runtime error if Tar is not present in the target container. Added a check for it before proceeding with copying process.
Note: This will only work for the containers which has POSIX based underlying image