### PR TITLE
Reflector and leader-elector exception handlers

### DIFF
--- a/util/src/test/java/io/kubernetes/client/informer/cache/ReflectorRunnableTest.java
+++ b/util/src/test/java/io/kubernetes/client/informer/cache/ReflectorRunnableTest.java
@@ -6,10 +6,14 @@ import static org.mockito.Mockito.*;
 import io.kubernetes.client.informer.EventType;
 import io.kubernetes.client.informer.ListerWatcher;
 import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.openapi.models.*;
+import io.kubernetes.client.openapi.models.V1ListMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodList;
+import io.kubernetes.client.openapi.models.V1Status;
 import io.kubernetes.client.util.CallGeneratorParams;
 import io.kubernetes.client.util.Watch;
 import io.kubernetes.client.util.Watchable;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -89,5 +93,56 @@ public class ReflectorRunnableTest {
     } finally {
       reflectorRunnable.stop();
     }
+  }
+
+  @Test
+  public void testReflectorRunnableCaptureListException()
+      throws ApiException, InterruptedException {
+    RuntimeException expectedException = new RuntimeException("noxu");
+    AtomicReference<Throwable> actualException = new AtomicReference<>();
+    when(listerWatcher.list(any())).thenThrow(expectedException);
+    ReflectorRunnable<V1Pod, V1PodList> reflectorRunnable =
+        new ReflectorRunnable<>(
+            V1Pod.class,
+            listerWatcher,
+            deltaFIFO,
+            (apiType, t) -> {
+              actualException.set(t);
+            });
+    try {
+      Thread thread = new Thread(reflectorRunnable::run);
+      thread.setDaemon(true);
+      thread.start();
+      Thread.sleep(1000);
+    } finally {
+      reflectorRunnable.stop();
+    }
+    assertEquals(expectedException, actualException.get());
+  }
+
+  @Test
+  public void testReflectorRunnableCaptureWatchException()
+      throws ApiException, InterruptedException {
+    RuntimeException expectedException = new RuntimeException("noxu");
+    AtomicReference<Throwable> actualException = new AtomicReference<>();
+    when(listerWatcher.list(any())).thenReturn(new V1PodList().metadata(new V1ListMeta()));
+    when(listerWatcher.watch(any())).thenThrow(expectedException);
+    ReflectorRunnable<V1Pod, V1PodList> reflectorRunnable =
+        new ReflectorRunnable<>(
+            V1Pod.class,
+            listerWatcher,
+            deltaFIFO,
+            (apiType, t) -> {
+              actualException.set(t);
+            });
+    try {
+      Thread thread = new Thread(reflectorRunnable::run);
+      thread.setDaemon(true);
+      thread.start();
+      Thread.sleep(1000);
+    } finally {
+      reflectorRunnable.stop();
+    }
+    assertEquals(expectedException, actualException.get());
   }
 }


### PR DESCRIPTION
the exception handlers for reflector is already supported in the golang client library https://github.com/kubernetes/kubernetes/pull/87329. this pull implements similar capabilities for both reflector and leader-electors..