### PR TITLE
Kubectl label equivalence

### DIFF
--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/Kubectl.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/Kubectl.java
@@ -1,0 +1,66 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.extended.kubectl;
+
+import io.kubernetes.client.common.KubernetesObject;
+import io.kubernetes.client.extended.kubectl.exception.KubectlException;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.Configuration;
+
+/**
+ * Kubectl provides a set of helper functions that has the same functionalities as corresponding
+ * kubectl commands.
+ */
+public class Kubectl {
+
+  /**
+   * Equivalence for `kubectl label`.
+   *
+   * @param <ApiType> the target api type
+   * @param apiTypeClass the api type class
+   * @return the kubectl label
+   */
+  public static <ApiType extends KubernetesObject> KubectlLabel<ApiType> label(
+      Class<ApiType> apiTypeClass) {
+    return label(Configuration.getDefaultApiClient(), apiTypeClass);
+  }
+
+  /**
+   * Equivalence for `kubectl label`.
+   *
+   * @param <ApiType> the target api type
+   * @param apiClient the api client instance
+   * @param apiTypeClass the api type class
+   * @return the kubectl label
+   */
+  public static <ApiType extends KubernetesObject> KubectlLabel<ApiType> label(
+      ApiClient apiClient, Class<ApiType> apiTypeClass) {
+    return new KubectlLabel<>(apiClient, apiTypeClass);
+  }
+
+  /**
+   * Executable executes a kubectl helper.
+   *
+   * @param <OUTPUT> the type parameter
+   */
+  public interface Executable<OUTPUT> {
+
+    /**
+     * Run and retrieve the output from the kubectl helpers.
+     *
+     * @return the output, can be Void
+     * @throws KubectlException the kubectl exception
+     */
+    OUTPUT execute() throws KubectlException;
+  }
+}

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlLabel.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlLabel.java
@@ -1,0 +1,130 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.extended.kubectl;
+
+import io.kubernetes.client.common.KubernetesListObject;
+import io.kubernetes.client.common.KubernetesObject;
+import io.kubernetes.client.extended.kubectl.exception.KubectlException;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.util.generic.GenericKubernetesApi;
+import io.kubernetes.client.util.generic.KubernetesApiResponse;
+import io.kubernetes.client.util.labels.Labels;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.lang.StringUtils;
+
+class KubectlLabel<ApiType extends KubernetesObject> implements Kubectl.Executable<ApiType> {
+
+  private final ApiClient apiClient;
+  private final Class<ApiType> apiTypeClass;
+  private final Map<String, String> addingLabels;
+
+  private String apiGroup;
+  private String apiVersion;
+  private String resourceNamePlural;
+
+  private String namespace;
+  private String name;
+
+  KubectlLabel(ApiClient apiClient, Class<ApiType> apiTypeClass) {
+    this.addingLabels = new HashMap<>();
+    this.apiTypeClass = apiTypeClass;
+    this.apiClient = apiClient;
+  }
+
+  public KubectlLabel<ApiType> apiGroup(String apiGroup) {
+    this.apiGroup = apiGroup;
+    return this;
+  }
+
+  public KubectlLabel<ApiType> apiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+    return this;
+  }
+
+  public KubectlLabel<ApiType> resourceNamePlural(String resourceNamePlural) {
+    this.resourceNamePlural = resourceNamePlural;
+    return this;
+  }
+
+  public KubectlLabel<ApiType> namespace(String namespace) {
+    this.namespace = namespace;
+    return this;
+  }
+
+  public KubectlLabel<ApiType> name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public KubectlLabel<ApiType> addLabel(String key, String value) {
+    this.addingLabels.put(key, value);
+    return this;
+  }
+
+  private boolean isNamespaced() {
+    return !StringUtils.isEmpty(namespace);
+  }
+
+  @Override
+  public ApiType execute() throws KubectlException {
+    verifyArguments();
+    GenericKubernetesApi<ApiType, KubernetesListObject> api =
+        new GenericKubernetesApi<>(
+            apiTypeClass,
+            KubernetesListObject.class,
+            apiGroup,
+            apiVersion,
+            resourceNamePlural,
+            apiClient);
+
+    try {
+      final KubernetesApiResponse<ApiType> getResponse;
+      if (isNamespaced()) {
+        getResponse = api.get(namespace, name);
+      } else {
+        getResponse = api.get(name);
+      }
+      if (!getResponse.isSuccess()) {
+        throw new KubectlException(getResponse.getStatus());
+      }
+      ApiType obj = getResponse.getObject();
+
+      Labels.addLabels(obj, addingLabels);
+
+      final KubernetesApiResponse<ApiType> updateResponse;
+      updateResponse = api.update(obj);
+      if (!updateResponse.isSuccess()) {
+        throw new KubectlException(updateResponse.getStatus());
+      }
+      return updateResponse.getObject();
+    } catch (Throwable t) {
+      throw new KubectlException(t);
+    }
+  }
+
+  private void verifyArguments() throws KubectlException {
+    if (null == apiGroup) {
+      throw new KubectlException("missing apiGroup argument");
+    }
+    if (null == apiVersion) {
+      throw new KubectlException("missing apiVersion argument");
+    }
+    if (null == resourceNamePlural) {
+      throw new KubectlException("missing resourceNamePlural argument");
+    }
+    if (null == name) {
+      throw new KubectlException("missing name argument");
+    }
+  }
+}

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/exception/KubectlException.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/exception/KubectlException.java
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.extended.kubectl.exception;
+
+import io.kubernetes.client.openapi.models.V1Status;
+
+/** KubectlException is thrown upon any failure from Kubectl helpers. */
+public class KubectlException extends Exception {
+
+  public KubectlException(String message) {
+    super(message);
+  }
+
+  public KubectlException(V1Status status) {
+    super(status.toString());
+  }
+
+  public KubectlException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlLabelTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlLabelTest.java
@@ -1,0 +1,198 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.extended.kubectl;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.kubernetes.client.extended.kubectl.exception.KubectlException;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.models.V1Node;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.util.ClientBuilder;
+import java.io.IOException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class KubectlLabelTest {
+
+  private ApiClient apiClient;
+
+  @Rule public WireMockRule wireMockRule = new WireMockRule(8384);
+
+  @Before
+  public void setup() throws IOException {
+    apiClient = new ClientBuilder().setBasePath("http://localhost:" + 8384).build();
+  }
+
+  @Test
+  public void testKubectlLabelNamespacedResourceShouldWork() throws KubectlException {
+    wireMockRule.stubFor(
+        get(urlPathEqualTo("/api/v1/namespaces/default/pods/foo"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withBody("{\"metadata\":{\"name\":\"foo\",\"namespace\":\"default\"}}")));
+    wireMockRule.stubFor(
+        put(urlPathEqualTo("/api/v1/namespaces/default/pods/foo"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withBody("{\"metadata\":{\"name\":\"foo\",\"namespace\":\"default\"}}")));
+    V1Pod labelledPod =
+        Kubectl.label(apiClient, V1Pod.class)
+            .apiGroup("")
+            .apiVersion("v1")
+            .resourceNamePlural("pods")
+            .namespace("default")
+            .name("foo")
+            .addLabel("k1", "v1")
+            .addLabel("k2", "v2")
+            .execute();
+    wireMockRule.verify(1, getRequestedFor(urlPathEqualTo("/api/v1/namespaces/default/pods/foo")));
+    wireMockRule.verify(1, putRequestedFor(urlPathEqualTo("/api/v1/namespaces/default/pods/foo")));
+    assertNotNull(labelledPod);
+  }
+
+  @Test
+  public void testKubectlLabelNamespacedResourceReceiveForbiddenShouldThrowException()
+      throws KubectlException {
+    wireMockRule.stubFor(
+        get(urlPathEqualTo("/api/v1/namespaces/default/pods/foo"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withBody("{\"metadata\":{\"name\":\"foo\",\"namespace\":\"default\"}}")));
+    wireMockRule.stubFor(
+        put(urlPathEqualTo("/api/v1/namespaces/default/pods/foo"))
+            .willReturn(aResponse().withStatus(403).withBody("{\"metadata\":{}}")));
+    assertThrows(
+        KubectlException.class,
+        () -> {
+          Kubectl.label(apiClient, V1Pod.class)
+              .apiGroup("")
+              .apiVersion("v1")
+              .resourceNamePlural("pods")
+              .namespace("default")
+              .name("foo")
+              .addLabel("k1", "v1")
+              .addLabel("k2", "v2")
+              .execute();
+        });
+    wireMockRule.verify(1, getRequestedFor(urlPathEqualTo("/api/v1/namespaces/default/pods/foo")));
+    wireMockRule.verify(1, putRequestedFor(urlPathEqualTo("/api/v1/namespaces/default/pods/foo")));
+  }
+
+  @Test
+  public void testKubectlLabelClusterResourceShouldWork() throws KubectlException {
+    wireMockRule.stubFor(
+        get(urlPathEqualTo("/api/v1/nodes/foo"))
+            .willReturn(aResponse().withStatus(200).withBody("{\"metadata\":{\"name\":\"foo\"}}")));
+    wireMockRule.stubFor(
+        put(urlPathEqualTo("/api/v1/nodes/foo"))
+            .willReturn(aResponse().withStatus(200).withBody("{\"metadata\":{\"name\":\"foo\"}}")));
+    V1Node labelledNode =
+        Kubectl.label(apiClient, V1Node.class)
+            .apiGroup("")
+            .apiVersion("v1")
+            .resourceNamePlural("nodes")
+            .name("foo")
+            .addLabel("k1", "v1")
+            .addLabel("k2", "v2")
+            .execute();
+    wireMockRule.verify(1, getRequestedFor(urlPathEqualTo("/api/v1/nodes/foo")));
+    wireMockRule.verify(1, putRequestedFor(urlPathEqualTo("/api/v1/nodes/foo")));
+    assertNotNull(labelledNode);
+  }
+
+  @Test
+  public void testKubectlLabelClusterResourceReceiveForbiddenShouldThrowException()
+      throws KubectlException {
+    wireMockRule.stubFor(
+        get(urlPathEqualTo("/api/v1/nodes/foo"))
+            .willReturn(aResponse().withStatus(200).withBody("{\"metadata\":{\"name\":\"foo\"}}")));
+    wireMockRule.stubFor(
+        put(urlPathEqualTo("/api/v1/nodes/foo"))
+            .willReturn(aResponse().withStatus(403).withBody("{\"metadata\":{\"name\":\"foo\"}}")));
+    assertThrows(
+        KubectlException.class,
+        () -> {
+          Kubectl.label(apiClient, V1Node.class)
+              .apiGroup("")
+              .apiVersion("v1")
+              .resourceNamePlural("nodes")
+              .name("foo")
+              .addLabel("k1", "v1")
+              .addLabel("k2", "v2")
+              .execute();
+        });
+    wireMockRule.verify(1, getRequestedFor(urlPathEqualTo("/api/v1/nodes/foo")));
+    wireMockRule.verify(1, putRequestedFor(urlPathEqualTo("/api/v1/nodes/foo")));
+  }
+
+  @Test
+  public void testMissingArgumentsShouldFail() throws KubectlException {
+    assertThrows(
+        KubectlException.class,
+        () -> {
+          Kubectl.label(apiClient, V1Node.class)
+              // .apiGroup("")  # missing apiGroup
+              .apiVersion("v1")
+              .resourceNamePlural("nodes")
+              .name("foo")
+              .addLabel("k1", "v1")
+              .addLabel("k2", "v2")
+              .execute();
+        });
+    assertThrows(
+        KubectlException.class,
+        () -> {
+          Kubectl.label(apiClient, V1Node.class)
+              .apiGroup("")
+              // .apiVersion("v1") # missing apiVersion
+              .resourceNamePlural("nodes")
+              .name("foo")
+              .addLabel("k1", "v1")
+              .addLabel("k2", "v2")
+              .execute();
+        });
+    assertThrows(
+        KubectlException.class,
+        () -> {
+          Kubectl.label(apiClient, V1Node.class)
+              .apiGroup("")
+              .apiVersion("v1")
+              // .resourceNamePlural("nodes") # missing resourceNamePlural
+              .name("foo")
+              .addLabel("k1", "v1")
+              .addLabel("k2", "v2")
+              .execute();
+        });
+    assertThrows(
+        KubectlException.class,
+        () -> {
+          Kubectl.label(apiClient, V1Node.class)
+              .apiGroup("")
+              .apiVersion("v1")
+              .resourceNamePlural("nodes")
+              // .name("foo") # missing name
+              .addLabel("k1", "v1")
+              .addLabel("k2", "v2")
+              .execute();
+        });
+  }
+}

--- a/util/src/main/java/io/kubernetes/client/util/generic/GenericKubernetesApi.java
+++ b/util/src/main/java/io/kubernetes/client/util/generic/GenericKubernetesApi.java
@@ -291,7 +291,6 @@ public class GenericKubernetesApi<
     if (Strings.isNullOrEmpty(name)) {
       throw new IllegalArgumentException("invalid namespace");
     }
-    CustomObjectsApi customObjectsApi = new CustomObjectsApi();
     return executeCall(
         customObjectsApi.getApiClient(),
         apiTypeClass,

--- a/util/src/main/java/io/kubernetes/client/util/labels/Labels.java
+++ b/util/src/main/java/io/kubernetes/client/util/labels/Labels.java
@@ -1,0 +1,53 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.util.labels;
+
+import io.kubernetes.client.common.KubernetesObject;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Helper utilities for manipulating kubernetes labels. */
+public class Labels {
+
+  /**
+   * Adds one label to the object.
+   *
+   * @param kubernetesObject the kubernetes object
+   * @param label the label key
+   * @param value the label value
+   */
+  public static void addLabels(KubernetesObject kubernetesObject, String label, String value) {
+    Map<String, String> mergingLabels = new HashMap<>();
+    mergingLabels.put(label, value);
+    addLabels(kubernetesObject, mergingLabels);
+  }
+
+  /**
+   * Adds a set of labels to the object.
+   *
+   * @param kubernetesObject the kubernetes object
+   * @param mergingLabels the merging labels
+   */
+  public static void addLabels(
+      KubernetesObject kubernetesObject, Map<String, String> mergingLabels) {
+    if (null == mergingLabels) {
+      return;
+    }
+    final Map<String, String> currentLabels =
+        null != kubernetesObject.getMetadata().getLabels()
+            ? kubernetesObject.getMetadata().getLabels()
+            : new HashMap<>();
+    mergingLabels.entrySet().stream().forEach(e -> currentLabels.put(e.getKey(), e.getValue()));
+    kubernetesObject.getMetadata().setLabels(currentLabels);
+  }
+}

--- a/util/src/test/java/io/kubernetes/client/util/labels/LabelsTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/labels/LabelsTest.java
@@ -1,0 +1,42 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.util.labels;
+
+import static org.junit.Assert.*;
+
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class LabelsTest {
+
+  @Test
+  public void testAddLabels() {
+    V1Pod pod = new V1Pod().metadata(new V1ObjectMeta());
+    Labels.addLabels(pod, "foo", "bar");
+    assertEquals(pod.getMetadata().getLabels().get("foo"), "bar");
+  }
+
+  @Test
+  public void testAddMultipleLabels() {
+    V1Pod pod = new V1Pod().metadata(new V1ObjectMeta());
+    Map<String, String> newLabels = new HashMap<>();
+    newLabels.put("foo1", "bar1");
+    newLabels.put("foo2", "bar2");
+    Labels.addLabels(pod, newLabels);
+    assertEquals(pod.getMetadata().getLabels().get("foo1"), "bar1");
+    assertEquals(pod.getMetadata().getLabels().get("foo2"), "bar2");
+  }
+}


### PR DESCRIPTION
this pull initiates a new set of helper classes under extended module providing similar capabilities w/ kubectl commands:

```
    V1Pod labelledPod =
        Kubectl.label(apiClient, V1Pod.class)
            .apiGroup("")
            .apiVersion("v1")
            .resourceNamePlural("pods")
            .namespace("default")
            .name("foo")
            .addLabel("k1", "v1")
            .addLabel("k2", "v2")
            .execute();
```