### PR TITLE
Gracefully shutdown listener pool

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>3.3.3</version>
+        <version>3.4.4</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Use the shutdown pattern in https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ExecutorService.html

I wonder how to determine the timeout