### PR TITLE
Support custom workqueue-keyfunc to directly manipulate work-queue instance

### DIFF
--- a/extended/src/main/java/io/kubernetes/client/extended/controller/DefaultController.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/controller/DefaultController.java
@@ -199,6 +199,15 @@ public class DefaultController implements Controller {
     }
   }
 
+  public RateLimitingQueue<Request> getWorkQueue() {
+    return workQueue;
+  }
+
+  public DefaultController setWorkQueue(RateLimitingQueue<Request> workQueue) {
+    this.workQueue = workQueue;
+    return this;
+  }
+
   public String getName() {
     return name;
   }

--- a/extended/src/main/java/io/kubernetes/client/extended/controller/DefaultControllerWatch.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/controller/DefaultControllerWatch.java
@@ -94,14 +94,20 @@ public class DefaultControllerWatch<ApiType extends KubernetesObject>
       @Override
       public void onAdd(ApiType obj) {
         if (onAddFilterPredicate == null || onAddFilterPredicate.test(obj)) {
-          workQueue.add(workKeyGenerator.apply(obj));
+          Request req = workKeyGenerator.apply(obj);
+          if (null != req) {
+            workQueue.add(req);
+          }
         }
       }
 
       @Override
       public void onUpdate(ApiType oldObj, ApiType newObj) {
         if (onUpdateFilterPredicate == null || onUpdateFilterPredicate.test(oldObj, newObj)) {
-          workQueue.add(workKeyGenerator.apply(newObj));
+          Request req = workKeyGenerator.apply(newObj);
+          if (null != req) {
+            workQueue.add(req);
+          }
         }
       }
 
@@ -109,7 +115,10 @@ public class DefaultControllerWatch<ApiType extends KubernetesObject>
       public void onDelete(ApiType obj, boolean deletedFinalStateUnknown) {
         if (onDeleteFilterPredicate == null
             || onDeleteFilterPredicate.test(obj, deletedFinalStateUnknown)) {
-          workQueue.add(workKeyGenerator.apply(obj));
+          Request req = workKeyGenerator.apply(obj);
+          if (null != req) {
+            workQueue.add(req);
+          }
         }
       }
     };

--- a/spring/src/main/java/io/kubernetes/client/spring/extended/controller/annotation/KubernetesReconcilerWatch.java
+++ b/spring/src/main/java/io/kubernetes/client/spring/extended/controller/annotation/KubernetesReconcilerWatch.java
@@ -38,9 +38,14 @@ public @interface KubernetesReconcilerWatch {
    * Work queue key func class maps the source resource of the watch event to a standard reconciler
    * request.
    *
+   * <p>Optionally you can declare the constructor of the class to receive a {@link
+   * io.kubernetes.client.extended.workqueue.WorkQueue} in the parameter in order to customize the
+   * work-queue key-func.
+   *
    * @return the class
    */
-  Class<? extends Function<?, Request>> workQueueKeyFunc() default DefaultReflectiveKeyFunc.class;
+  Class<? extends Function<? extends KubernetesObject, Request>> workQueueKeyFunc() default
+      DefaultReflectiveKeyFunc.class;
 
   /**
    * Resync period in milliseconds .

--- a/util/src/main/java/io/kubernetes/client/informer/impl/DefaultSharedIndexInformer.java
+++ b/util/src/main/java/io/kubernetes/client/informer/impl/DefaultSharedIndexInformer.java
@@ -216,7 +216,7 @@ public class DefaultSharedIndexInformer<
    *
    * @param deltas deltas
    */
-  private void handleDeltas(Deque<MutablePair<DeltaFIFO.DeltaType, KubernetesObject>> deltas) {
+  public void handleDeltas(Deque<MutablePair<DeltaFIFO.DeltaType, KubernetesObject>> deltas) {
     if (CollectionUtils.isEmpty(deltas)) {
       return;
     }


### PR DESCRIPTION
resolves https://github.com/kubernetes-client/java/issues/1108

in order to support mapping one resource event to multiple controller-requests, we made the following adjustment to the controller framework:

- support returning a `null` request from the work-queue-key-func so that it can optionally be silent/no-op at some time
- (for spring integration) support receiving `WorkQueue` instance in the constructor of the work-queue-key-func so it can now manually push multiple controller-requests to the work-queue upon resource events (for sample, see the tests in this pull)

as for [non-spring construction](https://github.com/kubernetes-client/java/blob/894b1631e83d23a65440060b341faeba58c66760/examples/src/main/java/io/kubernetes/client/examples/ControllerExample.java#L90-L92) of controllers, you can pass a key-func instance which holds work-queue instance and manually pushes events to the queue by its customized logic. however, for the versions before 9.0.0, you will have to push a dummy controller-request to the queue and handle it explicitly in your reconciler b/c `null` return value is not supported..



@brendandburns @tony-clarke-amdocs