### PR TITLE
Refactor(kubectl): get rid of force api type class casting

### DIFF
--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/Kubectl.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/Kubectl.java
@@ -105,7 +105,6 @@ public class Kubectl {
   /**
    * Equivalent for `kubectl exec`
    *
-   * @param apiClient The api client instance
    * @return the kubectl exec operator
    */
   public static KubectlExec exec() {
@@ -128,13 +127,14 @@ public class Kubectl {
     OUTPUT execute() throws KubectlException;
   }
 
-  abstract static class ResourceBuilder<T extends ResourceBuilder<T>> {
+  abstract static class ResourceBuilder<
+      ApiType extends KubernetesObject, T extends ResourceBuilder<ApiType, T>> {
     final ApiClient apiClient;
-    final Class<?> apiTypeClass;
+    final Class<ApiType> apiTypeClass;
     String namespace;
     String name;
 
-    ResourceBuilder(ApiClient client, Class<?> apiTypeClass) {
+    ResourceBuilder(ApiClient client, Class<ApiType> apiTypeClass) {
       this.apiClient = client;
       this.apiTypeClass = apiTypeClass;
     }
@@ -150,11 +150,12 @@ public class Kubectl {
     }
   }
 
-  abstract static class ResourceAndContainerBuilder<T extends ResourceAndContainerBuilder<T>>
-      extends ResourceBuilder<T> {
+  abstract static class ResourceAndContainerBuilder<
+          ApiType extends KubernetesObject, T extends ResourceAndContainerBuilder<ApiType, T>>
+      extends ResourceBuilder<ApiType, T> {
     String container;
 
-    ResourceAndContainerBuilder(ApiClient client, Class<?> apiTypeClass) {
+    ResourceAndContainerBuilder(ApiClient client, Class<ApiType> apiTypeClass) {
       super(client, apiTypeClass);
     }
 

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlExec.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlExec.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-public class KubectlExec extends Kubectl.ResourceAndContainerBuilder<KubectlExec>
+public class KubectlExec extends Kubectl.ResourceAndContainerBuilder<V1Pod, KubectlExec>
     implements Kubectl.Executable<V1Pod> {
   private String[] command;
   private boolean stdin;

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlLabel.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlLabel.java
@@ -24,7 +24,8 @@ import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 
 public class KubectlLabel<ApiType extends KubernetesObject>
-    extends Kubectl.ResourceBuilder<KubectlLabel<ApiType>> implements Kubectl.Executable<ApiType> {
+    extends Kubectl.ResourceBuilder<ApiType, KubectlLabel<ApiType>>
+    implements Kubectl.Executable<ApiType> {
   private final Map<String, String> addingLabels;
   private String apiGroup;
   private String apiVersion;
@@ -64,7 +65,7 @@ public class KubectlLabel<ApiType extends KubernetesObject>
     verifyArguments();
     GenericKubernetesApi<ApiType, KubernetesListObject> api =
         new GenericKubernetesApi<>(
-            (Class<ApiType>) apiTypeClass,
+            apiTypeClass,
             KubernetesListObject.class,
             apiGroup,
             apiVersion,

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlScale.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlScale.java
@@ -23,7 +23,8 @@ import io.kubernetes.client.openapi.models.V1ReplicaSet;
 import io.kubernetes.client.util.PatchUtils;
 
 public class KubectlScale<ApiType extends KubernetesObject>
-    extends Kubectl.ResourceBuilder<KubectlScale<ApiType>> implements Kubectl.Executable<ApiType> {
+    extends Kubectl.ResourceBuilder<ApiType, KubectlScale<ApiType>>
+    implements Kubectl.Executable<ApiType> {
   private final AppsV1Api api;
   private int replicas;
 


### PR DESCRIPTION
Get rid of force type casting by adding type parameter to ResourceBuilder.

follow-up of #1135 