### PR TITLE
Instrumenting follow-up: metrics labelling w/ finer granularity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <common.codec.version>1.14</common.codec.version>
     <spring.boot.version>2.3.3.RELEASE</spring.boot.version>
     <spring.version>5.2.8.RELEASE</spring.version>
+    <prometheus.client.version>0.9.0</prometheus.client.version>
 
     <gpg.keyname>48540ECBBF00A28EACCF04E720FD12AFB0C9EBA9</gpg.keyname>
     <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
@@ -152,6 +153,18 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-autoconfigure</artifactId>
         <version>${spring.boot.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.prometheus</groupId>
+        <artifactId>simpleclient</artifactId>
+        <version>${prometheus.client.version}</version>
+        <optional>true</optional>
+      </dependency>
+      <dependency>
+        <groupId>io.prometheus</groupId>
+        <artifactId>simpleclient_httpserver</artifactId>
+        <version>${prometheus.client.version}</version>
+        <optional>true</optional>
       </dependency>
 
 

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -15,14 +15,10 @@
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
-            <version>0.9.0</version>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient_httpserver</artifactId>
-            <version>0.9.0</version>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.kubernetes</groupId>

--- a/util/src/main/java/io/kubernetes/client/apimachinery/GroupVersionKind.java
+++ b/util/src/main/java/io/kubernetes/client/apimachinery/GroupVersionKind.java
@@ -1,0 +1,38 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.apimachinery;
+
+public class GroupVersionKind {
+
+  private final String group;
+  private final String version;
+  private final String kind;
+
+  public GroupVersionKind(String group, String version, String kind) {
+    this.group = group;
+    this.version = version;
+    this.kind = kind;
+  }
+
+  public String getGroup() {
+    return group;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public String getKind() {
+    return kind;
+  }
+}

--- a/util/src/main/java/io/kubernetes/client/apimachinery/GroupVersionResource.java
+++ b/util/src/main/java/io/kubernetes/client/apimachinery/GroupVersionResource.java
@@ -1,0 +1,38 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.apimachinery;
+
+public class GroupVersionResource {
+
+  private final String group;
+  private final String version;
+  private final String resource;
+
+  public GroupVersionResource(String group, String version, String resource) {
+    this.group = group;
+    this.version = version;
+    this.resource = resource;
+  }
+
+  public String getGroup() {
+    return group;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public String getResource() {
+    return resource;
+  }
+}

--- a/util/src/main/java/io/kubernetes/client/apimachinery/KubernetesRequestDigest.java
+++ b/util/src/main/java/io/kubernetes/client/apimachinery/KubernetesRequestDigest.java
@@ -1,0 +1,126 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.apimachinery;
+
+import com.google.common.base.Strings;
+import java.util.regex.Pattern;
+import okhttp3.Request;
+
+public class KubernetesRequestDigest {
+
+  public static final Pattern RESOURCE_URL_PATH_PATTERN =
+      Pattern.compile("^/(api|apis)(/\\S+)?/v\\d\\w*/\\S+");
+
+  KubernetesRequestDigest(
+      String urlPath,
+      boolean isNonResourceRequest,
+      KubernetesResource resourceMeta,
+      KubernetesVerb verb) {
+    this.urlPath = urlPath;
+    this.isNonResourceRequest = isNonResourceRequest;
+    this.resourceMeta = resourceMeta;
+    this.verb = verb;
+  }
+
+  public static KubernetesRequestDigest parse(Request request) {
+    String urlPath = request.url().encodedPath();
+    if (!isResourceRequest(urlPath)) {
+      return nonResource(urlPath);
+    }
+    try {
+      KubernetesResource resourceMeta;
+      if (urlPath.startsWith("/api/v1")) {
+        resourceMeta = KubernetesResource.parseCoreResource(urlPath);
+      } else {
+        resourceMeta = KubernetesResource.parseRegularResource(urlPath);
+      }
+
+      return new KubernetesRequestDigest(
+          urlPath,
+          false,
+          resourceMeta,
+          KubernetesVerb.of(
+              request.method(), hasNamePathParameter(resourceMeta), hasWatchParameter(request)));
+    } catch (ParseKubernetesResourceException e) {
+      return nonResource(urlPath);
+    }
+  }
+
+  private static KubernetesRequestDigest nonResource(String urlPath) {
+    KubernetesRequestDigest digest = new KubernetesRequestDigest(urlPath, true, null, null);
+    return digest;
+  }
+
+  public static boolean isResourceRequest(String urlPath) {
+    return RESOURCE_URL_PATH_PATTERN.matcher(urlPath).matches();
+  }
+
+  private static boolean hasWatchParameter(Request request) {
+    return !Strings.isNullOrEmpty(request.url().queryParameter("watch"));
+  }
+
+  private static boolean hasNamePathParameter(KubernetesResource resource) {
+    return !Strings.isNullOrEmpty(resource.getName());
+  }
+
+  private final String urlPath;
+  private final boolean isNonResourceRequest;
+
+  private final KubernetesResource resourceMeta;
+  private final KubernetesVerb verb;
+
+  public String getUrlPath() {
+    return urlPath;
+  }
+
+  public boolean isNonResourceRequest() {
+    return isNonResourceRequest;
+  }
+
+  public KubernetesResource getResourceMeta() {
+    return resourceMeta;
+  }
+
+  public KubernetesVerb getVerb() {
+    return verb;
+  }
+
+  @Override
+  public String toString() {
+    if (isNonResourceRequest) {
+      return new StringBuilder().append(verb).append(' ').append(urlPath).toString();
+    }
+
+    String groupVersion;
+    if (Strings.isNullOrEmpty(resourceMeta.getApiGroup())) { // core resource
+      groupVersion = "";
+    } else { // regular resource
+      groupVersion = resourceMeta.getApiGroup() + "/" + resourceMeta.getApiVersion();
+    }
+
+    String targetResourceName;
+    if (Strings.isNullOrEmpty(resourceMeta.getSubResource())) {
+      targetResourceName = resourceMeta.getResource();
+    } else { // subresource
+      targetResourceName = resourceMeta.getResource() + "/" + resourceMeta.getSubResource();
+    }
+
+    return new StringBuilder()
+        .append(verb.value())
+        .append(' ')
+        .append(groupVersion)
+        .append(' ')
+        .append(targetResourceName)
+        .toString();
+  }
+}

--- a/util/src/main/java/io/kubernetes/client/apimachinery/KubernetesRequestDigest.java
+++ b/util/src/main/java/io/kubernetes/client/apimachinery/KubernetesRequestDigest.java
@@ -102,17 +102,23 @@ public class KubernetesRequestDigest {
     }
 
     String groupVersion;
-    if (Strings.isNullOrEmpty(resourceMeta.getApiGroup())) { // core resource
+    if (Strings.isNullOrEmpty(resourceMeta.getGroupVersionResource().getGroup())) { // core resource
       groupVersion = "";
     } else { // regular resource
-      groupVersion = resourceMeta.getApiGroup() + "/" + resourceMeta.getApiVersion();
+      groupVersion =
+          resourceMeta.getGroupVersionResource().getGroup()
+              + "/"
+              + resourceMeta.getGroupVersionResource().getVersion();
     }
 
     String targetResourceName;
     if (Strings.isNullOrEmpty(resourceMeta.getSubResource())) {
-      targetResourceName = resourceMeta.getResource();
+      targetResourceName = resourceMeta.getGroupVersionResource().getResource();
     } else { // subresource
-      targetResourceName = resourceMeta.getResource() + "/" + resourceMeta.getSubResource();
+      targetResourceName =
+          resourceMeta.getGroupVersionResource().getResource()
+              + "/"
+              + resourceMeta.getSubResource();
     }
 
     return new StringBuilder()

--- a/util/src/main/java/io/kubernetes/client/apimachinery/KubernetesResource.java
+++ b/util/src/main/java/io/kubernetes/client/apimachinery/KubernetesResource.java
@@ -33,9 +33,7 @@ public class KubernetesResource {
     }
     KubernetesResource resource =
         new KubernetesResource(
-            "",
-            "v1",
-            matcher.group("resource"),
+            new GroupVersionResource("", "v1", matcher.group("resource")),
             matcher.group("subresource"),
             matcher.group("namespace"),
             matcher.group("name"));
@@ -50,48 +48,29 @@ public class KubernetesResource {
     }
     KubernetesResource resource =
         new KubernetesResource(
-            matcher.group("group"),
-            matcher.group("version"),
-            matcher.group("resource"),
+            new GroupVersionResource(
+                matcher.group("group"), matcher.group("version"), matcher.group("resource")),
             matcher.group("subresource"),
             matcher.group("namespace"),
             matcher.group("name"));
     return resource;
   }
 
-  KubernetesResource(
-      String apiGroup,
-      String apiVersion,
-      String resource,
-      String subResource,
-      String namespace,
-      String name) {
-    this.apiGroup = apiGroup;
-    this.apiVersion = apiVersion;
-    this.resource = resource;
+  KubernetesResource(GroupVersionResource gvr, String subResource, String namespace, String name) {
+    this.groupVersionResource = gvr;
     this.subResource = subResource;
     this.namespace = namespace;
     this.name = name;
   }
 
-  private final String apiGroup;
-  private final String apiVersion;
-  private final String resource;
+  private final GroupVersionResource groupVersionResource;
   private final String subResource;
 
   private final String namespace;
   private final String name;
 
-  public String getApiGroup() {
-    return apiGroup;
-  }
-
-  public String getApiVersion() {
-    return apiVersion;
-  }
-
-  public String getResource() {
-    return resource;
+  public GroupVersionResource getGroupVersionResource() {
+    return groupVersionResource;
   }
 
   public String getSubResource() {

--- a/util/src/main/java/io/kubernetes/client/apimachinery/KubernetesResource.java
+++ b/util/src/main/java/io/kubernetes/client/apimachinery/KubernetesResource.java
@@ -1,0 +1,108 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.apimachinery;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class KubernetesResource {
+
+  public static final Pattern CORE_RESOURCE_URL_PATH_PATTERN =
+      Pattern.compile(
+          "^/api/v1(/namespaces/(?<namespace>[\\w-]+))?/(?<resource>[\\w-]+)(/(?<name>[\\w-]+))?(/(?<subresource>[\\w-]+))?");
+
+  public static final Pattern REGULAR_RESOURCE_URL_PATH_PATTERN =
+      Pattern.compile(
+          "^/apis/(?<group>\\S+?)/(?<version>\\S+?)(/namespaces/(?<namespace>[\\w-]+))?/(?<resource>[\\w-]+)(/(?<name>[\\w-]+))?(/(?<subresource>[\\w-]+))?");
+
+  public static KubernetesResource parseCoreResource(String urlPath)
+      throws ParseKubernetesResourceException {
+    Matcher matcher = CORE_RESOURCE_URL_PATH_PATTERN.matcher(urlPath);
+    if (!matcher.matches()) {
+      throw new ParseKubernetesResourceException();
+    }
+    KubernetesResource resource =
+        new KubernetesResource(
+            "",
+            "v1",
+            matcher.group("resource"),
+            matcher.group("subresource"),
+            matcher.group("namespace"),
+            matcher.group("name"));
+    return resource;
+  }
+
+  public static KubernetesResource parseRegularResource(String urlPath)
+      throws ParseKubernetesResourceException {
+    Matcher matcher = REGULAR_RESOURCE_URL_PATH_PATTERN.matcher(urlPath);
+    if (!matcher.matches()) {
+      throw new ParseKubernetesResourceException();
+    }
+    KubernetesResource resource =
+        new KubernetesResource(
+            matcher.group("group"),
+            matcher.group("version"),
+            matcher.group("resource"),
+            matcher.group("subresource"),
+            matcher.group("namespace"),
+            matcher.group("name"));
+    return resource;
+  }
+
+  KubernetesResource(
+      String apiGroup,
+      String apiVersion,
+      String resource,
+      String subResource,
+      String namespace,
+      String name) {
+    this.apiGroup = apiGroup;
+    this.apiVersion = apiVersion;
+    this.resource = resource;
+    this.subResource = subResource;
+    this.namespace = namespace;
+    this.name = name;
+  }
+
+  private final String apiGroup;
+  private final String apiVersion;
+  private final String resource;
+  private final String subResource;
+
+  private final String namespace;
+  private final String name;
+
+  public String getApiGroup() {
+    return apiGroup;
+  }
+
+  public String getApiVersion() {
+    return apiVersion;
+  }
+
+  public String getResource() {
+    return resource;
+  }
+
+  public String getSubResource() {
+    return subResource;
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public String getName() {
+    return name;
+  }
+}

--- a/util/src/main/java/io/kubernetes/client/apimachinery/KubernetesVerb.java
+++ b/util/src/main/java/io/kubernetes/client/apimachinery/KubernetesVerb.java
@@ -1,0 +1,60 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.apimachinery;
+
+public enum KubernetesVerb {
+  GET("get"),
+  LIST("list"),
+  CREATE("create"),
+  UPDATE("update"),
+  DELETE("delete"),
+  PATCH("patch"),
+  WATCH("watch"),
+  DELETE_COLLECTION("deleteCollection");
+
+  private final String value;
+
+  KubernetesVerb(String value) {
+    this.value = value;
+  }
+
+  public static KubernetesVerb of(
+      String httpVerb, boolean hasNamePathParam, boolean hasWatchParam) {
+    if (hasWatchParam) {
+      return WATCH;
+    }
+    switch (httpVerb) {
+      case "GET":
+        if (!hasNamePathParam) {
+          return LIST;
+        }
+        return GET;
+      case "POST":
+        return CREATE;
+      case "PUT":
+        return UPDATE;
+      case "PATCH":
+        return PATCH;
+      case "DELETE":
+        if (!hasNamePathParam) {
+          return DELETE_COLLECTION;
+        }
+        return DELETE;
+    }
+    throw new IllegalArgumentException("invalid HTTP verb for kubernetes client");
+  }
+
+  public String value() {
+    return value;
+  }
+}

--- a/util/src/main/java/io/kubernetes/client/apimachinery/ParseKubernetesResourceException.java
+++ b/util/src/main/java/io/kubernetes/client/apimachinery/ParseKubernetesResourceException.java
@@ -1,0 +1,15 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.apimachinery;
+
+public class ParseKubernetesResourceException extends Exception {}

--- a/util/src/main/java/io/kubernetes/client/monitoring/PrometheusInterceptor.java
+++ b/util/src/main/java/io/kubernetes/client/monitoring/PrometheusInterceptor.java
@@ -42,8 +42,8 @@ public class PrometheusInterceptor implements Interceptor {
           .help("Kubernetes resource request latency (seconds)")
           .labelNames(
               "http_response_code",
-              "api_group",
-              "api_version",
+              "group",
+              "version",
               "resource",
               "subresource",
               "api_verb",
@@ -73,7 +73,6 @@ public class PrometheusInterceptor implements Interceptor {
     }
 
     codes.labels(Integer.toString(response.code())).inc();
-    ;
 
     if (requestDigest.isNonResourceRequest()) {
       nonResourceRequestLatencyHistogram
@@ -83,9 +82,12 @@ public class PrometheusInterceptor implements Interceptor {
       resourceRequestLatencyHistogram
           .labels(
               Integer.toString(response.code()),
-              Strings.nullToEmpty(requestDigest.getResourceMeta().getApiGroup()),
-              Strings.nullToEmpty(requestDigest.getResourceMeta().getApiVersion()),
-              Strings.nullToEmpty(requestDigest.getResourceMeta().getResource()),
+              Strings.nullToEmpty(
+                  requestDigest.getResourceMeta().getGroupVersionResource().getGroup()),
+              Strings.nullToEmpty(
+                  requestDigest.getResourceMeta().getGroupVersionResource().getVersion()),
+              Strings.nullToEmpty(
+                  requestDigest.getResourceMeta().getGroupVersionResource().getResource()),
               Strings.nullToEmpty(requestDigest.getResourceMeta().getSubResource()),
               requestDigest.getVerb().value(),
               Strings.nullToEmpty(requestDigest.getResourceMeta().getNamespace()))


### PR DESCRIPTION
the new classes are picked from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/651, except for those groovy unit tests..

a sample output from the prometheus example will be:

```
k8s_java_resource_request_latency_seconds_bucket{http_response_code="404",api_group="",api_version="v1",resource="pods",subresource="",api_verb="get",namespace="bar",le="0.005",} 0.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="404",api_group="",api_version="v1",resource="pods",subresource="",api_verb="get",namespace="bar",le="0.01",} 2.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="404",api_group="",api_version="v1",resource="pods",subresource="",api_verb="get",namespace="bar",le="0.025",} 2.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="404",api_group="",api_version="v1",resource="pods",subresource="",api_verb="get",namespace="bar",le="0.05",} 2.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="404",api_group="",api_version="v1",resource="pods",subresource="",api_verb="get",namespace="bar",le="0.075",} 2.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="404",api_group="",api_version="v1",resource="pods",subresource="",api_verb="get",namespace="bar",le="0.1",} 2.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="404",api_group="",api_version="v1",resource="pods",subresource="",api_verb="get",namespace="bar",le="0.25",} 2.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="404",api_group="",api_version="v1",resource="pods",subresource="",api_verb="get",namespace="bar",le="0.5",} 2.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="404",api_group="",api_version="v1",resource="pods",subresource="",api_verb="get",namespace="bar",le="0.75",} 2.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="404",api_group="",api_version="v1",resource="pods",subresource="",api_verb="get",namespace="bar",le="1.0",} 2.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="404",api_group="",api_version="v1",resource="pods",subresource="",api_verb="get",namespace="bar",le="2.5",} 2.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="404",api_group="",api_version="v1",resource="pods",subresource="",api_verb="get",namespace="bar",le="5.0",} 2.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="404",api_group="",api_version="v1",resource="pods",subresource="",api_verb="get",namespace="bar",le="7.5",} 2.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="404",api_group="",api_version="v1",resource="pods",subresource="",api_verb="get",namespace="bar",le="10.0",} 2.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="404",api_group="",api_version="v1",resource="pods",subresource="",api_verb="get",namespace="bar",le="+Inf",} 2.0
k8s_java_resource_request_latency_seconds_count{http_response_code="404",api_group="",api_version="v1",resource="pods",subresource="",api_verb="get",namespace="bar",} 2.0
k8s_java_resource_request_latency_seconds_sum{http_response_code="404",api_group="",api_version="v1",resource="pods",subresource="",api_verb="get",namespace="bar",} 0.014409807
k8s_java_resource_request_latency_seconds_bucket{http_response_code="200",api_group="",api_version="v1",resource="pods",subresource="",api_verb="list",namespace="",le="0.005",} 0.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="200",api_group="",api_version="v1",resource="pods",subresource="",api_verb="list",namespace="",le="0.01",} 0.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="200",api_group="",api_version="v1",resource="pods",subresource="",api_verb="list",namespace="",le="0.025",} 1.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="200",api_group="",api_version="v1",resource="pods",subresource="",api_verb="list",namespace="",le="0.05",} 1.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="200",api_group="",api_version="v1",resource="pods",subresource="",api_verb="list",namespace="",le="0.075",} 1.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="200",api_group="",api_version="v1",resource="pods",subresource="",api_verb="list",namespace="",le="0.1",} 1.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="200",api_group="",api_version="v1",resource="pods",subresource="",api_verb="list",namespace="",le="0.25",} 1.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="200",api_group="",api_version="v1",resource="pods",subresource="",api_verb="list",namespace="",le="0.5",} 1.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="200",api_group="",api_version="v1",resource="pods",subresource="",api_verb="list",namespace="",le="0.75",} 1.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="200",api_group="",api_version="v1",resource="pods",subresource="",api_verb="list",namespace="",le="1.0",} 1.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="200",api_group="",api_version="v1",resource="pods",subresource="",api_verb="list",namespace="",le="2.5",} 1.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="200",api_group="",api_version="v1",resource="pods",subresource="",api_verb="list",namespace="",le="5.0",} 1.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="200",api_group="",api_version="v1",resource="pods",subresource="",api_verb="list",namespace="",le="7.5",} 2.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="200",api_group="",api_version="v1",resource="pods",subresource="",api_verb="list",namespace="",le="10.0",} 2.0
k8s_java_resource_request_latency_seconds_bucket{http_response_code="200",api_group="",api_version="v1",resource="pods",subresource="",api_verb="list",namespace="",le="+Inf",} 2.0
k8s_java_resource_request_latency_seconds_count{http_response_code="200",api_group="",api_version="v1",resource="pods",subresource="",api_verb="list",namespace="",} 2.0
k8s_java_resource_request_latency_seconds_sum{http_response_code="200",api_group="",api_version="v1",resource="pods",subresource="",api_verb="list",namespace="",} 5.198464195000001
```