### PR TITLE
Refactor: Share more codes between kubectl entry methods

### DIFF
--- a/examples/src/main/java/io/kubernetes/client/examples/KubectlExample.java
+++ b/examples/src/main/java/io/kubernetes/client/examples/KubectlExample.java
@@ -96,7 +96,8 @@ public class KubectlExample {
           String[] parts = from.split(":");
           name = parts[0];
           from = parts[1];
-          copy(client)
+          copy()
+              .apiClient(client)
               .namespace(ns)
               .name(name)
               .container(cli.getOptionValue("c", ""))
@@ -107,7 +108,8 @@ public class KubectlExample {
           String[] parts = to.split(":");
           name = parts[0];
           to = parts[1];
-          copy(client)
+          copy()
+              .apiClient(client)
               .namespace(ns)
               .name(name)
               .container(cli.getOptionValue("c", ""))
@@ -133,9 +135,9 @@ public class KubectlExample {
           String effect = ix == -1 ? null : taintSpec.substring(ix + 1);
 
           if (effect == null) {
-            taint(client).name(name).removeTaint(key).execute();
+            taint().apiClient(client).name(name).removeTaint(key).execute();
           } else {
-            taint(client).name(name).removeTaint(key, effect).execute();
+            taint().apiClient(client).name(name).removeTaint(key, effect).execute();
           }
           System.exit(0);
         }
@@ -148,14 +150,14 @@ public class KubectlExample {
         String effect = taintSpec.substring(ix2 + 1);
 
         if (value == null) {
-          taint(client).name(name).addTaint(key, effect).execute();
+          taint().apiClient(client).name(name).addTaint(key, effect).execute();
         } else {
-          taint(client).name(name).addTaint(key, value, effect).execute();
+          taint().apiClient(client).name(name).addTaint(key, value, effect).execute();
         }
         System.exit(0);
       case "portforward":
         name = args[1];
-        KubectlPortForward forward = portforward(client).name(name).namespace(ns);
+        KubectlPortForward forward = portforward().apiClient(client).name(name).namespace(ns);
         for (int i = 2; i < args.length; i++) {
           String port = args[i];
           String[] ports = port.split(":");
@@ -167,7 +169,12 @@ public class KubectlExample {
       case "log":
         name = args[1];
         ByteStreams.copy(
-            log(client).name(name).namespace(ns).container(cli.getOptionValue("c", "")).execute(),
+            log()
+                .apiClient(client)
+                .name(name)
+                .namespace(ns)
+                .container(cli.getOptionValue("c", ""))
+                .execute(),
             System.out);
         System.exit(0);
       case "scale":
@@ -178,11 +185,16 @@ public class KubectlExample {
           System.exit(-3);
         }
         int replicas = Integer.parseInt(cli.getOptionValue("r"));
-        scale(client, getClassForKind(kind)).namespace(ns).name(name).replicas(replicas).execute();
+        scale(getClassForKind(kind))
+            .apiClient(client)
+            .namespace(ns)
+            .name(name)
+            .replicas(replicas)
+            .execute();
         System.out.println("Deployment scaled.");
         System.exit(0);
       case "version":
-        System.out.println(version(client));
+        System.out.println(version().apiClient(client));
         System.exit(0);
       case "label":
         kind = args[1];
@@ -194,20 +206,21 @@ public class KubectlExample {
           System.err.println("Unknown kind: " + kind);
           System.exit(-2);
         }
-        label(client, clazz).namespace(ns).name(name).addLabel(labelKey, labelValue);
+        label(clazz).apiClient(client).namespace(ns).name(name).addLabel(labelKey, labelValue);
         System.exit(0);
       case "exec":
         name = args[1];
         String[] command = Arrays.copyOfRange(args, 2, args.length);
         KubectlExec e =
-            exec(client)
+            exec()
+                .apiClient(client)
                 .namespace(ns)
                 .name(name)
                 .command(command)
                 .container(cli.getOptionValue("c", ""));
         System.exit(e.execute());
       case "api-resources":
-        apiResources(client).execute().stream()
+        apiResources().apiClient(client).execute().stream()
             .forEach(
                 r ->
                     System.out.printf(

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/Kubectl.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/Kubectl.java
@@ -25,16 +25,7 @@ public class Kubectl {
 
   /** Equivalence for `kubectl taint`. */
   public static KubectlTaint taint() {
-    return taint(Configuration.getDefaultApiClient());
-  }
-
-  /**
-   * Equivalence for `kubectl taint`
-   *
-   * @param apiClient The client to use
-   */
-  public static KubectlTaint taint(ApiClient apiClient) {
-    return new KubectlTaint(apiClient);
+    return new KubectlTaint();
   }
 
   /**
@@ -43,17 +34,7 @@ public class Kubectl {
    * @return the kubectl copy
    */
   public static KubectlCopy copy() {
-    return copy(Configuration.getDefaultApiClient());
-  }
-
-  /**
-   * Equivalence for `kubectl cp`.
-   *
-   * @param apiClient the api client instance
-   * @return the kubectl copy
-   */
-  public static KubectlCopy copy(ApiClient apiClient) {
-    return new KubectlCopy(apiClient);
+    return new KubectlCopy();
   }
 
   /**
@@ -65,20 +46,7 @@ public class Kubectl {
    */
   public static <ApiType extends KubernetesObject> KubectlLabel<ApiType> label(
       Class<ApiType> apiTypeClass) {
-    return label(Configuration.getDefaultApiClient(), apiTypeClass);
-  }
-
-  /**
-   * Equivalence for `kubectl label`.
-   *
-   * @param <ApiType> the target api type
-   * @param apiClient the api client instance
-   * @param apiTypeClass the api type class
-   * @return the kubectl label
-   */
-  public static <ApiType extends KubernetesObject> KubectlLabel<ApiType> label(
-      ApiClient apiClient, Class<ApiType> apiTypeClass) {
-    return new KubectlLabel<>(apiClient, apiTypeClass);
+    return new KubectlLabel<>(apiTypeClass);
   }
 
   /**
@@ -90,20 +58,7 @@ public class Kubectl {
    */
   public static <ApiType extends KubernetesObject> KubectlAnnotate<ApiType> annotate(
       Class<ApiType> apiTypeClass) {
-    return annotate(Configuration.getDefaultApiClient(), apiTypeClass);
-  }
-
-  /**
-   * Equivalence for `kubectl annotate`.
-   *
-   * @param <ApiType> the target api type
-   * @param apiClient the api client instance
-   * @param apiTypeClass the api type class
-   * @return the kubectl annotation
-   */
-  public static <ApiType extends KubernetesObject> KubectlAnnotate<ApiType> annotate(
-      ApiClient apiClient, Class<ApiType> apiTypeClass) {
-    return new KubectlAnnotate<>(apiClient, apiTypeClass);
+    return new KubectlAnnotate<>(apiTypeClass);
   }
 
   /**
@@ -112,17 +67,7 @@ public class Kubectl {
    * @return the kubectl version
    */
   public static KubectlVersion version() {
-    return version(Configuration.getDefaultApiClient());
-  }
-
-  /**
-   * Equivalence for `kubectl version`.
-   *
-   * @param apiClient the api client instance
-   * @return the kubectl version
-   */
-  public static KubectlVersion version(ApiClient apiClient) {
-    return new KubectlVersion(apiClient);
+    return new KubectlVersion();
   }
 
   /*
@@ -134,30 +79,7 @@ public class Kubectl {
    */
   public static <ApiType extends KubernetesObject> KubectlScale<ApiType> scale(
       Class<ApiType> apiTypeClass) {
-    return scale(Configuration.getDefaultApiClient(), apiTypeClass);
-  }
-
-  /**
-   * Equivalent for `kubectl scale`
-   *
-   * @param <ApiType> the target api type
-   * @param apiClient The api client instance
-   * @param apiTypeClass the api type class
-   * @return the kubectl scale operator
-   */
-  public static <ApiType extends KubernetesObject> KubectlScale<ApiType> scale(
-      ApiClient apiClient, Class<ApiType> apiTypeClass) {
-    return new KubectlScale<>(apiClient, apiTypeClass);
-  }
-
-  /**
-   * Equivalent for `kubectl exec`
-   *
-   * @param apiClient The api client instance
-   * @return the kubectl exec operator
-   */
-  public static KubectlExec exec(ApiClient apiClient) {
-    return new KubectlExec(apiClient);
+    return new KubectlScale<>(apiTypeClass);
   }
 
   /**
@@ -166,17 +88,7 @@ public class Kubectl {
    * @return the kubectl exec operator
    */
   public static KubectlExec exec() {
-    return exec(Configuration.getDefaultApiClient());
-  }
-
-  /**
-   * Equivalent for `kubectl log`
-   *
-   * @param apiClient The api client instance
-   * @return the kubectl log operator
-   */
-  public static KubectlLog log(ApiClient apiClient) {
-    return new KubectlLog(apiClient);
+    return new KubectlExec();
   }
 
   /**
@@ -185,23 +97,15 @@ public class Kubectl {
    * @return the kubectl log operator
    */
   public static KubectlLog log() {
-    return log(Configuration.getDefaultApiClient());
+    return new KubectlLog();
   }
 
   public static KubectlPortForward portforward() {
-    return portforward(Configuration.getDefaultApiClient());
-  }
-
-  public static KubectlPortForward portforward(ApiClient apiClient) {
-    return new KubectlPortForward(apiClient);
+    return new KubectlPortForward();
   }
 
   public static KubectlApiResources apiResources() {
-    return apiResources(Configuration.getDefaultApiClient());
-  }
-
-  public static KubectlApiResources apiResources(ApiClient apiClient) {
-    return new KubectlApiResources(apiClient);
+    return new KubectlApiResources();
   }
 
   /**
@@ -220,9 +124,19 @@ public class Kubectl {
     OUTPUT execute() throws KubectlException;
   }
 
+  abstract static class ApiClientBuilder<T extends ApiClientBuilder> {
+
+    ApiClient apiClient = Configuration.getDefaultApiClient();
+
+    public T apiClient(ApiClient apiClient) {
+      this.apiClient = apiClient;
+      return (T) this;
+    }
+  }
+
   abstract static class ResourceBuilder<
-      ApiType extends KubernetesObject, T extends ResourceBuilder<ApiType, T>> {
-    final ApiClient apiClient;
+          ApiType extends KubernetesObject, T extends ResourceBuilder<ApiType, T>>
+      extends ApiClientBuilder<T> {
     final Class<ApiType> apiTypeClass;
     String namespace;
     String name;
@@ -230,8 +144,7 @@ public class Kubectl {
     String apiVersion;
     String resourceNamePlural;
 
-    ResourceBuilder(ApiClient client, Class<ApiType> apiTypeClass) {
-      this.apiClient = client;
+    ResourceBuilder(Class<ApiType> apiTypeClass) {
       this.apiTypeClass = apiTypeClass;
     }
 
@@ -266,8 +179,8 @@ public class Kubectl {
       extends ResourceBuilder<ApiType, T> {
     String container;
 
-    ResourceAndContainerBuilder(ApiClient client, Class<ApiType> apiTypeClass) {
-      super(client, apiTypeClass);
+    ResourceAndContainerBuilder(Class<ApiType> apiTypeClass) {
+      super(apiTypeClass);
     }
 
     public T container(String container) {

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlAnnotate.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlAnnotate.java
@@ -15,7 +15,6 @@ package io.kubernetes.client.extended.kubectl;
 import io.kubernetes.client.common.KubernetesListObject;
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.extended.kubectl.exception.KubectlException;
-import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.util.annotations.Annotations;
 import io.kubernetes.client.util.generic.GenericKubernetesApi;
 import io.kubernetes.client.util.generic.KubernetesApiResponse;
@@ -29,8 +28,8 @@ public class KubectlAnnotate<ApiType extends KubernetesObject>
 
   private final Map<String, String> addingAnnotations;
 
-  KubectlAnnotate(ApiClient apiClient, Class<ApiType> apiTypeClass) {
-    super(apiClient, apiTypeClass);
+  KubectlAnnotate(Class<ApiType> apiTypeClass) {
+    super(apiTypeClass);
     this.addingAnnotations = new HashMap<>();
   }
 

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlApiResources.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlApiResources.java
@@ -14,22 +14,17 @@ package io.kubernetes.client.extended.kubectl;
 
 import io.kubernetes.client.Discovery;
 import io.kubernetes.client.extended.kubectl.exception.KubectlException;
-import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import java.util.Set;
 
-public class KubectlApiResources implements Kubectl.Executable<Set<Discovery.APIResource>> {
-
-  private final Discovery discovery;
-
-  KubectlApiResources(ApiClient apiClient) {
-    this.discovery = new Discovery(apiClient);
-  }
+public class KubectlApiResources extends Kubectl.ApiClientBuilder<KubectlApiResources>
+    implements Kubectl.Executable<Set<Discovery.APIResource>> {
 
   @Override
   public Set<Discovery.APIResource> execute() throws KubectlException {
+    Discovery discovery = new Discovery(this.apiClient);
     try {
-      return this.discovery.findAll();
+      return discovery.findAll();
     } catch (ApiException e) {
       throw new KubectlException(e);
     }

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlCopy.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlCopy.java
@@ -16,7 +16,6 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 
 import io.kubernetes.client.Copy;
 import io.kubernetes.client.extended.kubectl.exception.KubectlException;
-import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.util.exception.CopyNotSupportedException;
@@ -30,8 +29,8 @@ public class KubectlCopy extends Kubectl.ResourceAndContainerBuilder<V1Pod, Kube
   private Boolean toPod;
   private boolean dir;
 
-  KubectlCopy(ApiClient client) {
-    super(client, V1Pod.class);
+  KubectlCopy() {
+    super(V1Pod.class);
     this.toPod = null;
   }
 

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlExec.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlExec.java
@@ -15,7 +15,6 @@ package io.kubernetes.client.extended.kubectl;
 import com.google.common.io.ByteStreams;
 import io.kubernetes.client.Exec;
 import io.kubernetes.client.extended.kubectl.exception.KubectlException;
-import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
@@ -29,8 +28,8 @@ public class KubectlExec extends Kubectl.ResourceAndContainerBuilder<V1Pod, Kube
   private boolean stdin;
   private boolean tty;
 
-  KubectlExec(ApiClient client) {
-    super(client, V1Pod.class);
+  KubectlExec() {
+    super(V1Pod.class);
   }
 
   public KubectlExec command(String[] command) {

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlLabel.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlLabel.java
@@ -15,7 +15,6 @@ package io.kubernetes.client.extended.kubectl;
 import io.kubernetes.client.common.KubernetesListObject;
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.extended.kubectl.exception.KubectlException;
-import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.util.generic.GenericKubernetesApi;
 import io.kubernetes.client.util.generic.KubernetesApiResponse;
 import io.kubernetes.client.util.labels.Labels;
@@ -29,8 +28,8 @@ public class KubectlLabel<ApiType extends KubernetesObject>
 
   private final Map<String, String> addingLabels;
 
-  KubectlLabel(ApiClient apiClient, Class<ApiType> apiTypeClass) {
-    super(apiClient, apiTypeClass);
+  KubectlLabel(Class<ApiType> apiTypeClass) {
+    super(apiTypeClass);
     this.addingLabels = new HashMap<>();
   }
 

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlLog.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlLog.java
@@ -16,7 +16,6 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 
 import io.kubernetes.client.PodLogs;
 import io.kubernetes.client.extended.kubectl.exception.KubectlException;
-import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1Pod;
 import java.io.IOException;
@@ -24,10 +23,9 @@ import java.io.InputStream;
 
 public class KubectlLog extends Kubectl.ResourceAndContainerBuilder<V1Pod, KubectlLog>
     implements Kubectl.Executable<InputStream> {
-  private InputStream result;
 
-  KubectlLog(ApiClient client) {
-    super(client, V1Pod.class);
+  KubectlLog() {
+    super(V1Pod.class);
   }
 
   @Override

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlPortForward.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlPortForward.java
@@ -16,7 +16,6 @@ import static io.kubernetes.client.extended.kubectl.KubectlExec.copyAsync;
 
 import io.kubernetes.client.PortForward;
 import io.kubernetes.client.extended.kubectl.exception.KubectlException;
-import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1Pod;
 import java.io.IOException;
@@ -34,8 +33,8 @@ public class KubectlPortForward
   List<Integer> targetPorts;
   boolean running;
 
-  KubectlPortForward(ApiClient client) {
-    super(client, V1Pod.class);
+  KubectlPortForward() {
+    super(V1Pod.class);
 
     localPorts = new ArrayList<>();
     targetPorts = new ArrayList<>();

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlScale.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlScale.java
@@ -15,7 +15,6 @@ package io.kubernetes.client.extended.kubectl;
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.extended.kubectl.exception.KubectlException;
-import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.models.V1Deployment;
@@ -25,12 +24,10 @@ import io.kubernetes.client.util.PatchUtils;
 public class KubectlScale<ApiType extends KubernetesObject>
     extends Kubectl.ResourceBuilder<ApiType, KubectlScale<ApiType>>
     implements Kubectl.Executable<ApiType> {
-  private final AppsV1Api api;
   private int replicas;
 
-  KubectlScale(ApiClient client, Class<ApiType> apiTypeClass) {
-    super(client, apiTypeClass);
-    this.api = new AppsV1Api(client);
+  KubectlScale(Class<ApiType> apiTypeClass) {
+    super(apiTypeClass);
     this.replicas = -1;
   }
 
@@ -46,10 +43,11 @@ public class KubectlScale<ApiType extends KubernetesObject>
     String jsonPatchStr =
         String.format("[{\"op\":\"replace\",\"path\":\"/spec/replicas\",\"value\":%d}]", replicas);
 
+    AppsV1Api api = new AppsV1Api(this.apiClient);
     try {
       if (apiTypeClass.equals(V1Deployment.class)) {
         return PatchUtils.patch(
-            (Class<ApiType>) apiTypeClass,
+            apiTypeClass,
             () ->
                 api.patchNamespacedDeploymentCall(
                     name,
@@ -64,7 +62,7 @@ public class KubectlScale<ApiType extends KubernetesObject>
             this.apiClient);
       } else if (apiTypeClass.equals(V1ReplicaSet.class)) {
         return PatchUtils.patch(
-            (Class<ApiType>) apiTypeClass,
+            apiTypeClass,
             () ->
                 api.patchNamespacedReplicaSetCall(
                     name, namespace, new V1Patch(jsonPatchStr), null, null, null, null, null),

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlTaint.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlTaint.java
@@ -13,7 +13,6 @@ limitations under the License.
 package io.kubernetes.client.extended.kubectl;
 
 import io.kubernetes.client.extended.kubectl.exception.KubectlException;
-import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Node;
@@ -32,8 +31,8 @@ public class KubectlTaint extends Kubectl.ResourceBuilder<V1Node, KubectlTaint>
   private final Map<String, Pair<String, String>> addingTaints;
   private final Map<String, String> removeTaints;
 
-  KubectlTaint(ApiClient apiClient) {
-    super(apiClient, V1Node.class);
+  KubectlTaint() {
+    super(V1Node.class);
     this.addingTaints = new HashMap<>();
     this.removeTaints = new HashMap<>();
   }

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlVersion.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlVersion.java
@@ -13,24 +13,19 @@ limitations under the License.
 package io.kubernetes.client.extended.kubectl;
 
 import io.kubernetes.client.extended.kubectl.exception.KubectlException;
-import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.VersionInfo;
 import io.kubernetes.client.util.version.Version;
 import java.io.IOException;
 
-public class KubectlVersion implements Kubectl.Executable<VersionInfo> {
-
-  private final Version version;
-
-  KubectlVersion(ApiClient apiClient) {
-    this.version = new Version(apiClient);
-  }
+public class KubectlVersion extends Kubectl.ApiClientBuilder<KubectlVersion>
+    implements Kubectl.Executable<VersionInfo> {
 
   @Override
   public VersionInfo execute() throws KubectlException {
+    Version version = new Version(apiClient);
     try {
-      return this.version.getVersion();
+      return version.getVersion();
     } catch (ApiException | IOException e) {
       throw new KubectlException(e);
     }

--- a/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlAnnotateTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlAnnotateTest.java
@@ -53,7 +53,8 @@ public class KubectlAnnotateTest {
                     .withStatus(200)
                     .withBody("{\"metadata\":{\"name\":\"foo\",\"namespace\":\"default\"}}")));
     V1Pod annotatedPod =
-        Kubectl.annotate(apiClient, V1Pod.class)
+        Kubectl.annotate(V1Pod.class)
+            .apiClient(apiClient)
             .apiGroup("")
             .apiVersion("v1")
             .resourceNamePlural("pods")
@@ -82,7 +83,8 @@ public class KubectlAnnotateTest {
     assertThrows(
         KubectlException.class,
         () -> {
-          Kubectl.annotate(apiClient, V1Pod.class)
+          Kubectl.annotate(V1Pod.class)
+              .apiClient(apiClient)
               .apiGroup("")
               .apiVersion("v1")
               .resourceNamePlural("pods")
@@ -105,7 +107,8 @@ public class KubectlAnnotateTest {
         put(urlPathEqualTo("/api/v1/nodes/foo"))
             .willReturn(aResponse().withStatus(200).withBody("{\"metadata\":{\"name\":\"foo\"}}")));
     V1Node annotatedNode =
-        Kubectl.annotate(apiClient, V1Node.class)
+        Kubectl.annotate(V1Node.class)
+            .apiClient(apiClient)
             .apiGroup("")
             .apiVersion("v1")
             .resourceNamePlural("nodes")
@@ -130,7 +133,8 @@ public class KubectlAnnotateTest {
     assertThrows(
         KubectlException.class,
         () -> {
-          Kubectl.annotate(apiClient, V1Node.class)
+          Kubectl.annotate(V1Node.class)
+              .apiClient(apiClient)
               .apiGroup("")
               .apiVersion("v1")
               .resourceNamePlural("nodes")
@@ -148,7 +152,8 @@ public class KubectlAnnotateTest {
     assertThrows(
         KubectlException.class,
         () -> {
-          Kubectl.annotate(apiClient, V1Node.class)
+          Kubectl.annotate(V1Node.class)
+              .apiClient(apiClient)
               // .apiGroup("")  # missing apiGroup
               .apiVersion("v1")
               .resourceNamePlural("nodes")
@@ -160,7 +165,8 @@ public class KubectlAnnotateTest {
     assertThrows(
         KubectlException.class,
         () -> {
-          Kubectl.annotate(apiClient, V1Node.class)
+          Kubectl.annotate(V1Node.class)
+              .apiClient(apiClient)
               .apiGroup("")
               // .apiVersion("v1") # missing apiVersion
               .resourceNamePlural("nodes")
@@ -172,7 +178,8 @@ public class KubectlAnnotateTest {
     assertThrows(
         KubectlException.class,
         () -> {
-          Kubectl.annotate(apiClient, V1Node.class)
+          Kubectl.annotate(V1Node.class)
+              .apiClient(apiClient)
               .apiGroup("")
               .apiVersion("v1")
               // .resourceNamePlural("nodes") # missing resourceNamePlural
@@ -184,7 +191,8 @@ public class KubectlAnnotateTest {
     assertThrows(
         KubectlException.class,
         () -> {
-          Kubectl.annotate(apiClient, V1Node.class)
+          Kubectl.annotate(V1Node.class)
+              .apiClient(apiClient)
               .apiGroup("")
               .apiVersion("v1")
               .resourceNamePlural("nodes")

--- a/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlLabelTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlLabelTest.java
@@ -54,7 +54,8 @@ public class KubectlLabelTest {
                     .withStatus(200)
                     .withBody("{\"metadata\":{\"name\":\"foo\",\"namespace\":\"default\"}}")));
     V1Pod labelledPod =
-        Kubectl.label(apiClient, V1Pod.class)
+        Kubectl.label(V1Pod.class)
+            .apiClient(apiClient)
             .apiGroup("")
             .apiVersion("v1")
             .resourceNamePlural("pods")
@@ -83,7 +84,8 @@ public class KubectlLabelTest {
     assertThrows(
         KubectlException.class,
         () -> {
-          Kubectl.label(apiClient, V1Pod.class)
+          Kubectl.label(V1Pod.class)
+              .apiClient(apiClient)
               .apiGroup("")
               .apiVersion("v1")
               .resourceNamePlural("pods")
@@ -106,7 +108,8 @@ public class KubectlLabelTest {
         put(urlPathEqualTo("/api/v1/nodes/foo"))
             .willReturn(aResponse().withStatus(200).withBody("{\"metadata\":{\"name\":\"foo\"}}")));
     V1Node labelledNode =
-        Kubectl.label(apiClient, V1Node.class)
+        Kubectl.label(V1Node.class)
+            .apiClient(apiClient)
             .apiGroup("")
             .apiVersion("v1")
             .resourceNamePlural("nodes")
@@ -131,7 +134,8 @@ public class KubectlLabelTest {
     assertThrows(
         KubectlException.class,
         () -> {
-          Kubectl.label(apiClient, V1Node.class)
+          Kubectl.label(V1Node.class)
+              .apiClient(apiClient)
               .apiGroup("")
               .apiVersion("v1")
               .resourceNamePlural("nodes")
@@ -149,7 +153,8 @@ public class KubectlLabelTest {
     assertThrows(
         KubectlException.class,
         () -> {
-          Kubectl.label(apiClient, V1Node.class)
+          Kubectl.label(V1Node.class)
+              .apiClient(apiClient)
               // .apiGroup("")  # missing apiGroup
               .apiVersion("v1")
               .resourceNamePlural("nodes")
@@ -161,7 +166,8 @@ public class KubectlLabelTest {
     assertThrows(
         KubectlException.class,
         () -> {
-          Kubectl.label(apiClient, V1Node.class)
+          Kubectl.label(V1Node.class)
+              .apiClient(apiClient)
               .apiGroup("")
               // .apiVersion("v1") # missing apiVersion
               .resourceNamePlural("nodes")
@@ -173,7 +179,8 @@ public class KubectlLabelTest {
     assertThrows(
         KubectlException.class,
         () -> {
-          Kubectl.label(apiClient, V1Node.class)
+          Kubectl.label(V1Node.class)
+              .apiClient(apiClient)
               .apiGroup("")
               .apiVersion("v1")
               // .resourceNamePlural("nodes") # missing resourceNamePlural
@@ -185,7 +192,8 @@ public class KubectlLabelTest {
     assertThrows(
         KubectlException.class,
         () -> {
-          Kubectl.label(apiClient, V1Node.class)
+          Kubectl.label(V1Node.class)
+              .apiClient(apiClient)
               .apiGroup("")
               .apiVersion("v1")
               .resourceNamePlural("nodes")

--- a/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlScaleTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlScaleTest.java
@@ -50,7 +50,8 @@ public class KubectlScaleTest {
                     .withStatus(200)
                     .withBody("{\"metadata\":{\"name\":\"foo\",\"namespace\":\"default\"}}")));
     V1Deployment scaled =
-        Kubectl.scale(apiClient, V1Deployment.class)
+        Kubectl.scale(V1Deployment.class)
+            .apiClient(apiClient)
             .name("foo")
             .namespace("default")
             .replicas(2)
@@ -71,9 +72,13 @@ public class KubectlScaleTest {
                 aResponse()
                     .withStatus(200)
                     .withBody("{\"metadata\":{\"name\":\"foo\",\"namespace\":\"default\"}}")));
-    KubectlScale<V1ReplicaSet> s =
-        Kubectl.scale(apiClient, V1ReplicaSet.class).replicas(4).name("foo").namespace("default");
-    V1ReplicaSet scaled = s.execute();
+    V1ReplicaSet scaled =
+        Kubectl.scale(V1ReplicaSet.class)
+            .apiClient(apiClient)
+            .replicas(4)
+            .name("foo")
+            .namespace("default")
+            .execute();
     wireMockRule.verify(
         1,
         patchRequestedFor(urlPathEqualTo("/apis/apps/v1/namespaces/default/replicasets/foo"))
@@ -88,7 +93,8 @@ public class KubectlScaleTest {
         KubectlException.class,
         () -> {
           V1Pod scaled =
-              Kubectl.scale(apiClient, V1Pod.class)
+              Kubectl.scale(V1Pod.class)
+                  .apiClient(apiClient)
                   .name("foo")
                   .namespace("default")
                   .replicas(2)


### PR DESCRIPTION
move those redundant `KubectlXXX(ApiClient)` entry methods to a `ApiClientBuilder` abstract base class to share more codes