### PR TITLE
fix issue 912: do dedupe with resourceVersion

### DIFF
--- a/util/src/main/java/io/kubernetes/client/informer/cache/DeltaFIFO.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/DeltaFIFO.java
@@ -447,7 +447,8 @@ public class DeltaFIFO {
     MutablePair<DeltaType, KubernetesObject> deletionDelta = isDeletionDup(d1, d2);
 
     // TODO: remove this after the cause of memory leakage is confirmed
-    // Squashing deltas w/ the same resource version, note that is a temporary fix that eases memory intensity.
+    // Squashing deltas w/ the same resource version, note that is a temporary fix that eases memory
+    // intensity.
     if (deletionDelta != null) {
       return deletionDelta;
     }

--- a/util/src/main/java/io/kubernetes/client/informer/cache/DeltaFIFO.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/DeltaFIFO.java
@@ -448,8 +448,11 @@ public class DeltaFIFO {
     if (deletionDelta != null) {
       return deletionDelta;
     }
-    if (d1.getLeft() != DeltaType.Deleted && d2.getLeft() != DeltaType.Deleted &&
-            StringUtils.equals(d1.getRight().getMetadata().getResourceVersion(), d2.getRight().getMetadata().getResourceVersion())) {
+    if (d1.getLeft() != DeltaType.Deleted
+        && d2.getLeft() != DeltaType.Deleted
+        && StringUtils.equals(
+            d1.getRight().getMetadata().getResourceVersion(),
+            d2.getRight().getMetadata().getResourceVersion())) {
       return d1;
     }
     return null;

--- a/util/src/main/java/io/kubernetes/client/informer/cache/DeltaFIFO.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/DeltaFIFO.java
@@ -29,6 +29,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -443,7 +444,15 @@ public class DeltaFIFO {
    */
   private MutablePair<DeltaType, KubernetesObject> isDuplicate(
       MutablePair<DeltaType, KubernetesObject> d1, MutablePair<DeltaType, KubernetesObject> d2) {
-    return isDeletionDup(d1, d2);
+    MutablePair<DeltaType, KubernetesObject> deletionDelta = isDeletionDup(d1, d2);
+    if (deletionDelta != null) {
+      return deletionDelta;
+    }
+    if (d1.getLeft() != DeltaType.Deleted && d2.getLeft() != DeltaType.Deleted &&
+            StringUtils.equals(d1.getRight().getMetadata().getResourceVersion(), d2.getRight().getMetadata().getResourceVersion())) {
+      return d1;
+    }
+    return null;
   }
 
   /**

--- a/util/src/main/java/io/kubernetes/client/informer/cache/DeltaFIFO.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/DeltaFIFO.java
@@ -445,6 +445,9 @@ public class DeltaFIFO {
   private MutablePair<DeltaType, KubernetesObject> isDuplicate(
       MutablePair<DeltaType, KubernetesObject> d1, MutablePair<DeltaType, KubernetesObject> d2) {
     MutablePair<DeltaType, KubernetesObject> deletionDelta = isDeletionDup(d1, d2);
+
+    // TODO: remove this after the cause of memory leakage is confirmed
+    // Squashing deltas w/ the same resource version, note that is a temporary fix that eases memory intensity.
     if (deletionDelta != null) {
       return deletionDelta;
     }

--- a/util/src/test/java/io/kubernetes/client/informer/cache/DeltaFIFOTest.java
+++ b/util/src/test/java/io/kubernetes/client/informer/cache/DeltaFIFOTest.java
@@ -95,7 +95,9 @@ public class DeltaFIFOTest {
 
   @Test
   public void testDeltaFIFODedup() {
-    V1Pod foo1 = new V1Pod().metadata(new V1ObjectMeta().name("foo1").namespace("default").resourceVersion("ver"));
+    V1Pod foo1 =
+        new V1Pod()
+            .metadata(new V1ObjectMeta().name("foo1").namespace("default").resourceVersion("ver"));
     Cache cache = new Cache();
     DeltaFIFO deltaFIFO = new DeltaFIFO(Caches::deletionHandlingMetaNamespaceKeyFunc, cache);
     Deque<MutablePair<DeltaFIFO.DeltaType, KubernetesObject>> deltas;


### PR DESCRIPTION
reason: on timeout-reconnect it will add new a new copy to all objects in FIFO items map.
fix: check resourceVersion when adding object copy, skip if newly added object has same resourceVersion with previous latest object.