### PR TITLE
Provide base images for saving installation time

### DIFF
--- a/client-java-contrib/Dockerfile
+++ b/client-java-contrib/Dockerfile
@@ -8,7 +8,9 @@ RUN apk add --no-cache git bash && \
     chmod +x /usr/bin/kubectl && \
     git clone https://github.com/kubernetes-client/gen.git
 
+COPY Dockerfile.gen gen/openapi/openapi-generator/Dockerfile
 COPY generate.sh generate.sh
+
 RUN chmod +x generate.sh
 
 WORKDIR gen/openapi

--- a/client-java-contrib/Dockerfile.gen
+++ b/client-java-contrib/Dockerfile.gen
@@ -1,0 +1,14 @@
+FROM ghcr.io/yue9944882/crd-model-gen-base:v1.0.0
+# TODO: move this to kubernetes-client group after the permission issue fixed
+
+ARG OPENAPI_GENERATOR_COMMIT
+ARG GENERATION_XML_FILE
+ARG OPENAPI_GENERATOR_USER_ORG=OpenAPITools
+
+# Copy required files
+COPY openapi-generator/generate_client_in_container.sh /generate_client.sh
+COPY preprocess_spec.py /
+COPY custom_objects_spec.json /
+COPY ${GENERATION_XML_FILE} /generation_params.xml
+
+ENTRYPOINT ["mvn-entrypoint.sh", "/generate_client.sh"]

--- a/client-java-contrib/Dockerfile.gen-base
+++ b/client-java-contrib/Dockerfile.gen-base
@@ -1,0 +1,40 @@
+FROM maven:3.5-jdk-8-slim
+
+# Install preprocessing script requirements
+RUN apt-get update && apt-get -y install git python-pip && pip install urllib3==1.24.2
+
+# Install Autorest
+RUN apt-get update && apt-get -qq -y install libunwind8 libicu57 libssl1.0 liblttng-ust0 libcurl3 libuuid1 libkrb5-3 zlib1g gnupg2
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN apt-get update && apt-get -y install \
+    nodejs \
+    libunwind8-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g autorest@3
+
+# Check out specific commit of openapi-generator
+RUN mkdir /source && \
+    cd /source && \
+    git clone -n https://github.com/${OPENAPI_GENERATOR_USER_ORG}/openapi-generator.git && \
+    cd openapi-generator && \
+    git checkout $OPENAPI_GENERATOR_COMMIT
+
+# Build it and persist local repository
+RUN mkdir /.npm && chmod -R go+rwx /.npm && chmod -R go+rwx /root && umask 0 && cd /source/openapi-generator && \
+    mvn install -DskipTests -Dmaven.test.skip=true -pl modules/openapi-generator-maven-plugin -am && \
+    cp -r /root/.m2/* /usr/share/maven/ref
+
+RUN mkdir -p /node_modules && chmod -R go+rwx /node_modules
+RUN npm install @microsoft.azure/autorest.csharp \
+                @microsoft.azure/autorest.modeler
+
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg
+RUN mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/
+RUN curl https://packages.microsoft.com/config/debian/9/prod.list > prod.list
+RUN mv prod.list /etc/apt/sources.list.d/microsoft-prod.list
+RUN chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg
+RUN chown root:root /etc/apt/sources.list.d/microsoft-prod.list
+
+RUN apt-get update
+RUN apt-get install -yy -q dotnet-hosting-2.0.8

--- a/client-java-contrib/cert-manager/update.sh
+++ b/client-java-contrib/cert-manager/update.sh
@@ -17,7 +17,7 @@
 # under src/main/java/io/cert/manager/models.
 
 DEFAULT_IMAGE_NAME=docker.pkg.github.com/kubernetes-client/java/crd-model-gen
-DEFAULT_IMAGE_TAG=v1.0.2
+DEFAULT_IMAGE_TAG=v1.0.3
 IMAGE_NAME=${IMAGE_NAME:=$DEFAULT_IMAGE_NAME}
 IMAGE_TAG=${IMAGE_TAG:=$DEFAULT_IMAGE_TAG}
 

--- a/client-java-contrib/prometheus-operator/update.sh
+++ b/client-java-contrib/prometheus-operator/update.sh
@@ -17,7 +17,7 @@
 # under src/main/java/io/cert/manager/models.
 
 DEFAULT_IMAGE_NAME=docker.pkg.github.com/kubernetes-client/java/crd-model-gen
-DEFAULT_IMAGE_TAG=v1.0.2
+DEFAULT_IMAGE_TAG=v1.0.3
 IMAGE_NAME=${IMAGE_NAME:=$DEFAULT_IMAGE_NAME}
 IMAGE_TAG=${IMAGE_TAG:=$DEFAULT_IMAGE_TAG}
 

--- a/client-java-contrib/publish-gen-image.sh
+++ b/client-java-contrib/publish-gen-image.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+GEN_BASE_IMAGE_NAME=ghcr.io/yue9944882/crd-model-gen-base  # TODO: move this to kubernetes-client group after the permission issue fixed
+GEN_BASE_IMAGE_VERSION=v1.0.0
+
+docker build -t ${GEN_BASE_IMAGE_NAME}:${GEN_BASE_IMAGE_VERSION} .
+docker push ${GEN_BASE_IMAGE_NAME}:${GEN_BASE_IMAGE_VERSION}
+
+GEN_IMAGE_NAME=docker.pkg.github.com/kubernetes-client/java/crd-model-gen
+GEN_IMAGE_VERSION=v1.0.3
+
+docker build -t ${GEN_IMAGE_NAME}:${GEN_IMAGE_VERSION} .
+docker push ${GEN_IMAGE_NAME}:${GEN_IMAGE_VERSION}

--- a/docs/generate-model-from-third-party-resources.md
+++ b/docs/generate-model-from-third-party-resources.md
@@ -7,6 +7,10 @@ and [KubernetesListObject](https://github.com/kubernetes-client/java/blob/master
 
 ### Setup Environment
 
+__Note__: You can skip this section by replacing image prefix `docker.pkg.github.com/kubernetes-client/java/..`
+to `ghcr.io/yue9944882/..` which is a mirror repository allows anonymous access. `docker.pkg.github.com/kubernetes-client/java/..`
+will require docker-login due to `kubernetes-client` permission limit.
+
 1. Make there's an active docker daemon service working on your host, run `docker ps` to check it if
 it's correctly setup.
 
@@ -53,7 +57,7 @@ docker run \
   -v "$(pwd)":"$(pwd)" \
   -ti \
   --network host \
-  docker.pkg.github.com/kubernetes-client/java/crd-model-gen:v1.0.2 \
+  docker.pkg.github.com/kubernetes-client/java/crd-model-gen:v1.0.3 \
   /generate.sh \
   -u https://gist.githubusercontent.com/yue9944882/266fee8e95c2f15a93778263633e72ed/raw/be12c13379eeed13d2532cb65da61fffb19ee3e7/crontab-crd.yaml \
   -n com.example.stable \
@@ -84,7 +88,7 @@ docker run \
   -v "$(pwd)":"$(pwd)" \
   -ti \
   --network host \
-  docker.pkg.github.com/kubernetes-client/java/crd-model-gen:v1.0.2 \
+  docker.pkg.github.com/kubernetes-client/java/crd-model-gen:v1.0.3 \
   /generate.sh \
   -u $LOCAL_MANIFEST_FILE \
   -n com.example.stable \


### PR DESCRIPTION
making `docker.pkg.github.com/..` images public requires `kubernetes-client` admin access so i copied the images under my repository so that users can pull anonymously..

@brendandburns @kumars17
