### PR TITLE
reflector: fix watch timeout by using it as seconds unit

### DIFF
--- a/util/src/main/java/io/kubernetes/client/informer/cache/ReflectorRunnable.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/ReflectorRunnable.java
@@ -103,7 +103,7 @@ public class ReflectorRunnable<
                   new CallGeneratorParams(
                       Boolean.TRUE,
                       lastSyncResourceVersion,
-                      Long.valueOf(Duration.ofMinutes(5).toMillis()).intValue()));
+                      Long.valueOf(Duration.ofMinutes(5).getSeconds()).intValue()));
 
           synchronized (this) {
             if (!isActive.get()) {


### PR DESCRIPTION
Reflector Runnable is using timeout duration as millis value rather than seconds as mentioned in [api references](https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#watch-deployment-v1-apps).

@brendanburns @yue9944882 