### PR TITLE
fix a simple para error in an example

### DIFF
--- a/examples/src/main/java/io/kubernetes/client/examples/Example.java
+++ b/examples/src/main/java/io/kubernetes/client/examples/Example.java
@@ -36,7 +36,7 @@ public class Example {
 
     CoreV1Api api = new CoreV1Api();
     V1PodList list =
-        api.listPodForAllNamespaces(null, null, null, null, null, null, null, null, null, null);
+        api.listPodForAllNamespaces(null, null, null, null, null, null, null, null, null);
     for (V1Pod item : list.getItems()) {
       System.out.println(item.getMetadata().getName());
     }


### PR DESCRIPTION
listPodForAllNamespaces in the base example should have 9 paras but has 10 paras.