### PR TITLE
Doc: Use module name directly instead of symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,48 +73,48 @@ Consider either catch and ignore the JsonSyntaxException or do the deletion in t
 
 We prepared a few examples for common use-cases which are shown below:
 - __Configuration__:
-  - [InClusterClientExample](./examples/examples-release-last/src/main/java/io/kubernetes/client/examples/InClusterClientExample.java): 
+  - [InClusterClientExample](./examples/examples-release-10/src/main/java/io/kubernetes/client/examples/InClusterClientExample.java): 
   Configure a client while running inside the Kubernetes cluster.
-  - [KubeConfigFileClientExample](./examples/examples-release-last/src/main/java/io/kubernetes/client/examples/KubeConfigFileClientExample.java): 
+  - [KubeConfigFileClientExample](./examples/examples-release-10/src/main/java/io/kubernetes/client/examples/KubeConfigFileClientExample.java): 
   Configure a client to access a Kubernetes cluster from outside.
 - __Basics__:
-  - [SimpleExample](./examples/examples-release-last/src/main/java/io/kubernetes/client/examples/Example.java):
+  - [SimpleExample](./examples/examples-release-10/src/main/java/io/kubernetes/client/examples/Example.java):
   Simple minimum example of how to use the client.
-  - [ProtoExample](./examples/examples-release-last/src/main/java/io/kubernetes/client/examples/ProtoExample.java): 
+  - [ProtoExample](./examples/examples-release-10/src/main/java/io/kubernetes/client/examples/ProtoExample.java): 
   Request/receive payloads in protobuf serialization protocol.
-  - ([5.0.0+](https://github.com/kubernetes-client/java/tree/client-java-parent-5.0.0)) [PatchExample](./examples/examples-release-last/src/main/java/io/kubernetes/client/examples/PatchExample.java): 
+  - ([5.0.0+](https://github.com/kubernetes-client/java/tree/client-java-parent-5.0.0)) [PatchExample](./examples/examples-release-10/src/main/java/io/kubernetes/client/examples/PatchExample.java): 
   Patch resource objects in various supported patch formats, equal to `kubectl patch`.
-  - [FluentExample](./examples/examples-release-last/src/main/java/io/kubernetes/client/examples/FluentExample.java): 
+  - [FluentExample](./examples/examples-release-10/src/main/java/io/kubernetes/client/examples/FluentExample.java): 
   Construct arbitrary resource in a fluent builder style.
-  - [YamlExample](./examples/examples-release-last/src/main/java/io/kubernetes/client/examples/YamlExample.java): 
+  - [YamlExample](./examples/examples-release-10/src/main/java/io/kubernetes/client/examples/YamlExample.java): 
   Suggested way to load or dump resource in Yaml.
 - __Streaming__:
-  - [WatchExample](./examples/examples-release-last/src/main/java/io/kubernetes/client/examples/WatchExample.java): 
+  - [WatchExample](./examples/examples-release-10/src/main/java/io/kubernetes/client/examples/WatchExample.java): 
   Subscribe watch events from certain resources, equal to `kubectl get <resource> -w`.
-  - [LogsExample](./examples/examples-release-last/src/main/java/io/kubernetes/client/examples/LogsExample.java): 
+  - [LogsExample](./examples/examples-release-10/src/main/java/io/kubernetes/client/examples/LogsExample.java): 
   Fetch logs from running containers, equal to `kubectl logs`.
-  - [ExecExample](./examples/examples-release-last/src/main/java/io/kubernetes/client/examples/ExecExample.java): 
+  - [ExecExample](./examples/examples-release-10/src/main/java/io/kubernetes/client/examples/ExecExample.java): 
   Establish an "exec" session with running containers, equal to `kubectl exec`.
-  - [PortForwardExample](./examples/examples-release-last/src/main/java/io/kubernetes/client/examples/PortForwardExample.java): 
+  - [PortForwardExample](./examples/examples-release-10/src/main/java/io/kubernetes/client/examples/PortForwardExample.java): 
   Maps local port to a port on the pod, equal to `kubectl port-forward`.
-  - [AttachExample](./examples/examples-release-last/src/main/java/io/kubernetes/client/examples/AttachExample.java): 
+  - [AttachExample](./examples/examples-release-10/src/main/java/io/kubernetes/client/examples/AttachExample.java): 
   Attach to a process that is already running inside an existing container, equal to `kubectl attach`.
-  - [CopyExample](./examples/examples-release-last/src/main/java/io/kubernetes/client/examples/CopyExample.java): 
+  - [CopyExample](./examples/examples-release-10/src/main/java/io/kubernetes/client/examples/CopyExample.java): 
   Copy files and directories to and from containers, equal to `kubectl cp`.
-  - [WebSocketsExample](./examples/examples-release-last/src/main/java/io/kubernetes/client/examples/WebSocketsExample.java): 
+  - [WebSocketsExample](./examples/examples-release-10/src/main/java/io/kubernetes/client/examples/WebSocketsExample.java): 
   Establish an arbitrary web-socket session to certain resources.
 - __Advanced__: (NOTE: The following example requires `client-java-extended` module）
-  - ([5.0.0+](https://github.com/kubernetes-client/java/tree/client-java-parent-5.0.0)) [InformerExample](./examples/examples-release-last/src/main/java/io/kubernetes/client/examples/InformerExample.java): 
+  - ([5.0.0+](https://github.com/kubernetes-client/java/tree/client-java-parent-5.0.0)) [InformerExample](./examples/examples-release-10/src/main/java/io/kubernetes/client/examples/InformerExample.java): 
   Build an informer which list-watches resources and reflects the notifications to a local cache.
-  - ([5.0.0+](https://github.com/kubernetes-client/java/tree/client-java-parent-5.0.0)) [PagerExample](./examples/examples-release-last/src/main/java/io/kubernetes/client/examples/PagerExample.java): 
+  - ([5.0.0+](https://github.com/kubernetes-client/java/tree/client-java-parent-5.0.0)) [PagerExample](./examples/examples-release-10/src/main/java/io/kubernetes/client/examples/PagerExample.java): 
   Support Pagination (only for the list request) to ease server-side loads/network congestion.
-  - ([6.0.0+](https://github.com/kubernetes-client/java/tree/client-java-parent-6.0.0)) [ControllerExample](./examples/examples-release-last/src/main/java/io/kubernetes/client/examples/ControllerExample.java): 
+  - ([6.0.0+](https://github.com/kubernetes-client/java/tree/client-java-parent-6.0.0)) [ControllerExample](./examples/examples-release-10/src/main/java/io/kubernetes/client/examples/ControllerExample.java): 
   Build a controller reconciling the state of world by list-watching one or multiple resources.
-  - ([6.0.0+](https://github.com/kubernetes-client/java/tree/client-java-parent-6.0.0)) [LeaderElectionExample](./examples/examples-release-last/src/main/java/io/kubernetes/client/examples/LeaderElectionExample.java): 
+  - ([6.0.0+](https://github.com/kubernetes-client/java/tree/client-java-parent-6.0.0)) [LeaderElectionExample](./examples/examples-release-10/src/main/java/io/kubernetes/client/examples/LeaderElectionExample.java): 
   Leader election utilities to help implement HA controllers.
-  - ([9.0.0+](https://github.com/kubernetes-client/java/tree/client-java-parent-9.0.0)) [SpringIntegrationControllerExample](./examples/examples-release-last/src/main/java/io/kubernetes/client/examples/SpringControllerExample.java): 
+  - ([9.0.0+](https://github.com/kubernetes-client/java/tree/client-java-parent-9.0.0)) [SpringIntegrationControllerExample](./examples/examples-release-10/src/main/java/io/kubernetes/client/examples/SpringControllerExample.java): 
   Building a kubernetes controller based on spring framework's bean injection, see additional documentation [here](./docs/java-controller-tutorial-rewrite-rs-controller.md).
-  - ([9.0.0+](https://github.com/kubernetes-client/java/tree/client-java-parent-9.0.0)) [GenericKubernetesClientExample](./examples/examples-release-last/src/main/java/io/kubernetes/client/examples/GenericClientExample.java): 
+  - ([9.0.0+](https://github.com/kubernetes-client/java/tree/client-java-parent-9.0.0)) [GenericKubernetesClientExample](./examples/examples-release-10/src/main/java/io/kubernetes/client/examples/GenericClientExample.java): 
   Construct a generic client interface for any kubernetes types, including CRDs.
 
 

--- a/examples/examples-release-last
+++ b/examples/examples-release-last
@@ -1,1 +1,0 @@
-examples-release-10/


### PR DESCRIPTION
sadly the symlink doesn't work on the github README page.. revert the symlink path to the actual module path