### PR TITLE
Factor out usage of Guava in shared libraries

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -10,14 +10,14 @@
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
-    <version>1.0.0-SNAPSHOT</version>
+	<version>1.0.0-SNAPSHOT</version>
 
 	<artifactId>client-java-examples-parent</artifactId>
 	<packaging>pom</packaging>
 	<name>client-java-examples-parent</name>
 
 	<properties>
-        <guava.version>30.0-jre</guava.version>
+		<guava.version>30.0-jre</guava.version>
 		<kubernetes.client.version>10.0.1-SNAPSHOT</kubernetes.client.version>
 	</properties>
 
@@ -26,15 +26,15 @@
 		<module>examples-release-10</module>
 	</modules>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>${guava.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<build>
 		<plugins>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -17,6 +17,7 @@
 	<name>client-java-examples-parent</name>
 
 	<properties>
+        <guava.version>30.0-jre</guava.version>
 		<kubernetes.client.version>10.0.1-SNAPSHOT</kubernetes.client.version>
 	</properties>
 
@@ -24,6 +25,16 @@
 		<module>examples-release-11</module>
 		<module>examples-release-10</module>
 	</modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
 	<build>
 		<plugins>

--- a/extended/pom.xml
+++ b/extended/pom.xml
@@ -35,16 +35,16 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-core</artifactId>
         </dependency>
         <dependency>
             <groupId>com.flipkart.zjsonpatch</groupId>
             <artifactId>zjsonpatch</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
         </dependency>
         <!-- test dependencies -->
         <dependency>

--- a/extended/src/main/java/io/kubernetes/client/extended/controller/Controllers.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/controller/Controllers.java
@@ -16,10 +16,7 @@ import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.extended.controller.reconciler.Request;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.util.Threads;
-
-import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/extended/src/main/java/io/kubernetes/client/extended/controller/Controllers.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/controller/Controllers.java
@@ -12,17 +12,15 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.controller;
 
+import io.kubernetes.client.common.KubernetesObject;
+import io.kubernetes.client.extended.controller.reconciler.Request;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import io.kubernetes.client.common.KubernetesObject;
-import io.kubernetes.client.extended.controller.reconciler.Request;
-import io.kubernetes.client.openapi.models.V1ObjectMeta;
 
 /** The Controllers is a set of commonly used utility functions for constructing controller. */
 public class Controllers {

--- a/extended/src/main/java/io/kubernetes/client/extended/controller/Controllers.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/controller/Controllers.java
@@ -15,6 +15,8 @@ package io.kubernetes.client.extended.controller;
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.extended.controller.reconciler.Request;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.util.Threads;
+
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -51,16 +53,6 @@ public class Controllers {
    * @return the thread factory
    */
   public static ThreadFactory namedControllerThreadFactory(String controllerName) {
-    final ThreadFactory defaultFactory = Executors.defaultThreadFactory();
-    final AtomicInteger threadNumber = new AtomicInteger(1);
-    String format = controllerName + "-%d";
-    return r -> {
-      Thread thread = defaultFactory.newThread(r);
-      if (!thread.isDaemon()) {
-        thread.setDaemon(true);
-      }
-      thread.setName(String.format(format, threadNumber.getAndIncrement()));
-      return thread;
-    };
+    return Threads.threadFactory(controllerName + "-%d");
   }
 }

--- a/extended/src/main/java/io/kubernetes/client/extended/event/legacy/EventAggregator.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/event/legacy/EventAggregator.java
@@ -12,6 +12,8 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.event.legacy;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.kubernetes.client.fluent.Function;
 import io.kubernetes.client.openapi.models.CoreV1Event;
 import io.kubernetes.client.openapi.models.CoreV1EventBuilder;
@@ -19,11 +21,6 @@ import io.kubernetes.client.openapi.models.V1ObjectMetaBuilder;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
-
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.joda.time.DateTime;
 

--- a/extended/src/main/java/io/kubernetes/client/extended/event/legacy/EventLogger.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/event/legacy/EventLogger.java
@@ -12,18 +12,20 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.event.legacy;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.Configuration;
 import io.kubernetes.client.openapi.models.CoreV1Event;
 import java.util.function.Function;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.joda.time.DateTime;
 
 public class EventLogger {
   public EventLogger(int lruCacheEntries, Function<CoreV1Event, String> eventKeyFunc) {
-    this.eventCache = CacheBuilder.newBuilder().maximumSize(lruCacheEntries).build();
+    this.eventCache = Caffeine.newBuilder().maximumSize(lruCacheEntries).build();
     this.eventKeyFunc = eventKeyFunc;
   }
 

--- a/extended/src/main/java/io/kubernetes/client/extended/event/legacy/EventLogger.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/event/legacy/EventLogger.java
@@ -12,14 +12,12 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.event.legacy;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.Configuration;
 import io.kubernetes.client.openapi.models.CoreV1Event;
 import java.util.function.Function;
-
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.joda.time.DateTime;
 

--- a/extended/src/main/java/io/kubernetes/client/extended/event/legacy/EventSpamFilter.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/event/legacy/EventSpamFilter.java
@@ -12,6 +12,8 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.event.legacy;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket4j;
 import io.github.bucket4j.Refill;
@@ -19,11 +21,7 @@ import io.github.bucket4j.local.LocalBucket;
 import io.github.bucket4j.local.SynchronizationStrategy;
 import io.kubernetes.client.openapi.models.CoreV1Event;
 import java.time.Duration;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
-
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 
 public class EventSpamFilter {
 

--- a/extended/src/main/java/io/kubernetes/client/extended/event/legacy/ObjectReferenceResolvingEventRecorder.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/event/legacy/ObjectReferenceResolvingEventRecorder.java
@@ -12,15 +12,6 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.event.legacy;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.TimeUnit;
-
-import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.extended.event.EventType;
 import io.kubernetes.client.openapi.models.CoreV1Event;
@@ -31,6 +22,13 @@ import io.kubernetes.client.openapi.models.V1ObjectMetaBuilder;
 import io.kubernetes.client.openapi.models.V1ObjectReference;
 import io.kubernetes.client.openapi.models.V1ObjectReferenceBuilder;
 import io.kubernetes.client.util.Strings;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ObjectReferenceResolvingEventRecorder implements EventRecorder {
 

--- a/extended/src/main/java/io/kubernetes/client/extended/event/legacy/ObjectReferenceResolvingEventRecorder.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/event/legacy/ObjectReferenceResolvingEventRecorder.java
@@ -12,7 +12,15 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.event.legacy;
 
-import com.google.common.base.Strings;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.extended.event.EventType;
 import io.kubernetes.client.openapi.models.CoreV1Event;
@@ -22,13 +30,7 @@ import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1ObjectMetaBuilder;
 import io.kubernetes.client.openapi.models.V1ObjectReference;
 import io.kubernetes.client.openapi.models.V1ObjectReferenceBuilder;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.TimeUnit;
-import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.kubernetes.client.util.Strings;
 
 public class ObjectReferenceResolvingEventRecorder implements EventRecorder {
 

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlApply.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlApply.java
@@ -12,7 +12,6 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.kubectl;
 
-import com.google.common.base.Strings;
 import io.kubernetes.client.common.KubernetesListObject;
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.custom.V1Patch;
@@ -20,6 +19,7 @@ import io.kubernetes.client.extended.kubectl.exception.KubectlException;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.util.ModelMapper;
 import io.kubernetes.client.util.Namespaces;
+import io.kubernetes.client.util.Strings;
 import io.kubernetes.client.util.generic.GenericKubernetesApi;
 import io.kubernetes.client.util.generic.KubernetesApiResponse;
 import io.kubernetes.client.util.generic.options.PatchOptions;

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlCopy.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlCopy.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.kubectl;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
+import static io.kubernetes.client.util.Strings.isNullOrEmpty;
 
 import io.kubernetes.client.Copy;
 import io.kubernetes.client.extended.kubectl.exception.KubectlException;

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlCreate.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlCreate.java
@@ -12,13 +12,13 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.kubectl;
 
-import com.google.common.base.Strings;
 import io.kubernetes.client.common.KubernetesListObject;
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.extended.kubectl.exception.KubectlException;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.util.ModelMapper;
 import io.kubernetes.client.util.Namespaces;
+import io.kubernetes.client.util.Strings;
 import io.kubernetes.client.util.generic.GenericKubernetesApi;
 import io.kubernetes.client.util.generic.options.CreateOptions;
 

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlExec.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlExec.java
@@ -12,16 +12,15 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.kubectl;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-
 import io.kubernetes.client.Exec;
 import io.kubernetes.client.extended.kubectl.exception.KubectlException;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.util.Streams;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 public class KubectlExec extends Kubectl.ResourceAndContainerBuilder<V1Pod, KubectlExec>
     implements Kubectl.Executable<Integer> {

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlExec.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlExec.java
@@ -12,15 +12,16 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.kubectl;
 
-import com.google.common.io.ByteStreams;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
 import io.kubernetes.client.Exec;
 import io.kubernetes.client.extended.kubectl.exception.KubectlException;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import io.kubernetes.client.util.Streams;
 
 public class KubectlExec extends Kubectl.ResourceAndContainerBuilder<V1Pod, KubectlExec>
     implements Kubectl.Executable<Integer> {
@@ -71,7 +72,7 @@ public class KubectlExec extends Kubectl.ResourceAndContainerBuilder<V1Pod, Kube
             new Runnable() {
               public void run() {
                 try {
-                  ByteStreams.copy(in, out);
+                  Streams.copy(in, out);
                 } catch (IOException ex) {
                   ex.printStackTrace();
                 }

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlLog.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlLog.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.kubectl;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
+import static io.kubernetes.client.util.Strings.isNullOrEmpty;
 
 import io.kubernetes.client.PodLogs;
 import io.kubernetes.client.extended.kubectl.exception.KubectlException;

--- a/extended/src/main/java/io/kubernetes/client/extended/leaderelection/LeaderElector.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/leaderelection/LeaderElector.java
@@ -12,6 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.leaderelection;
 
+import io.kubernetes.client.openapi.ApiException;
 import java.net.HttpURLConnection;
 import java.time.Duration;
 import java.util.Date;
@@ -30,11 +31,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import io.kubernetes.client.openapi.ApiException;
 
 public class LeaderElector implements AutoCloseable {
 
@@ -346,16 +344,16 @@ public class LeaderElector implements AutoCloseable {
   }
 
   private ThreadFactory makeThreadFactory(String format) {
-      final ThreadFactory defaultFactory = Executors.defaultThreadFactory();
-      final AtomicInteger threadNumber = new AtomicInteger(1);
-      return r -> {
-        Thread thread = defaultFactory.newThread(r);
-        if (!thread.isDaemon()) {
-          thread.setDaemon(true);
-        }
-        thread.setName(String.format(format, threadNumber.getAndIncrement()));
-        return thread;
-      };
+    final ThreadFactory defaultFactory = Executors.defaultThreadFactory();
+    final AtomicInteger threadNumber = new AtomicInteger(1);
+    return r -> {
+      Thread thread = defaultFactory.newThread(r);
+      if (!thread.isDaemon()) {
+        thread.setDaemon(true);
+      }
+      thread.setName(String.format(format, threadNumber.getAndIncrement()));
+      return thread;
+    };
   }
 
   @Override

--- a/extended/src/main/java/io/kubernetes/client/extended/leaderelection/LeaderElector.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/leaderelection/LeaderElector.java
@@ -12,6 +12,8 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.leaderelection;
 
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.util.Threads;
 import java.net.HttpURLConnection;
 import java.time.Duration;
 import java.util.Date;
@@ -28,12 +30,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.util.Threads;
 
 public class LeaderElector implements AutoCloseable {
 

--- a/extended/src/main/java/io/kubernetes/client/extended/workqueue/DefaultDelayingQueue.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/workqueue/DefaultDelayingQueue.java
@@ -12,7 +12,6 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.workqueue;
 
-import com.google.common.primitives.Longs;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.Temporal;
@@ -143,7 +142,7 @@ public class DefaultDelayingQueue<T> extends DefaultWorkQueue<T> implements Dela
 
     @Override
     public int compareTo(Delayed o) {
-      return Longs.compare(getDelay(TimeUnit.MILLISECONDS), o.getDelay(TimeUnit.MILLISECONDS));
+      return Long.compare(getDelay(TimeUnit.MILLISECONDS), o.getDelay(TimeUnit.MILLISECONDS));
     }
   }
 }

--- a/extended/src/main/java/io/kubernetes/client/extended/workqueue/DefaultWorkQueue.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/workqueue/DefaultWorkQueue.java
@@ -12,8 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.workqueue;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Set;
 
@@ -42,9 +41,9 @@ public class DefaultWorkQueue<T> implements WorkQueue<T> {
   private boolean shuttingDown = false;
 
   public DefaultWorkQueue() {
-    this.queue = Lists.newLinkedList();
-    this.dirty = Sets.newHashSet();
-    this.processing = Sets.newHashSet();
+    this.queue = new LinkedList<>();
+    this.dirty = new HashSet<>();
+    this.processing = new HashSet<>();
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -510,51 +510,5 @@ limitations under the License.
         </plugins>
       </build>
     </profile>
-    <profile>
-      <id>imports</id>
-      <activation>
-        <os>
-          <family>!windows</family>
-        </os>
-        <file>
-        <missing>.google</missing>
-        </file>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>exec-maven-plugin</artifactId>
-            <version>${exec-maven-plugin.version}</version>
-            <executions>
-              <execution>
-                <id>imports</id>
-                <phase>process-sources</phase>
-                <configuration>
-                  <executable>egrep</executable>
-                  <successCodes>
-                    <successCode>1</successCode>
-                    <successCode>2</successCode>
-                  </successCodes>
-                  <arguments>
-                    <argument>-rm</argument>
-                    <argument>1</argument>
-                    <!-- Forbidden Keywords -->
-                    <argument>^import com.google.common</argument>
-                    <!-- file patterns -->
-                    <argument>--include=*.java</argument>
-                    <!-- search path -->
-                    <argument>${project.build.sourceDirectory}</argument>
-                  </arguments>
-                </configuration>
-                <goals>
-                  <goal>exec</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
     <snakeyaml.version>1.27</snakeyaml.version>
     <slf4j.version>1.7.30</slf4j.version>
     <caffeine.version>2.8.6</caffeine.version>
-    <guava.version>30.0-jre</guava.version>
     <protobuf.version>3.14.0</protobuf.version>
     <junit.version>4.13</junit.version>
     <bucket4j.version>4.10.0</bucket4j.version>
@@ -112,11 +111,6 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
         <version>${apache.commons.compress}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>${guava.version}</version>
       </dependency>
       <dependency>
         <groupId>com.github.ben-manes.caffeine</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <javax.annotation.version>1.3.2</javax.annotation.version>
     <snakeyaml.version>1.27</snakeyaml.version>
     <slf4j.version>1.7.30</slf4j.version>
+    <caffeine.version>2.8.6</caffeine.version>
     <guava.version>30.0-jre</guava.version>
     <protobuf.version>3.14.0</protobuf.version>
     <junit.version>4.13</junit.version>
@@ -116,6 +117,11 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.ben-manes.caffeine</groupId>
+        <artifactId>caffeine</artifactId>
+        <version>${caffeine.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -517,7 +517,7 @@ limitations under the License.
           <family>!windows</family>
         </os>
         <file>
-			<missing>.google</missing>
+        <missing>.google</missing>
         </file>
       </activation>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven-plugin-version>1.0.0</maven-plugin-version>
+    <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <javax.annotation.version>1.3.2</javax.annotation.version>
@@ -503,6 +504,52 @@ limitations under the License.
                     <arg>loopback</arg>
                   </gpgArguments>
                 </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>imports</id>
+      <activation>
+        <os>
+          <family>!windows</family>
+        </os>
+        <file>
+			<missing>.google</missing>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>${exec-maven-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>imports</id>
+                <phase>process-sources</phase>
+                <configuration>
+                  <executable>egrep</executable>
+                  <successCodes>
+                    <successCode>1</successCode>
+                    <successCode>2</successCode>
+                  </successCodes>
+                  <arguments>
+                    <argument>-rm</argument>
+                    <argument>1</argument>
+                    <!-- Forbidden Keywords -->
+                    <argument>^import com.google.common</argument>
+                    <!-- file patterns -->
+                    <argument>--include=*.java</argument>
+                    <!-- search path -->
+                    <argument>${project.build.sourceDirectory}</argument>
+                  </arguments>
+                </configuration>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
               </execution>
             </executions>
           </plugin>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -39,6 +39,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-actuator</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/spring/src/main/java/io/kubernetes/client/spring/extended/manifests/KubernetesFromYamlProcessor.java
+++ b/spring/src/main/java/io/kubernetes/client/spring/extended/manifests/KubernetesFromYamlProcessor.java
@@ -12,7 +12,6 @@ limitations under the License.
 */
 package io.kubernetes.client.spring.extended.manifests;
 
-import com.google.common.io.Resources;
 import io.kubernetes.client.spring.extended.manifests.annotation.FromYaml;
 import io.kubernetes.client.util.Yaml;
 import java.io.IOException;
@@ -91,7 +90,7 @@ public class KubernetesFromYamlProcessor
     Path targetPath = Paths.get(targetFilePath);
     if (!Files.exists(Paths.get(targetFilePath))) { // checks if it exists on the machine
       // otherwise use load from classpath resources
-      Path classPath = Paths.get(Resources.getResource(targetFilePath).getPath());
+      Path classPath = Paths.get(getClass().getClassLoader().getResource(targetFilePath).getPath());
       if (Files.exists(classPath)) { // use classpath it works
         targetPath = classPath;
       } else {

--- a/spring/src/main/java/io/kubernetes/client/spring/extended/network/endpoints/PollingEndpointsGetter.java
+++ b/spring/src/main/java/io/kubernetes/client/spring/extended/network/endpoints/PollingEndpointsGetter.java
@@ -12,34 +12,35 @@ limitations under the License.
 */
 package io.kubernetes.client.spring.extended.network.endpoints;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import io.kubernetes.client.apimachinery.NamespaceName;
 import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Endpoints;
 import java.time.Duration;
-import java.util.concurrent.ExecutionException;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class PollingEndpointsGetter implements EndpointsGetter {
 
-  private static final Cache<NamespaceName, V1Endpoints> lastObservedEndpoints =
-      CacheBuilder.newBuilder().expireAfterWrite(Duration.ofMinutes(5)).build();
+  private static final Cache<NamespaceName, V1Endpoints> lastObservedEndpoints = Caffeine.newBuilder()
+      .expireAfterWrite(Duration.ofMinutes(5)).build();
 
-  @Autowired private ApiClient apiClient;
+  @Autowired
+  private ApiClient apiClient;
 
   @Override
   public V1Endpoints get(String namespace, String name) {
     CoreV1Api coreV1Api = new CoreV1Api(apiClient);
-    try {
-      return lastObservedEndpoints.get(
-          new NamespaceName(namespace, name),
-          () -> {
-            return coreV1Api.readNamespacedEndpoints(name, namespace, null, null, null);
-          });
-    } catch (ExecutionException e) {
-      throw new RuntimeException(e);
-    }
+    return lastObservedEndpoints.get(new NamespaceName(namespace, name), k -> {
+      try {
+        return coreV1Api.readNamespacedEndpoints(name, namespace, null, null, null);
+      } catch (ApiException e) {
+        throw new IllegalStateException(e);
+      }
+    });
   }
 }

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -47,10 +47,6 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
@@ -81,9 +77,9 @@
             <artifactId>commons-collections4</artifactId>
         </dependency>
         <dependency>
-			<groupId>org.bitbucket.b_c</groupId>
-			<artifactId>jose4j</artifactId>
-		</dependency>
+            <groupId>org.bitbucket.b_c</groupId>
+            <artifactId>jose4j</artifactId>
+        </dependency>
         <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/util/src/main/java/io/kubernetes/client/Copy.java
+++ b/util/src/main/java/io/kubernetes/client/Copy.java
@@ -12,11 +12,11 @@ limitations under the License.
 */
 package io.kubernetes.client;
 
-import com.google.common.io.ByteStreams;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.Configuration;
 import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.util.Streams;
 import io.kubernetes.client.util.exception.CopyNotSupportedException;
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
@@ -95,7 +95,7 @@ public class Copy extends Exec {
       throws ApiException, IOException {
     try (InputStream is = copyFileFromPod(namespace, name, container, srcPath);
         FileOutputStream fos = new FileOutputStream(destination.toFile())) {
-      ByteStreams.copy(is, fos);
+      Streams.copy(is, fos);
       fos.flush();
     }
   }
@@ -199,7 +199,7 @@ public class Copy extends Exec {
             throw new IOException("create directory failed: " + parent);
           }
           try (OutputStream fs = new FileOutputStream(f)) {
-            ByteStreams.copy(archive, fs);
+            Streams.copy(archive, fs);
             fs.flush();
           }
         }
@@ -245,7 +245,7 @@ public class Copy extends Exec {
         String modifiedSrcPath = genericPathBuilder(srcPath, childNode.name);
         try (InputStream is = copyFileFromPod(namespace, pod, modifiedSrcPath);
             OutputStream fs = new FileOutputStream(f)) {
-          ByteStreams.copy(is, fs);
+          Streams.copy(is, fs);
           fs.flush();
         }
       } else {
@@ -332,7 +332,7 @@ public class Copy extends Exec {
     Copy c = new Copy();
     try (InputStream is = c.copyFileFromPod(namespace, pod, null, srcPath);
         FileOutputStream os = new FileOutputStream(dest.toFile())) {
-      ByteStreams.copy(is, os);
+      Streams.copy(is, os);
       os.flush();
     }
   }
@@ -366,7 +366,7 @@ public class Copy extends Exec {
       ArchiveEntry tarEntry = new TarArchiveEntry(srcFile, destPath.getFileName().toString());
 
       archiveOutputStream.putArchiveEntry(tarEntry);
-      ByteStreams.copy(input, archiveOutputStream);
+      Streams.copy(input, archiveOutputStream);
       archiveOutputStream.closeArchiveEntry();
 
       return new ProcessFuture(proc);
@@ -399,7 +399,7 @@ public class Copy extends Exec {
       ((TarArchiveEntry) tarEntry).setSize(src.length);
 
       archiveOutputStream.putArchiveEntry(tarEntry);
-      ByteStreams.copy(new ByteArrayInputStream(src), archiveOutputStream);
+      Streams.copy(new ByteArrayInputStream(src), archiveOutputStream);
       archiveOutputStream.closeArchiveEntry();
 
       return new ProcessFuture(proc);

--- a/util/src/main/java/io/kubernetes/client/Discovery.java
+++ b/util/src/main/java/io/kubernetes/client/Discovery.java
@@ -12,7 +12,18 @@ limitations under the License.
 */
 package io.kubernetes.client;
 
-import com.google.common.base.Objects;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.ApiResponse;
@@ -21,16 +32,6 @@ import io.kubernetes.client.openapi.models.V1APIGroup;
 import io.kubernetes.client.openapi.models.V1APIGroupList;
 import io.kubernetes.client.openapi.models.V1APIResourceList;
 import io.kubernetes.client.openapi.models.V1APIVersions;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 import okhttp3.Call;
 
 public class Discovery {
@@ -237,19 +238,19 @@ public class Discovery {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       APIResource that = (APIResource) o;
-      return Objects.equal(group, that.group)
-          && Objects.equal(kind, that.kind)
-          && Objects.equal(versions, that.versions)
-          && Objects.equal(preferredVersion, that.preferredVersion)
-          && Objects.equal(isNamespaced, that.isNamespaced)
-          && Objects.equal(resourcePlural, that.resourcePlural)
-          && Objects.equal(resourceSingular, that.resourceSingular)
-          && Objects.equal(subResources, that.subResources);
+      return Objects.equals(group, that.group)
+          && Objects.equals(kind, that.kind)
+          && Objects.equals(versions, that.versions)
+          && Objects.equals(preferredVersion, that.preferredVersion)
+          && Objects.equals(isNamespaced, that.isNamespaced)
+          && Objects.equals(resourcePlural, that.resourcePlural)
+          && Objects.equals(resourceSingular, that.resourceSingular)
+          && Objects.equals(subResources, that.subResources);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(
+      return Objects.hash(
           group,
           kind,
           versions,

--- a/util/src/main/java/io/kubernetes/client/Discovery.java
+++ b/util/src/main/java/io/kubernetes/client/Discovery.java
@@ -12,6 +12,14 @@ limitations under the License.
 */
 package io.kubernetes.client;
 
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.ApiResponse;
+import io.kubernetes.client.openapi.Configuration;
+import io.kubernetes.client.openapi.models.V1APIGroup;
+import io.kubernetes.client.openapi.models.V1APIGroupList;
+import io.kubernetes.client.openapi.models.V1APIResourceList;
+import io.kubernetes.client.openapi.models.V1APIVersions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -23,15 +31,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import io.kubernetes.client.openapi.ApiClient;
-import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.openapi.ApiResponse;
-import io.kubernetes.client.openapi.Configuration;
-import io.kubernetes.client.openapi.models.V1APIGroup;
-import io.kubernetes.client.openapi.models.V1APIGroupList;
-import io.kubernetes.client.openapi.models.V1APIResourceList;
-import io.kubernetes.client.openapi.models.V1APIVersions;
 import okhttp3.Call;
 
 public class Discovery {

--- a/util/src/main/java/io/kubernetes/client/Exec.java
+++ b/util/src/main/java/io/kubernetes/client/Exec.java
@@ -14,7 +14,6 @@ package io.kubernetes.client;
 
 import static io.kubernetes.client.KubernetesConstants.*;
 
-import com.google.common.io.CharStreams;
 import com.google.gson.reflect.TypeToken;
 import io.kubernetes.client.custom.IOTrio;
 import io.kubernetes.client.openapi.ApiClient;
@@ -25,6 +24,7 @@ import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1Status;
 import io.kubernetes.client.openapi.models.V1StatusCause;
 import io.kubernetes.client.openapi.models.V1StatusDetails;
+import io.kubernetes.client.util.Streams;
 import io.kubernetes.client.util.WebSocketStreamHandler;
 import io.kubernetes.client.util.WebSockets;
 import java.io.IOException;
@@ -446,7 +446,7 @@ public class Exec {
       Type returnType = new TypeToken<V1Status>() {}.getType();
       String body;
       try (final Reader reader = new InputStreamReader(inputStream)) {
-        body = CharStreams.toString(reader);
+        body = Streams.toString(reader);
       }
 
       V1Status status = client.getJSON().deserialize(body, returnType);

--- a/util/src/main/java/io/kubernetes/client/ProtoClient.java
+++ b/util/src/main/java/io/kubernetes/client/ProtoClient.java
@@ -23,7 +23,6 @@ import io.kubernetes.client.proto.Meta.Status;
 import io.kubernetes.client.proto.Runtime.TypeMeta;
 import io.kubernetes.client.proto.Runtime.Unknown;
 import io.kubernetes.client.util.Streams;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;

--- a/util/src/main/java/io/kubernetes/client/ProtoClient.java
+++ b/util/src/main/java/io/kubernetes/client/ProtoClient.java
@@ -12,8 +12,6 @@ limitations under the License.
 */
 package io.kubernetes.client;
 
-import com.google.common.io.ByteStreams;
-import com.google.common.primitives.Bytes;
 import com.google.protobuf.Message;
 import com.google.protobuf.Message.Builder;
 import io.kubernetes.client.openapi.ApiClient;
@@ -24,6 +22,8 @@ import io.kubernetes.client.proto.Meta.DeleteOptions;
 import io.kubernetes.client.proto.Meta.Status;
 import io.kubernetes.client.proto.Runtime.TypeMeta;
 import io.kubernetes.client.proto.Runtime.Unknown;
+import io.kubernetes.client.util.Streams;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -309,12 +309,19 @@ public class ProtoClient {
             .setTypeMeta(TypeMeta.newBuilder().setApiVersion(apiVersion).setKind(kind))
             .setRaw(msg.toByteString())
             .build();
-    return Bytes.concat(MAGIC, u.toByteArray());
+    return concat(MAGIC, u.toByteArray());
+  }
+
+  private static byte[] concat(byte[] one, byte[] two) {
+    byte[] result = new byte[one.length + two.length];
+    System.arraycopy(one, 0, result, 0, one.length);
+    System.arraycopy(two, 0, result, one.length, two.length);
+    return result;
   }
 
   private Unknown parse(InputStream stream) throws ApiException, IOException {
     byte[] magic = new byte[4];
-    ByteStreams.readFully(stream, magic);
+    Streams.readFully(stream, magic);
     if (!Arrays.equals(magic, MAGIC)) {
       throw new ApiException("Unexpected magic number: " + Hex.encodeHexString(magic));
     }

--- a/util/src/main/java/io/kubernetes/client/apimachinery/GroupVersion.java
+++ b/util/src/main/java/io/kubernetes/client/apimachinery/GroupVersion.java
@@ -12,10 +12,9 @@ limitations under the License.
 */
 package io.kubernetes.client.apimachinery;
 
-import java.util.Objects;
-
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.util.Strings;
+import java.util.Objects;
 
 public class GroupVersion {
 
@@ -29,8 +28,7 @@ public class GroupVersion {
     }
     String[] parts = apiVersion.split("/");
     if (parts.length != 2) {
-      throw new IllegalArgumentException(
-              "Invalid apiVersion found on object: " + apiVersion);
+      throw new IllegalArgumentException("Invalid apiVersion found on object: " + apiVersion);
     }
     return new GroupVersion(parts[0], parts[1]);
   }
@@ -64,10 +62,8 @@ public class GroupVersion {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o)
-      return true;
-    if (o == null || getClass() != o.getClass())
-      return false;
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
     GroupVersion that = (GroupVersion) o;
     return Objects.equals(group, that.group) && Objects.equals(version, that.version);
   }
@@ -76,5 +72,4 @@ public class GroupVersion {
   public int hashCode() {
     return Objects.hash(group, version);
   }
-
 }

--- a/util/src/main/java/io/kubernetes/client/apimachinery/GroupVersion.java
+++ b/util/src/main/java/io/kubernetes/client/apimachinery/GroupVersion.java
@@ -12,9 +12,10 @@ limitations under the License.
 */
 package io.kubernetes.client.apimachinery;
 
-import com.google.common.base.Objects;
-import com.google.common.base.Strings;
+import java.util.Objects;
+
 import io.kubernetes.client.common.KubernetesObject;
+import io.kubernetes.client.util.Strings;
 
 public class GroupVersion {
 
@@ -28,7 +29,8 @@ public class GroupVersion {
     }
     String[] parts = apiVersion.split("/");
     if (parts.length != 2) {
-      throw new IllegalArgumentException("Invalid apiVersion found on object: " + apiVersion);
+      throw new IllegalArgumentException(
+              "Invalid apiVersion found on object: " + apiVersion);
     }
     return new GroupVersion(parts[0], parts[1]);
   }
@@ -49,6 +51,7 @@ public class GroupVersion {
   }
 
   private final String group;
+
   private final String version;
 
   public String getGroup() {
@@ -61,14 +64,17 @@ public class GroupVersion {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
     GroupVersion that = (GroupVersion) o;
-    return Objects.equal(group, that.group) && Objects.equal(version, that.version);
+    return Objects.equals(group, that.group) && Objects.equals(version, that.version);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(group, version);
+    return Objects.hash(group, version);
   }
+
 }

--- a/util/src/main/java/io/kubernetes/client/apimachinery/GroupVersionKind.java
+++ b/util/src/main/java/io/kubernetes/client/apimachinery/GroupVersionKind.java
@@ -32,12 +32,9 @@ public class GroupVersionKind extends GroupVersion {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o)
-      return true;
-    if (o == null || getClass() != o.getClass())
-      return false;
-    if (!super.equals(o))
-      return false;
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
     GroupVersionKind that = (GroupVersionKind) o;
     return Objects.equals(kind, that.kind);
   }
@@ -46,5 +43,4 @@ public class GroupVersionKind extends GroupVersion {
   public int hashCode() {
     return Objects.hash(super.hashCode(), kind);
   }
-
 }

--- a/util/src/main/java/io/kubernetes/client/apimachinery/GroupVersionKind.java
+++ b/util/src/main/java/io/kubernetes/client/apimachinery/GroupVersionKind.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.apimachinery;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 public class GroupVersionKind extends GroupVersion {
 
@@ -32,15 +32,19 @@ public class GroupVersionKind extends GroupVersion {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    if (!super.equals(o))
+      return false;
     GroupVersionKind that = (GroupVersionKind) o;
-    return Objects.equal(kind, that.kind);
+    return Objects.equals(kind, that.kind);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(super.hashCode(), kind);
+    return Objects.hash(super.hashCode(), kind);
   }
+
 }

--- a/util/src/main/java/io/kubernetes/client/apimachinery/GroupVersionResource.java
+++ b/util/src/main/java/io/kubernetes/client/apimachinery/GroupVersionResource.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.apimachinery;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 public class GroupVersionResource extends GroupVersion {
 
@@ -28,19 +28,23 @@ public class GroupVersionResource extends GroupVersion {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    if (!super.equals(o)) return false;
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    if (!super.equals(o))
+      return false;
     GroupVersionResource that = (GroupVersionResource) o;
-    return Objects.equal(resource, that.resource);
+    return Objects.equals(resource, that.resource);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(super.hashCode(), resource);
+    return Objects.hash(super.hashCode(), resource);
   }
 
   public String getResource() {
     return resource;
   }
+
 }

--- a/util/src/main/java/io/kubernetes/client/apimachinery/GroupVersionResource.java
+++ b/util/src/main/java/io/kubernetes/client/apimachinery/GroupVersionResource.java
@@ -28,12 +28,9 @@ public class GroupVersionResource extends GroupVersion {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o)
-      return true;
-    if (o == null || getClass() != o.getClass())
-      return false;
-    if (!super.equals(o))
-      return false;
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
     GroupVersionResource that = (GroupVersionResource) o;
     return Objects.equals(resource, that.resource);
   }
@@ -46,5 +43,4 @@ public class GroupVersionResource extends GroupVersion {
   public String getResource() {
     return resource;
   }
-
 }

--- a/util/src/main/java/io/kubernetes/client/apimachinery/KubernetesRequestDigest.java
+++ b/util/src/main/java/io/kubernetes/client/apimachinery/KubernetesRequestDigest.java
@@ -12,16 +12,19 @@ limitations under the License.
 */
 package io.kubernetes.client.apimachinery;
 
-import java.util.regex.Pattern;
-
 import io.kubernetes.client.util.Strings;
+import java.util.regex.Pattern;
 import okhttp3.Request;
 
 public class KubernetesRequestDigest {
 
-  public static final Pattern RESOURCE_URL_PATH_PATTERN = Pattern.compile("^/(api|apis)(/\\S+)?/v\\d\\w*/\\S+");
+  public static final Pattern RESOURCE_URL_PATH_PATTERN =
+      Pattern.compile("^/(api|apis)(/\\S+)?/v\\d\\w*/\\S+");
 
-  KubernetesRequestDigest(String urlPath, boolean isNonResourceRequest, KubernetesResource resourceMeta,
+  KubernetesRequestDigest(
+      String urlPath,
+      boolean isNonResourceRequest,
+      KubernetesResource resourceMeta,
       KubernetesVerb verb) {
     this.urlPath = urlPath;
     this.isNonResourceRequest = isNonResourceRequest;
@@ -38,15 +41,17 @@ public class KubernetesRequestDigest {
       KubernetesResource resourceMeta;
       if (urlPath.startsWith("/api/v1")) {
         resourceMeta = KubernetesResource.parseCoreResource(urlPath);
-      }
-      else {
+      } else {
         resourceMeta = KubernetesResource.parseRegularResource(urlPath);
       }
 
-      return new KubernetesRequestDigest(urlPath, false, resourceMeta, KubernetesVerb.of(request.method(),
-          hasNamePathParameter(resourceMeta), hasWatchParameter(request)));
-    }
-    catch (ParseKubernetesResourceException e) {
+      return new KubernetesRequestDigest(
+          urlPath,
+          false,
+          resourceMeta,
+          KubernetesVerb.of(
+              request.method(), hasNamePathParameter(resourceMeta), hasWatchParameter(request)));
+    } catch (ParseKubernetesResourceException e) {
       return nonResource(urlPath);
     }
   }
@@ -99,26 +104,33 @@ public class KubernetesRequestDigest {
     }
 
     String groupVersion;
-    if (Strings.isNullOrEmpty(resourceMeta.getGroupVersionResource().getGroup())) { // core
-                                            // resource
+    if (Strings.isNullOrEmpty(resourceMeta.getGroupVersionResource().getGroup())) {
+      // core resource
       groupVersion = "";
-    }
-    else { // regular resource
-      groupVersion = resourceMeta.getGroupVersionResource().getGroup() + "/"
-          + resourceMeta.getGroupVersionResource().getVersion();
+    } else {
+      // regular resource
+      groupVersion =
+          resourceMeta.getGroupVersionResource().getGroup()
+              + "/"
+              + resourceMeta.getGroupVersionResource().getVersion();
     }
 
     String targetResourceName;
     if (Strings.isNullOrEmpty(resourceMeta.getSubResource())) {
       targetResourceName = resourceMeta.getGroupVersionResource().getResource();
-    }
-    else { // subresource
-      targetResourceName = resourceMeta.getGroupVersionResource().getResource() + "/"
-          + resourceMeta.getSubResource();
+    } else { // subresource
+      targetResourceName =
+          resourceMeta.getGroupVersionResource().getResource()
+              + "/"
+              + resourceMeta.getSubResource();
     }
 
-    return new StringBuilder().append(verb.value()).append(' ').append(groupVersion).append(' ')
-        .append(targetResourceName).toString();
+    return new StringBuilder()
+        .append(verb.value())
+        .append(' ')
+        .append(groupVersion)
+        .append(' ')
+        .append(targetResourceName)
+        .toString();
   }
-
 }

--- a/util/src/main/java/io/kubernetes/client/apimachinery/KubernetesRequestDigest.java
+++ b/util/src/main/java/io/kubernetes/client/apimachinery/KubernetesRequestDigest.java
@@ -12,19 +12,16 @@ limitations under the License.
 */
 package io.kubernetes.client.apimachinery;
 
-import com.google.common.base.Strings;
 import java.util.regex.Pattern;
+
+import io.kubernetes.client.util.Strings;
 import okhttp3.Request;
 
 public class KubernetesRequestDigest {
 
-  public static final Pattern RESOURCE_URL_PATH_PATTERN =
-      Pattern.compile("^/(api|apis)(/\\S+)?/v\\d\\w*/\\S+");
+  public static final Pattern RESOURCE_URL_PATH_PATTERN = Pattern.compile("^/(api|apis)(/\\S+)?/v\\d\\w*/\\S+");
 
-  KubernetesRequestDigest(
-      String urlPath,
-      boolean isNonResourceRequest,
-      KubernetesResource resourceMeta,
+  KubernetesRequestDigest(String urlPath, boolean isNonResourceRequest, KubernetesResource resourceMeta,
       KubernetesVerb verb) {
     this.urlPath = urlPath;
     this.isNonResourceRequest = isNonResourceRequest;
@@ -41,17 +38,15 @@ public class KubernetesRequestDigest {
       KubernetesResource resourceMeta;
       if (urlPath.startsWith("/api/v1")) {
         resourceMeta = KubernetesResource.parseCoreResource(urlPath);
-      } else {
+      }
+      else {
         resourceMeta = KubernetesResource.parseRegularResource(urlPath);
       }
 
-      return new KubernetesRequestDigest(
-          urlPath,
-          false,
-          resourceMeta,
-          KubernetesVerb.of(
-              request.method(), hasNamePathParameter(resourceMeta), hasWatchParameter(request)));
-    } catch (ParseKubernetesResourceException e) {
+      return new KubernetesRequestDigest(urlPath, false, resourceMeta, KubernetesVerb.of(request.method(),
+          hasNamePathParameter(resourceMeta), hasWatchParameter(request)));
+    }
+    catch (ParseKubernetesResourceException e) {
       return nonResource(urlPath);
     }
   }
@@ -74,9 +69,11 @@ public class KubernetesRequestDigest {
   }
 
   private final String urlPath;
+
   private final boolean isNonResourceRequest;
 
   private final KubernetesResource resourceMeta;
+
   private final KubernetesVerb verb;
 
   public String getUrlPath() {
@@ -102,31 +99,26 @@ public class KubernetesRequestDigest {
     }
 
     String groupVersion;
-    if (Strings.isNullOrEmpty(resourceMeta.getGroupVersionResource().getGroup())) { // core resource
+    if (Strings.isNullOrEmpty(resourceMeta.getGroupVersionResource().getGroup())) { // core
+                                            // resource
       groupVersion = "";
-    } else { // regular resource
-      groupVersion =
-          resourceMeta.getGroupVersionResource().getGroup()
-              + "/"
-              + resourceMeta.getGroupVersionResource().getVersion();
+    }
+    else { // regular resource
+      groupVersion = resourceMeta.getGroupVersionResource().getGroup() + "/"
+          + resourceMeta.getGroupVersionResource().getVersion();
     }
 
     String targetResourceName;
     if (Strings.isNullOrEmpty(resourceMeta.getSubResource())) {
       targetResourceName = resourceMeta.getGroupVersionResource().getResource();
-    } else { // subresource
-      targetResourceName =
-          resourceMeta.getGroupVersionResource().getResource()
-              + "/"
-              + resourceMeta.getSubResource();
+    }
+    else { // subresource
+      targetResourceName = resourceMeta.getGroupVersionResource().getResource() + "/"
+          + resourceMeta.getSubResource();
     }
 
-    return new StringBuilder()
-        .append(verb.value())
-        .append(' ')
-        .append(groupVersion)
-        .append(' ')
-        .append(targetResourceName)
-        .toString();
+    return new StringBuilder().append(verb.value()).append(' ').append(groupVersion).append(' ')
+        .append(targetResourceName).toString();
   }
+
 }

--- a/util/src/main/java/io/kubernetes/client/informer/SharedInformerFactory.java
+++ b/util/src/main/java/io/kubernetes/client/informer/SharedInformerFactory.java
@@ -12,13 +12,6 @@ limitations under the License.
 */
 package io.kubernetes.client.informer;
 
-import java.lang.reflect.Type;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-
 import com.google.gson.reflect.TypeToken;
 import io.kubernetes.client.common.KubernetesListObject;
 import io.kubernetes.client.common.KubernetesObject;
@@ -33,6 +26,12 @@ import io.kubernetes.client.util.Watch;
 import io.kubernetes.client.util.Watchable;
 import io.kubernetes.client.util.generic.GenericKubernetesApi;
 import io.kubernetes.client.util.generic.options.ListOptions;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import okhttp3.Call;
 import org.apache.commons.collections4.MapUtils;
 
@@ -296,4 +295,23 @@ public class SharedInformerFactory {
     stopAllRegisteredInformers(true);
   }
 
+  /**
+   * Stop all registered informers.
+   *
+   * @param shutdownThreadPool whether or not to shut down the thread pool.
+   */
+  public synchronized void stopAllRegisteredInformers(boolean shutdownThreadPool) {
+    if (MapUtils.isEmpty(informers)) {
+      return;
+    }
+    informers.forEach(
+        (informerType, informer) -> {
+          if (startedInformers.remove(informerType) != null) {
+            informer.stop();
+          }
+        });
+    if (shutdownThreadPool) {
+      informerExecutor.shutdown();
+    }
+  }
 }

--- a/util/src/main/java/io/kubernetes/client/informer/SharedInformerFactory.java
+++ b/util/src/main/java/io/kubernetes/client/informer/SharedInformerFactory.java
@@ -12,6 +12,13 @@ limitations under the License.
 */
 package io.kubernetes.client.informer;
 
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
 import com.google.gson.reflect.TypeToken;
 import io.kubernetes.client.common.KubernetesListObject;
 import io.kubernetes.client.common.KubernetesObject;
@@ -26,12 +33,6 @@ import io.kubernetes.client.util.Watch;
 import io.kubernetes.client.util.Watchable;
 import io.kubernetes.client.util.generic.GenericKubernetesApi;
 import io.kubernetes.client.util.generic.options.ListOptions;
-import java.lang.reflect.Type;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import okhttp3.Call;
 import org.apache.commons.collections4.MapUtils;
 
@@ -295,23 +296,4 @@ public class SharedInformerFactory {
     stopAllRegisteredInformers(true);
   }
 
-  /**
-   * Stop all registered informers.
-   *
-   * @param shutdownThreadPool whether or not to shut down the thread pool.
-   */
-  public synchronized void stopAllRegisteredInformers(boolean shutdownThreadPool) {
-    if (MapUtils.isEmpty(informers)) {
-      return;
-    }
-    informers.forEach(
-        (informerType, informer) -> {
-          if (startedInformers.remove(informerType) != null) {
-            informer.stop();
-          }
-        });
-    if (shutdownThreadPool) {
-      informerExecutor.shutdown();
-    }
-  }
 }

--- a/util/src/main/java/io/kubernetes/client/informer/cache/Caches.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/Caches.java
@@ -12,12 +12,11 @@ limitations under the License.
 */
 package io.kubernetes.client.informer.cache;
 
-import java.util.Collections;
-import java.util.List;
-
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.util.Strings;
+import java.util.Collections;
+import java.util.List;
 
 /** A set of helper utilities for constructing a cache. */
 public class Caches {

--- a/util/src/main/java/io/kubernetes/client/informer/cache/Caches.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/Caches.java
@@ -12,11 +12,12 @@ limitations under the License.
 */
 package io.kubernetes.client.informer.cache;
 
-import com.google.common.base.Strings;
-import io.kubernetes.client.common.KubernetesObject;
-import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import java.util.Collections;
 import java.util.List;
+
+import io.kubernetes.client.common.KubernetesObject;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.util.Strings;
 
 /** A set of helper utilities for constructing a cache. */
 public class Caches {

--- a/util/src/main/java/io/kubernetes/client/informer/cache/Controller.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/Controller.java
@@ -12,6 +12,11 @@ limitations under the License.
 */
 package io.kubernetes.client.informer.cache;
 
+import io.kubernetes.client.common.KubernetesListObject;
+import io.kubernetes.client.common.KubernetesObject;
+import io.kubernetes.client.informer.ListerWatcher;
+import io.kubernetes.client.informer.ResyncRunnable;
+import io.kubernetes.client.util.Threads;
 import java.util.Deque;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
@@ -20,16 +25,9 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import io.kubernetes.client.common.KubernetesListObject;
-import io.kubernetes.client.common.KubernetesObject;
-import io.kubernetes.client.informer.ListerWatcher;
-import io.kubernetes.client.informer.ResyncRunnable;
-import io.kubernetes.client.util.Threads;
 
 /**
  * Controller is a java port of k/client-go's informer#Controller. It plumbs reflector and the queue
@@ -84,12 +82,12 @@ public class Controller<
     // starts one daemon thread for reflector
     this.reflectExecutor =
         Executors.newSingleThreadScheduledExecutor(
-          Threads.threadFactory("controller-reflector-" + apiTypeClass.getName() + "-%d"));
+            Threads.threadFactory("controller-reflector-" + apiTypeClass.getName() + "-%d"));
 
     // starts one daemon thread for resync
     this.resyncExecutor =
         Executors.newSingleThreadScheduledExecutor(
-          Threads.threadFactory("controller-reflector-" + apiTypeClass.getName() + "-%d"));
+            Threads.threadFactory("controller-reflector-" + apiTypeClass.getName() + "-%d"));
   }
 
   public Controller(

--- a/util/src/main/java/io/kubernetes/client/informer/cache/Lister.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/Lister.java
@@ -12,10 +12,9 @@ limitations under the License.
 */
 package io.kubernetes.client.informer.cache;
 
-import java.util.List;
-
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.util.Strings;
+import java.util.List;
 
 /** Lister interface is used to list cached items from a running informer. */
 public class Lister<ApiType extends KubernetesObject> {

--- a/util/src/main/java/io/kubernetes/client/informer/cache/Lister.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/Lister.java
@@ -12,9 +12,10 @@ limitations under the License.
 */
 package io.kubernetes.client.informer.cache;
 
-import com.google.common.base.Strings;
-import io.kubernetes.client.common.KubernetesObject;
 import java.util.List;
+
+import io.kubernetes.client.common.KubernetesObject;
+import io.kubernetes.client.util.Strings;
 
 /** Lister interface is used to list cached items from a running informer. */
 public class Lister<ApiType extends KubernetesObject> {

--- a/util/src/main/java/io/kubernetes/client/informer/cache/ReflectorRunnable.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/ReflectorRunnable.java
@@ -12,16 +12,6 @@ limitations under the License.
 */
 package io.kubernetes.client.informer.cache;
 
-import java.io.IOException;
-import java.net.ConnectException;
-import java.time.Duration;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.BiConsumer;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.kubernetes.client.common.KubernetesListObject;
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.informer.EventType;
@@ -31,6 +21,14 @@ import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.util.CallGeneratorParams;
 import io.kubernetes.client.util.Strings;
 import io.kubernetes.client.util.Watchable;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ReflectorRunnable<
         ApiType extends KubernetesObject, ApiListType extends KubernetesListObject>

--- a/util/src/main/java/io/kubernetes/client/informer/cache/ReflectorRunnable.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/ReflectorRunnable.java
@@ -12,7 +12,16 @@ limitations under the License.
 */
 package io.kubernetes.client.informer.cache;
 
-import com.google.common.base.Strings;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.kubernetes.client.common.KubernetesListObject;
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.informer.EventType;
@@ -20,15 +29,8 @@ import io.kubernetes.client.informer.ListerWatcher;
 import io.kubernetes.client.openapi.models.V1ListMeta;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.util.CallGeneratorParams;
+import io.kubernetes.client.util.Strings;
 import io.kubernetes.client.util.Watchable;
-import java.io.IOException;
-import java.net.ConnectException;
-import java.time.Duration;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.BiConsumer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ReflectorRunnable<
         ApiType extends KubernetesObject, ApiListType extends KubernetesListObject>

--- a/util/src/main/java/io/kubernetes/client/monitoring/PrometheusInterceptor.java
+++ b/util/src/main/java/io/kubernetes/client/monitoring/PrometheusInterceptor.java
@@ -12,12 +12,13 @@ limitations under the License.
 */
 package io.kubernetes.client.monitoring;
 
-import com.google.common.base.Strings;
+import java.io.IOException;
+
 import io.kubernetes.client.apimachinery.KubernetesRequestDigest;
+import io.kubernetes.client.util.Strings;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Histogram;
 import io.prometheus.client.SimpleTimer;
-import java.io.IOException;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;

--- a/util/src/main/java/io/kubernetes/client/monitoring/PrometheusInterceptor.java
+++ b/util/src/main/java/io/kubernetes/client/monitoring/PrometheusInterceptor.java
@@ -12,13 +12,12 @@ limitations under the License.
 */
 package io.kubernetes.client.monitoring;
 
-import java.io.IOException;
-
 import io.kubernetes.client.apimachinery.KubernetesRequestDigest;
 import io.kubernetes.client.util.Strings;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Histogram;
 import io.prometheus.client.SimpleTimer;
+import java.io.IOException;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;

--- a/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
+++ b/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
@@ -12,9 +12,6 @@ limitations under the License.
 */
 package io.kubernetes.client.util;
 
-import com.google.common.base.Strings;
-import com.google.common.reflect.ClassPath;
-import com.google.common.util.concurrent.Striped;
 import io.kubernetes.client.Discovery;
 import io.kubernetes.client.apimachinery.GroupVersionKind;
 import io.kubernetes.client.apimachinery.GroupVersionResource;

--- a/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
+++ b/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
@@ -12,6 +12,12 @@ limitations under the License.
 */
 package io.kubernetes.client.util;
 
+import io.kubernetes.client.Discovery;
+import io.kubernetes.client.apimachinery.GroupVersionKind;
+import io.kubernetes.client.apimachinery.GroupVersionResource;
+import io.kubernetes.client.common.KubernetesListObject;
+import io.kubernetes.client.common.KubernetesObject;
+import io.kubernetes.client.openapi.ApiException;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -28,30 +34,20 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.kubernetes.client.Discovery;
-import io.kubernetes.client.apimachinery.GroupVersionKind;
-import io.kubernetes.client.apimachinery.GroupVersionResource;
-import io.kubernetes.client.common.KubernetesListObject;
-import io.kubernetes.client.common.KubernetesObject;
-import io.kubernetes.client.openapi.ApiException;
-import sun.tools.java.ClassPath;
-
 /**
- * Model mapper loads pre-built kubernetes models from classpath and manages their mapping
- * between their apiVersion and kind.
+ * Model mapper loads pre-built kubernetes models from classpath and manages their mapping between
+ * their apiVersion and kind.
  */
 public class ModelMapper {
 
   private static final Logger logger = LoggerFactory.getLogger(ModelMapper.class);
 
-  public static final Duration DEFAULT_DISCOVERY_REFRESH_INTERVAL = Duration
-      .ofMinutes(30);
+  public static final Duration DEFAULT_DISCOVERY_REFRESH_INTERVAL = Duration.ofMinutes(30);
 
   // initially loaded from classpath, can be incorrect
   private static Map<GroupVersionKind, Class<?>> preBuiltClassesByGVK = new HashMap<>();
@@ -62,34 +58,33 @@ public class ModelMapper {
   // Model's api-version midfix to kubernetes api-version
   private static List<String> preBuiltApiVersions = new ArrayList<>();
 
-  private static BiDirectionalMap<GroupVersionKind, Class<?>> classesByGVK = new BiDirectionalMap<>();
+  private static BiDirectionalMap<GroupVersionKind, Class<?>> classesByGVK =
+      new BiDirectionalMap<>();
 
-  private static BiDirectionalMap<GroupVersionResource, Class<?>> classesByGVR = new BiDirectionalMap<>();
+  private static BiDirectionalMap<GroupVersionResource, Class<?>> classesByGVR =
+      new BiDirectionalMap<>();
 
   private static Map<Class<?>, Boolean> isNamespacedByClasses = new ConcurrentHashMap<>();
 
   private static Set<Discovery.APIResource> lastAPIDiscovery = new HashSet<>();
 
-  private static volatile long nextDiscoveryRefreshTimeMillis = 0; // zero means
-  // api-discovery
-  // never done
+  // zero means api-discovery never done
+  private static volatile long nextDiscoveryRefreshTimeMillis = 0;
 
   static {
     try {
       initModelMap();
-    }
-    catch (Exception ex) {
+    } catch (Exception ex) {
       logger.error("Unexpected exception while loading classes", ex);
     }
   }
 
   /**
-   * Registering concrete model classes by its apiGroupVersion (e.g. "apps/v1") and kind
-   * (e.g. "Deployment").
+   * Registering concrete model classes by its apiGroupVersion (e.g. "apps/v1") and kind (e.g.
+   * "Deployment").
    *
-   * <p>
-   * Note that the the so-called apiGroupVersion equals to the "apiVersion" in the
-   * kubenretes resource yamls.
+   * <p>Note that the the so-called apiGroupVersion equals to the "apiVersion" in the kubenretes
+   * resource yamls.
    */
   @Deprecated
   public static void addModelMap(String apiGroupVersion, String kind, Class<?> clazz) {
@@ -103,36 +98,38 @@ public class ModelMapper {
   /**
    * Registering concrete model classes by its group, version and kind (e.g. "apps", "v1",
    * "Deployment")
+   *
    * @param group the group
    * @param version the version
    * @param kind the kind
    * @param clazz the clazz
    */
   @Deprecated
-  public static void addModelMap(String group, String version, String kind,
-      Class<?> clazz) {
+  public static void addModelMap(String group, String version, String kind, Class<?> clazz) {
     preBuiltAddModelMap(group, version, kind, clazz);
   }
 
   /**
    * Registering concrete model classes by its group, version and kind (e.g. "apps", "v1",
    * "Deployment")
+   *
    * @param group the group
    * @param version the version
    * @param kind the kind
    * @param resourceNamePlural the resource name plural
    * @param clazz the clazz
    */
-  public static void addModelMap(String group, String version, String kind,
-      String resourceNamePlural, Class<?> clazz) {
+  public static void addModelMap(
+      String group, String version, String kind, String resourceNamePlural, Class<?> clazz) {
     // TODO(yue9944882): consistency between bi-directional maps
     classesByGVK.add(new GroupVersionKind(group, version, kind), clazz);
     classesByGVR.add(new GroupVersionResource(group, version, resourceNamePlural), clazz);
   }
 
   /**
-   * Registering concrete model classes by its group, version, kind and isNamespaced (e.g.
-   * "apps", "v1", "Deployment", true).
+   * Registering concrete model classes by its group, version, kind and isNamespaced (e.g. "apps",
+   * "v1", "Deployment", true).
+   *
    * @param group the group
    * @param version the version
    * @param kind the kind
@@ -140,15 +137,20 @@ public class ModelMapper {
    * @param isNamespacedResource the is namespaced resource
    * @param clazz the clazz
    */
-  public static void addModelMap(String group, String version, String kind,
-      String resourceNamePlural, Boolean isNamespacedResource, Class<?> clazz) {
+  public static void addModelMap(
+      String group,
+      String version,
+      String kind,
+      String resourceNamePlural,
+      Boolean isNamespacedResource,
+      Class<?> clazz) {
     addModelMap(group, version, kind, resourceNamePlural, clazz);
     isNamespacedByClasses.put(clazz, isNamespacedResource);
   }
 
   /**
-   * Gets the model classes by given apiGroupVersion (e.g. "apps/v1") and kind (e.g.
-   * "Deployment").
+   * Gets the model classes by given apiGroupVersion (e.g. "apps/v1") and kind (e.g. "Deployment").
+   *
    * @param apiGroupVersion the api version
    * @param kind the kind
    * @return the api type class
@@ -161,8 +163,7 @@ public class ModelMapper {
       // legacy group
       apiGroup = "";
       apiVersion = apiGroupVersion;
-    }
-    else {
+    } else {
       apiGroup = parts[0];
       apiVersion = parts[1];
     }
@@ -170,8 +171,8 @@ public class ModelMapper {
   }
 
   /**
-   * Gets the model classes by given group, version and kind (e.g. "apps", ""v1",
-   * "Deployment").
+   * Gets the model classes by given group, version and kind (e.g. "apps", ""v1", "Deployment").
+   *
    * @param group the group
    * @param version the version
    * @param kind the kind
@@ -187,6 +188,7 @@ public class ModelMapper {
 
   /**
    * Gets the GVK by the given model class.
+   *
    * @param clazz the clazz
    * @return the group version kind by class
    */
@@ -196,6 +198,7 @@ public class ModelMapper {
 
   /**
    * Gets the GVK by the given model class.
+   *
    * @param clazz the clazz
    * @return the group version kind by class
    */
@@ -204,30 +207,30 @@ public class ModelMapper {
   }
 
   /**
-   * Refreshes the model mapping by syncing up w/the api discovery info from the
-   * kubernetes apiserver. These mapping will be cached for
-   * {@link ModelMapper#DEFAULT_DISCOVERY_REFRESH_INTERVAL}.
+   * Refreshes the model mapping by syncing up w/the api discovery info from the kubernetes
+   * apiserver. These mapping will be cached for {@link
+   * ModelMapper#DEFAULT_DISCOVERY_REFRESH_INTERVAL}.
+   *
    * @param discovery the discovery
    * @return the set
    * @throws ApiException the api exception
    */
-  public static Set<Discovery.APIResource> refresh(Discovery discovery)
-      throws ApiException {
+  public static Set<Discovery.APIResource> refresh(Discovery discovery) throws ApiException {
     return refresh(discovery, DEFAULT_DISCOVERY_REFRESH_INTERVAL);
   }
 
   /**
-   * Refreshes the model mapping by syncing up w/the api discovery info from the
-   * kubernetes apiserver.
+   * Refreshes the model mapping by syncing up w/the api discovery info from the kubernetes
+   * apiserver.
    *
-   * <p>
-   * Note: if model mappings can be incomplete if this method is never called.
+   * <p>Note: if model mappings can be incomplete if this method is never called.
+   *
    * @param discovery the discovery
    * @return the api-discovery set
    * @throws ApiException the api exception
    */
-  public static Set<Discovery.APIResource> refresh(Discovery discovery,
-      Duration refreshInterval) throws ApiException {
+  public static Set<Discovery.APIResource> refresh(Discovery discovery, Duration refreshInterval)
+      throws ApiException {
     long nowMillis = System.currentTimeMillis();
     if (nowMillis < nextDiscoveryRefreshTimeMillis) {
       return lastAPIDiscovery;
@@ -237,15 +240,19 @@ public class ModelMapper {
 
     for (Discovery.APIResource apiResource : apiResources) {
       for (String version : apiResource.getVersions()) {
-        Class<?> clazz = getApiTypeClass(apiResource.getGroup(), version,
-            apiResource.getKind());
+        Class<?> clazz = getApiTypeClass(apiResource.getGroup(), version, apiResource.getKind());
         // no such classes registered in the ModelMapper, ignoring
         if (clazz == null) {
           continue;
         }
         // sync up w/ the latest api discovery
-        addModelMap(apiResource.getGroup(), version, apiResource.getKind(),
-            apiResource.getResourcePlural(), apiResource.getNamespaced(), clazz);
+        addModelMap(
+            apiResource.getGroup(),
+            version,
+            apiResource.getKind(),
+            apiResource.getResourcePlural(),
+            apiResource.getNamespaced(),
+            clazz);
       }
     }
 
@@ -258,13 +265,11 @@ public class ModelMapper {
     return nextDiscoveryRefreshTimeMillis != 0;
   }
 
-  static void preBuiltAddModelMap(String group, String version, String kind,
-      Class<?> clazz) {
+  static void preBuiltAddModelMap(String group, String version, String kind, Class<?> clazz) {
     preBuiltClassesByGVK.put(new GroupVersionKind(group, version, kind), clazz);
   }
 
-  public static Class<?> preBuiltGetApiTypeClass(String group, String version,
-      String kind) {
+  public static Class<?> preBuiltGetApiTypeClass(String group, String version, String kind) {
     Class<?> clazz = preBuiltClassesByGVK.get(new GroupVersionKind(group, version, kind));
     if (clazz != null) {
       return clazz;
@@ -274,11 +279,15 @@ public class ModelMapper {
 
   public static GroupVersionKind preBuiltGetGroupVersionKindByClass(Class<?> clazz) {
     return preBuiltClassesByGVK.entrySet().stream()
-        .filter(e -> clazz.equals(e.getValue())).map(e -> e.getKey()).findFirst().get();
+        .filter(e -> clazz.equals(e.getValue()))
+        .map(e -> e.getKey())
+        .findFirst()
+        .get();
   }
 
   /**
    * Checks whether the class is connected with a namespaced kubernetes resource.
+   *
    * @param clazz the clazz
    * @return the boolean
    */
@@ -323,8 +332,9 @@ public class ModelMapper {
     initApiGroupMap();
     initApiVersionList();
 
-    for (String classInfo : getClassNamesFromPackage(Yaml.class.getClassLoader(),
-        "io.kubernetes.client.openapi.models")) {
+    for (String classInfo :
+        getClassNamesFromPackage(
+            Yaml.class.getClassLoader(), "io.kubernetes.client.openapi.models")) {
       Class<?> clazz = loadClass(classInfo, Yaml.class.getClassLoader());
       if (!KubernetesObject.class.isAssignableFrom(clazz)
           && !KubernetesListObject.class.isAssignableFrom(clazz)) {
@@ -345,22 +355,25 @@ public class ModelMapper {
   private static Class<?> loadClass(String name, ClassLoader classLoader) {
     try {
       return Class.forName(name, false, classLoader);
-    }
-    catch (ClassNotFoundException e) {
+    } catch (ClassNotFoundException e) {
       return null;
     }
   }
 
   private static Pair<String, String> getApiGroup(String name) {
-    return preBuiltApiGroups.entrySet().stream().filter(e -> name.startsWith(e.getKey()))
+    return preBuiltApiGroups.entrySet().stream()
+        .filter(e -> name.startsWith(e.getKey()))
         .map(e -> new MutablePair(e.getValue(), name.substring(e.getKey().length())))
-        .findFirst().orElse(new MutablePair(null, name));
+        .findFirst()
+        .orElse(new MutablePair(null, name));
   }
 
   private static Pair<String, String> getApiVersion(String name) {
-    return preBuiltApiVersions.stream().filter(v -> name.startsWith(v))
+    return preBuiltApiVersions.stream()
+        .filter(v -> name.startsWith(v))
         .map(v -> new MutablePair(v.toLowerCase(), name.substring(v.length())))
-        .findFirst().orElse(new MutablePair(null, name));
+        .findFirst()
+        .orElse(new MutablePair(null, name));
   }
 
   static class BiDirectionalMap<K, V> {
@@ -381,13 +394,12 @@ public class ModelMapper {
     K getByV(V v) {
       return vkMap.get(v);
     }
-
   }
 
   private static List<String> getClassNamesFromPackage(ClassLoader classLoader, String pkg)
       throws IOException {
 
-        URL packageURL;
+    URL packageURL;
     ArrayList<String> names = new ArrayList<String>();
 
     String packageName = pkg.replace(".", "/");
@@ -405,16 +417,13 @@ public class ModelMapper {
       jarEntries = jf.entries();
       while (jarEntries.hasMoreElements()) {
         entryName = jarEntries.nextElement().getName();
-        if (entryName.startsWith(packageName)
-            && entryName.length() > packageName.length() + 5) {
-          entryName = entryName.substring(packageName.length()+1,
-              entryName.lastIndexOf('.'));
+        if (entryName.startsWith(packageName) && entryName.length() > packageName.length() + 5) {
+          entryName = entryName.substring(packageName.length() + 1, entryName.lastIndexOf('.'));
           names.add(pkg + "." + entryName);
         }
       }
       jf.close();
-    }
-    else {
+    } else {
       URI uri = URI.create(packageURL.toString());
       File folder = new File(uri.getPath());
       File[] contenuti = folder.listFiles();
@@ -427,5 +436,4 @@ public class ModelMapper {
     }
     return names;
   }
-
 }

--- a/util/src/main/java/io/kubernetes/client/util/Namespaces.java
+++ b/util/src/main/java/io/kubernetes/client/util/Namespaces.java
@@ -12,10 +12,10 @@ limitations under the License.
 */
 package io.kubernetes.client.util;
 
-import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 /** Namespaces provides a set of helpers for operating namespaces. */
 public class Namespaces {
@@ -27,8 +27,8 @@ public class Namespaces {
   public static final String NAMESPACE_KUBESYSTEM = "kube-system";
 
   public static String getPodNamespace() throws IOException {
-    return Files.asCharSource(
-            new File(Config.SERVICEACCOUNT_NAMESPACE_PATH), Charset.defaultCharset())
-        .read();
+    return new String(Files.readAllBytes(new File(Config.SERVICEACCOUNT_NAMESPACE_PATH).toPath()),
+        StandardCharsets.UTF_8);
   }
+
 }

--- a/util/src/main/java/io/kubernetes/client/util/Namespaces.java
+++ b/util/src/main/java/io/kubernetes/client/util/Namespaces.java
@@ -27,8 +27,8 @@ public class Namespaces {
   public static final String NAMESPACE_KUBESYSTEM = "kube-system";
 
   public static String getPodNamespace() throws IOException {
-    return new String(Files.readAllBytes(new File(Config.SERVICEACCOUNT_NAMESPACE_PATH).toPath()),
+    return new String(
+        Files.readAllBytes(new File(Config.SERVICEACCOUNT_NAMESPACE_PATH).toPath()),
         StandardCharsets.UTF_8);
   }
-
 }

--- a/util/src/main/java/io/kubernetes/client/util/ProxyContentTypeRequestBody.java
+++ b/util/src/main/java/io/kubernetes/client/util/ProxyContentTypeRequestBody.java
@@ -13,7 +13,6 @@ limitations under the License.
 package io.kubernetes.client.util;
 
 import java.io.IOException;
-
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import okio.BufferedSink;

--- a/util/src/main/java/io/kubernetes/client/util/ProxyContentTypeRequestBody.java
+++ b/util/src/main/java/io/kubernetes/client/util/ProxyContentTypeRequestBody.java
@@ -12,8 +12,8 @@ limitations under the License.
 */
 package io.kubernetes.client.util;
 
-import com.google.common.base.Strings;
 import java.io.IOException;
+
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import okio.BufferedSink;

--- a/util/src/main/java/io/kubernetes/client/util/Streams.java
+++ b/util/src/main/java/io/kubernetes/client/util/Streams.java
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+
+public class Streams {
+
+  public static final int BUFFER_SIZE = 4096;
+
+  public static void copy(InputStream in, OutputStream out) throws IOException {
+    byte[] buffer = new byte[BUFFER_SIZE];
+    int bytesRead;
+    while ((bytesRead = in.read(buffer)) != -1) {
+      out.write(buffer, 0, bytesRead);
+    }
+    out.flush();
+  }
+
+  public static String toString(Reader reader) throws IOException {
+    StringBuilder out = new StringBuilder(BUFFER_SIZE);
+    char[] buffer = new char[BUFFER_SIZE];
+    int charsRead;
+    while ((charsRead = reader.read(buffer)) != -1) {
+      out.append(buffer, 0, charsRead);
+    }
+    return out.toString();
+  }
+
+  public static void readFully(InputStream in, byte[] bytes) throws IOException {
+    int total = 0;
+    int len = bytes.length;
+    while (total < len) {
+      int result = in.read(bytes, total, len - total);
+      if (result == -1) {
+        break;
+      }
+      total += result;
+    }
+  }
+}

--- a/util/src/main/java/io/kubernetes/client/util/Strings.java
+++ b/util/src/main/java/io/kubernetes/client/util/Strings.java
@@ -10,24 +10,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package io.kubernetes.client.util.credentials;
+package io.kubernetes.client.util;
 
-import java.util.Objects;
+import javax.annotation.Nullable;
 
-import io.kubernetes.client.openapi.ApiClient;
+public class Strings {
 
-/** Uses a Bearer Token to configure {@link ApiClient} authentication to the Kubernetes API. */
-public class AccessTokenAuthentication implements Authentication {
-  private String token;
-
-  public AccessTokenAuthentication(final String token) {
-    Objects.requireNonNull(token, "Access Token cannot be null");
-    this.token = token;
+  public static boolean isNullOrEmpty(String value) {
+    return value == null || value.length() == 0;
   }
 
-  @Override
-  public void provide(ApiClient client) {
-    client.setApiKeyPrefix("Bearer");
-    client.setApiKey(token);
+  public static String nullToEmpty(@Nullable String string) {
+    return (string == null) ? "" : string;
   }
 }

--- a/util/src/main/java/io/kubernetes/client/util/Threads.java
+++ b/util/src/main/java/io/kubernetes/client/util/Threads.java
@@ -17,7 +17,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class Threads {
-  
+
   public static ThreadFactory threadFactory(String format) {
     final ThreadFactory defaultFactory = Executors.defaultThreadFactory();
     final AtomicInteger threadNumber = new AtomicInteger(1);

--- a/util/src/main/java/io/kubernetes/client/util/Threads.java
+++ b/util/src/main/java/io/kubernetes/client/util/Threads.java
@@ -23,9 +23,7 @@ public class Threads {
     final AtomicInteger threadNumber = new AtomicInteger(1);
     return r -> {
       Thread thread = defaultFactory.newThread(r);
-      if (!thread.isDaemon()) {
-        thread.setDaemon(true);
-      }
+      // Daemon status inherited from default
       thread.setName(String.format(format, threadNumber.getAndIncrement()));
       return thread;
     };

--- a/util/src/main/java/io/kubernetes/client/util/Threads.java
+++ b/util/src/main/java/io/kubernetes/client/util/Threads.java
@@ -1,0 +1,33 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.util;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class Threads {
+  
+  public static ThreadFactory threadFactory(String format) {
+    final ThreadFactory defaultFactory = Executors.defaultThreadFactory();
+    final AtomicInteger threadNumber = new AtomicInteger(1);
+    return r -> {
+      Thread thread = defaultFactory.newThread(r);
+      if (!thread.isDaemon()) {
+        thread.setDaemon(true);
+      }
+      thread.setName(String.format(format, threadNumber.getAndIncrement()));
+      return thread;
+    };
+  }
+}

--- a/util/src/main/java/io/kubernetes/client/util/WebSocketStreamHandler.java
+++ b/util/src/main/java/io/kubernetes/client/util/WebSocketStreamHandler.java
@@ -12,9 +12,6 @@ limitations under the License.
 */
 package io.kubernetes.client.util;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.ByteStreams;
-import com.google.common.io.CharStreams;
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.IOException;
@@ -24,6 +21,7 @@ import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import okhttp3.WebSocket;
@@ -84,7 +82,7 @@ public class WebSocketStreamHandler implements WebSockets.SocketListener, Closea
   public void textMessage(Reader in) {
     try {
       handleMessage(
-          in.read(), new ByteArrayInputStream(CharStreams.toString(in).getBytes(Charsets.UTF_8)));
+          in.read(), new ByteArrayInputStream(Streams.toString(in).getBytes(StandardCharsets.UTF_8)));
     } catch (IOException ex) {
       log.error("Error writing message", ex);
     }
@@ -93,7 +91,7 @@ public class WebSocketStreamHandler implements WebSockets.SocketListener, Closea
   protected void handleMessage(int stream, InputStream inStream) throws IOException {
     try {
       OutputStream out = getSocketInputOutputStream(stream);
-      ByteStreams.copy(inStream, out);
+      Streams.copy(inStream, out);
       out.flush();
     } finally {
       inStream.close();

--- a/util/src/main/java/io/kubernetes/client/util/WebSocketStreamHandler.java
+++ b/util/src/main/java/io/kubernetes/client/util/WebSocketStreamHandler.java
@@ -82,7 +82,8 @@ public class WebSocketStreamHandler implements WebSockets.SocketListener, Closea
   public void textMessage(Reader in) {
     try {
       handleMessage(
-          in.read(), new ByteArrayInputStream(Streams.toString(in).getBytes(StandardCharsets.UTF_8)));
+          in.read(),
+          new ByteArrayInputStream(Streams.toString(in).getBytes(StandardCharsets.UTF_8)));
     } catch (IOException ex) {
       log.error("Error writing message", ex);
     }

--- a/util/src/main/java/io/kubernetes/client/util/WebSockets.java
+++ b/util/src/main/java/io/kubernetes/client/util/WebSockets.java
@@ -12,7 +12,6 @@ limitations under the License.
 */
 package io.kubernetes.client.util;
 
-import com.google.common.net.HttpHeaders;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.Pair;
@@ -30,6 +29,7 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
+import okhttp3.internal.http.HttpHeaders;
 import okio.ByteString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +41,8 @@ public class WebSockets {
   public static final String V4_STREAM_PROTOCOL = "v4.channel.k8s.io";
   public static final String STREAM_PROTOCOL_HEADER = "Sec-WebSocket-Protocol";
   public static final String SPDY_3_1 = "SPDY/3.1";
+  public static final String CONNECTION = "Connection";
+  public static final String UPGRADE = "Upgrade";
 
   /** A simple interface for a listener on a web socket */
   public interface SocketListener {
@@ -91,8 +93,8 @@ public class WebSockets {
 
     HashMap<String, String> headers = new HashMap<String, String>();
     headers.put(STREAM_PROTOCOL_HEADER, V4_STREAM_PROTOCOL);
-    headers.put(HttpHeaders.CONNECTION, HttpHeaders.UPGRADE);
-    headers.put(HttpHeaders.UPGRADE, SPDY_3_1);
+    headers.put(WebSockets.CONNECTION, WebSockets.UPGRADE);
+    headers.put(WebSockets.UPGRADE, SPDY_3_1);
     String[] localVarAuthNames = new String[] {"BearerToken"};
 
     Request request =

--- a/util/src/main/java/io/kubernetes/client/util/WebSockets.java
+++ b/util/src/main/java/io/kubernetes/client/util/WebSockets.java
@@ -29,7 +29,6 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
-import okhttp3.internal.http.HttpHeaders;
 import okio.ByteString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/util/src/main/java/io/kubernetes/client/util/annotations/Annotations.java
+++ b/util/src/main/java/io/kubernetes/client/util/annotations/Annotations.java
@@ -12,8 +12,9 @@ limitations under the License.
 */
 package io.kubernetes.client.util.annotations;
 
-import com.google.common.collect.ImmutableMap;
 import io.kubernetes.client.common.KubernetesObject;
+
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,7 +29,7 @@ public class Annotations {
    */
   public static void addAnnotations(
       KubernetesObject kubernetesObject, String annotation, String value) {
-    addAnnotations(kubernetesObject, ImmutableMap.of(annotation, value));
+    addAnnotations(kubernetesObject, Collections.singletonMap(annotation, value));
   }
 
   /**

--- a/util/src/main/java/io/kubernetes/client/util/annotations/Annotations.java
+++ b/util/src/main/java/io/kubernetes/client/util/annotations/Annotations.java
@@ -13,7 +13,6 @@ limitations under the License.
 package io.kubernetes.client.util.annotations;
 
 import io.kubernetes.client.common.KubernetesObject;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;

--- a/util/src/main/java/io/kubernetes/client/util/credentials/AccessTokenAuthentication.java
+++ b/util/src/main/java/io/kubernetes/client/util/credentials/AccessTokenAuthentication.java
@@ -12,9 +12,8 @@ limitations under the License.
 */
 package io.kubernetes.client.util.credentials;
 
-import java.util.Objects;
-
 import io.kubernetes.client.openapi.ApiClient;
+import java.util.Objects;
 
 /** Uses a Bearer Token to configure {@link ApiClient} authentication to the Kubernetes API. */
 public class AccessTokenAuthentication implements Authentication {

--- a/util/src/main/java/io/kubernetes/client/util/generic/GenericKubernetesApi.java
+++ b/util/src/main/java/io/kubernetes/client/util/generic/GenericKubernetesApi.java
@@ -12,11 +12,13 @@ limitations under the License.
 */
 package io.kubernetes.client.util.generic;
 
-import com.google.common.base.Strings;
+import java.io.IOException;
+
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
+
 import io.kubernetes.client.common.KubernetesListObject;
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.common.KubernetesType;
@@ -28,6 +30,7 @@ import io.kubernetes.client.openapi.apis.CustomObjectsApi;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Status;
 import io.kubernetes.client.util.PatchUtils;
+import io.kubernetes.client.util.Strings;
 import io.kubernetes.client.util.Watch;
 import io.kubernetes.client.util.Watchable;
 import io.kubernetes.client.util.generic.options.CreateOptions;
@@ -36,7 +39,6 @@ import io.kubernetes.client.util.generic.options.GetOptions;
 import io.kubernetes.client.util.generic.options.ListOptions;
 import io.kubernetes.client.util.generic.options.PatchOptions;
 import io.kubernetes.client.util.generic.options.UpdateOptions;
-import java.io.IOException;
 import okhttp3.Call;
 import okhttp3.HttpUrl;
 

--- a/util/src/main/java/io/kubernetes/client/util/generic/GenericKubernetesApi.java
+++ b/util/src/main/java/io/kubernetes/client/util/generic/GenericKubernetesApi.java
@@ -12,13 +12,10 @@ limitations under the License.
 */
 package io.kubernetes.client.util.generic;
 
-import java.io.IOException;
-
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
-
 import io.kubernetes.client.common.KubernetesListObject;
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.common.KubernetesType;
@@ -39,6 +36,7 @@ import io.kubernetes.client.util.generic.options.GetOptions;
 import io.kubernetes.client.util.generic.options.ListOptions;
 import io.kubernetes.client.util.generic.options.PatchOptions;
 import io.kubernetes.client.util.generic.options.UpdateOptions;
+import java.io.IOException;
 import okhttp3.Call;
 import okhttp3.HttpUrl;
 


### PR DESCRIPTION
A few utilities have their own shared implementations
in util package (e.g. Strings, Streams).

ThreadFactory implemented as private method where needed.

Use ConcurrentHashMap instead of Stripe.

The ClassPath scan in ModelMapper is replaced with private
method.

Caffeine is used for caches.

Fixes #1412