### PR TITLE
Add a KubectlApply processor for Spring.

### DIFF
--- a/spring/src/main/java/io/kubernetes/client/spring/extended/manifests/KubernetesKubectlApplyProcessor.java
+++ b/spring/src/main/java/io/kubernetes/client/spring/extended/manifests/KubernetesKubectlApplyProcessor.java
@@ -1,0 +1,72 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.spring.extended.manifests;
+
+import io.kubernetes.client.common.KubernetesObject;
+import io.kubernetes.client.extended.kubectl.Kubectl;
+import io.kubernetes.client.extended.kubectl.exception.KubectlException;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.spring.extended.manifests.annotation.KubectlApply;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+public class KubernetesKubectlApplyProcessor implements BeanPostProcessor, BeanFactoryAware {
+
+  private static final Logger log = LoggerFactory.getLogger(KubernetesKubectlApplyProcessor.class);
+
+  private ListableBeanFactory beanFactory;
+
+  @Autowired private ApiClient apiClient;
+
+  public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+    if (!(bean instanceof KubernetesObject)) {
+      return bean; // no-op
+    }
+
+    KubectlApply apply = beanFactory.findAnnotationOnBean(beanName, KubectlApply.class);
+    if (apply == null) {
+      return bean;
+    }
+
+    Class<? extends KubernetesObject> apiTypeClass =
+        (Class<? extends KubernetesObject>) bean.getClass();
+
+    try {
+      log.info("@KubectlApply ensuring resource upon bean {}", beanName);
+      return apply(apiTypeClass, bean);
+    } catch (KubectlException e) {
+      log.error("Failed ensuring resource from @KubectlApply", e);
+      throw new BeanCreationException("Failed ensuring resource from @KubectlApply", e);
+    }
+  }
+
+  public <ApiType extends KubernetesObject> ApiType apply(Class<ApiType> apiTypeClass, Object obj)
+      throws KubectlException {
+    return Kubectl.apply(apiTypeClass)
+        .apiClient(this.apiClient)
+        .resource((ApiType) obj)
+        .execute(); // replaced the bean of the created status
+  }
+
+  @Override
+  public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+    this.beanFactory = (ListableBeanFactory) beanFactory;
+  }
+}

--- a/spring/src/main/java/io/kubernetes/client/spring/extended/manifests/annotation/KubectlApply.java
+++ b/spring/src/main/java/io/kubernetes/client/spring/extended/manifests/annotation/KubectlApply.java
@@ -1,0 +1,24 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.spring.extended.manifests.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface KubectlApply {
+  boolean skipApiDiscovery() default false;
+}

--- a/spring/src/main/java/io/kubernetes/client/spring/extended/manifests/config/KubernetesManifestsAutoConfiguration.java
+++ b/spring/src/main/java/io/kubernetes/client/spring/extended/manifests/config/KubernetesManifestsAutoConfiguration.java
@@ -13,6 +13,7 @@ limitations under the License.
 package io.kubernetes.client.spring.extended.manifests.config;
 
 import io.kubernetes.client.spring.extended.manifests.KubernetesFromYamlProcessor;
+import io.kubernetes.client.spring.extended.manifests.KubernetesKubectlApplyProcessor;
 import io.kubernetes.client.spring.extended.manifests.KubernetesKubectlCreateProcessor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -32,5 +33,11 @@ public class KubernetesManifestsAutoConfiguration {
   @ConditionalOnMissingBean
   public KubernetesFromYamlProcessor kubernetesFromYamlProcessor() {
     return new KubernetesFromYamlProcessor();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public KubernetesKubectlApplyProcessor kubernetesKubectlApplyProcessor() {
+    return new KubernetesKubectlApplyProcessor();
   }
 }

--- a/spring/src/test/java/io/kubernetes/client/spring/extended/manifests/KubernetesManifestTest.java
+++ b/spring/src/test/java/io/kubernetes/client/spring/extended/manifests/KubernetesManifestTest.java
@@ -14,6 +14,7 @@ package io.kubernetes.client.spring.extended.manifests;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.patch;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
@@ -26,7 +27,9 @@ import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.Configuration;
 import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1ServiceAccount;
+import io.kubernetes.client.spring.extended.manifests.annotation.KubectlApply;
 import io.kubernetes.client.spring.extended.manifests.annotation.KubectlCreate;
 import io.kubernetes.client.util.ClientBuilder;
 import java.io.IOException;
@@ -84,6 +87,21 @@ public class KubernetesManifestTest {
                   .namespace(testNamespace.getMetadata().getName())
                   .name("spring-boot-test-serviceaccount"));
     }
+
+    @Bean
+    public KubernetesKubectlApplyProcessor kubernetesApplyManifestsProcessor() {
+      return new KubernetesKubectlApplyProcessor();
+    }
+
+    @Bean
+    @KubectlApply
+    public V1Pod testApplyPod(V1Namespace testNamespace) {
+      return new V1Pod()
+          .metadata(
+              new V1ObjectMeta()
+                  .namespace(testNamespace.getMetadata().getName())
+                  .name("spring-boot-test-pod"));
+    }
   }
 
   @Autowired private ApiClient client;
@@ -91,6 +109,8 @@ public class KubernetesManifestTest {
   @Autowired private V1Namespace createdNamespace;
 
   @Autowired private V1ServiceAccount createdServiceAccount;
+
+  @Autowired private V1Pod createdPod;
 
   private static final V1Namespace returningCreatedNamespace =
       new V1Namespace()
@@ -104,6 +124,14 @@ public class KubernetesManifestTest {
           .metadata(
               new V1ObjectMeta()
                   .name("spring-boot-test-serviceaccount")
+                  .putLabelsItem("created", "true"));
+
+  private static final V1Pod returningCreatedPod =
+      new V1Pod()
+          .metadata(
+              new V1ObjectMeta()
+                  .name("spring-boot-test-pod")
+                  .namespace("spring-boot-test-namespace")
                   .putLabelsItem("created", "true"));
 
   static {
@@ -128,6 +156,18 @@ public class KubernetesManifestTest {
                         Configuration.getDefaultApiClient()
                             .getJSON()
                             .serialize(returningCreatedServiceAccount))));
+
+    wireMockRule.stubFor(
+        patch(
+                urlEqualTo(
+                    "/api/v1/namespaces/spring-boot-test-namespace/pods/spring-boot-test-pod?fieldManager=kubernetes-java-kubectl-apply&force=false"))
+            .willReturn(
+                aResponse()
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        Configuration.getDefaultApiClient()
+                            .getJSON()
+                            .serialize(returningCreatedPod))));
 
     try {
       wireMockRule.stubFor(
@@ -157,8 +197,10 @@ public class KubernetesManifestTest {
   public void test() {
     assertNotNull(createdNamespace);
     assertNotNull(createdServiceAccount);
+    assertNotNull(createdPod);
 
     assertEquals("true", createdNamespace.getMetadata().getLabels().get("created"));
     assertEquals("true", createdServiceAccount.getMetadata().getLabels().get("created"));
+    assertEquals("true", createdPod.getMetadata().getLabels().get("created"));
   }
 }


### PR DESCRIPTION
KubectlCreate is good if things are constant, but if resources could have changed, it's useful to perform an apply instead.

Note that this is largely, copy/paste from KubectlCreate, we could consider extracting a super-class for shared methods if we wanted to.