### PR TITLE
Fix Guava regexp in spotless config

### DIFF
--- a/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlApplyTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlApplyTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.*;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
-import com.google.common.io.Resources;
 import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.extended.kubectl.exception.KubectlException;
 import io.kubernetes.client.openapi.ApiClient;
@@ -35,13 +34,14 @@ import org.junit.Test;
 
 public class KubectlApplyTest {
 
-  private static final String DISCOVERY_API = Resources.getResource("discovery-api.json").getPath();
+  private static final String DISCOVERY_API =
+      KubectlApplyTest.class.getClassLoader().getResource("discovery-api.json").getPath();
 
   private static final String DISCOVERY_APIV1 =
-      Resources.getResource("discovery-api-v1.json").getPath();
+      KubectlApplyTest.class.getClassLoader().getResource("discovery-api-v1.json").getPath();
 
   private static final String DISCOVERY_APIS =
-      Resources.getResource("discovery-apis.json").getPath();
+      KubectlApplyTest.class.getClassLoader().getResource("discovery-apis.json").getPath();
 
   private ApiClient apiClient;
 

--- a/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlCreateTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlCreateTest.java
@@ -16,7 +16,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.junit.Assert.assertNotNull;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.google.common.io.Resources;
 import io.kubernetes.client.extended.kubectl.exception.KubectlException;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
@@ -32,13 +31,14 @@ import org.junit.Test;
 
 public class KubectlCreateTest {
 
-  private static final String DISCOVERY_API = Resources.getResource("discovery-api.json").getPath();
+  private static final String DISCOVERY_API =
+      KubectlCreateTest.class.getClassLoader().getResource("discovery-api.json").getPath();
 
   private static final String DISCOVERY_APIV1 =
-      Resources.getResource("discovery-api-v1.json").getPath();
+      KubectlCreateTest.class.getClassLoader().getResource("discovery-api-v1.json").getPath();
 
   private static final String DISCOVERY_APIS =
-      Resources.getResource("discovery-apis.json").getPath();
+      KubectlCreateTest.class.getClassLoader().getResource("discovery-apis.json").getPath();
 
   private ApiClient apiClient;
 

--- a/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlDrainTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlDrainTest.java
@@ -25,7 +25,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.junit.Assert.assertEquals;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.google.common.io.Resources;
 import io.kubernetes.client.extended.kubectl.exception.KubectlException;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.models.V1Node;
@@ -41,7 +40,8 @@ import org.junit.Test;
 
 public class KubectlDrainTest {
 
-  private static final String POD_LIST_API = Resources.getResource("pod-list.json").getPath();
+  private static final String POD_LIST_API =
+      KubectlDrainTest.class.getClassLoader().getResource("pod-list.json").getPath();
 
   private ApiClient apiClient;
 

--- a/extended/src/test/java/io/kubernetes/client/extended/pager/PagerTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/pager/PagerTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.google.common.io.Resources;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Namespace;
@@ -47,15 +46,15 @@ public class PagerTest {
 
   private ApiClient client;
   private static final String LIST_PAGE0_FILE_PATH =
-      Resources.getResource("namespace-list-pager0.json").getPath();
+      PagerTest.class.getClassLoader().getResource("namespace-list-pager0.json").getPath();
   private static final String LIST_PAGE1_FILE_PATH =
-      Resources.getResource("namespace-list-pager1.json").getPath();
+      PagerTest.class.getClassLoader().getResource("namespace-list-pager1.json").getPath();
   private static final String LIST_PAGE2_FILE_PATH =
-      Resources.getResource("namespace-list-pager2.json").getPath();
+      PagerTest.class.getClassLoader().getResource("namespace-list-pager2.json").getPath();
   private static final String LIST_STATUS_FILE_PATH =
-      Resources.getResource("status-400.json").getPath();
+      PagerTest.class.getClassLoader().getResource("status-400.json").getPath();
   private static final String STATUS_BAD_TOKEN_FILE_PATH =
-      Resources.getResource("bad-token-status.json").getPath();
+      PagerTest.class.getClassLoader().getResource("bad-token-status.json").getPath();
   @Rule public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
   @Before

--- a/pom.xml
+++ b/pom.xml
@@ -481,7 +481,6 @@
             <!-- removes guava imports -->
             <format>
               <includes>
-                <include>examples/**/*.java</include>
                 <include>extended/**/*.java</include>
                 <include>kubernetes/**/*.java</include>
                 <include>proto/**/*.java</include>
@@ -490,7 +489,7 @@
               </includes>
               <replaceRegex>
                 <name>Forbids guava imports</name>
-                <searchRegex>^import (static )?com\.google\.guava\..*;$</searchRegex>
+                <searchRegex>^import (static )?com\.google\.common\..*;$</searchRegex>
                 <replacement>INVALID IMPORTS (GUAVA)</replacement>
               </replaceRegex>
             </format>

--- a/spring/src/test/java/io/kubernetes/client/spring/extended/manifests/KubernetesManifestTest.java
+++ b/spring/src/test/java/io/kubernetes/client/spring/extended/manifests/KubernetesManifestTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.google.common.io.Resources;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.Configuration;
 import io.kubernetes.client.openapi.models.V1Namespace;
@@ -42,19 +41,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = KubernetesManifestTest.App.class)
 public class KubernetesManifestTest {
 
-  private static final String DISCOVERY_API = Resources.getResource("discovery-api.json").getPath();
+  private static final Resource DISCOVERY_API = new ClassPathResource("discovery-api.json");
 
-  private static final String DISCOVERY_APIV1 =
-      Resources.getResource("discovery-api-v1.json").getPath();
+  private static final Resource DISCOVERY_APIV1 = new ClassPathResource("discovery-api-v1.json");
 
-  private static final String DISCOVERY_APIS =
-      Resources.getResource("discovery-apis.json").getPath();
+  private static final Resource DISCOVERY_APIS = new ClassPathResource("discovery-apis.json");
 
   @ClassRule public static WireMockRule wireMockRule = new WireMockRule(8288);
 
@@ -175,19 +174,22 @@ public class KubernetesManifestTest {
               .willReturn(
                   aResponse()
                       .withStatus(200)
-                      .withBody(new String(Files.readAllBytes(Paths.get(DISCOVERY_API))))));
+                      .withBody(
+                          new String(Files.readAllBytes(Paths.get(DISCOVERY_API.getURI()))))));
       wireMockRule.stubFor(
           get(urlPathEqualTo("/apis"))
               .willReturn(
                   aResponse()
                       .withStatus(200)
-                      .withBody(new String(Files.readAllBytes(Paths.get(DISCOVERY_APIS))))));
+                      .withBody(
+                          new String(Files.readAllBytes(Paths.get(DISCOVERY_APIS.getURI()))))));
       wireMockRule.stubFor(
           get(urlPathEqualTo("/api/v1"))
               .willReturn(
                   aResponse()
                       .withStatus(200)
-                      .withBody(new String(Files.readAllBytes(Paths.get(DISCOVERY_APIV1))))));
+                      .withBody(
+                          new String(Files.readAllBytes(Paths.get(DISCOVERY_APIV1.getURI()))))));
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/util/src/test/java/io/kubernetes/client/ExecTest.java
+++ b/util/src/test/java/io/kubernetes/client/ExecTest.java
@@ -21,13 +21,13 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import static org.junit.Assert.assertEquals;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.google.common.io.ByteStreams;
 import io.kubernetes.client.Exec.ExecProcess;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.util.ClientBuilder;
+import io.kubernetes.client.util.Streams;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -88,7 +88,7 @@ public class ExecTest {
             new Runnable() {
               public void run() {
                 try {
-                  ByteStreams.copy(is, os);
+                  Streams.copy(is, os);
                 } catch (IOException ex) {
                   ex.printStackTrace();
                 }

--- a/util/src/test/java/io/kubernetes/client/PodLogsTest.java
+++ b/util/src/test/java/io/kubernetes/client/PodLogsTest.java
@@ -21,7 +21,6 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import static org.junit.Assert.assertEquals;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.google.common.io.ByteStreams;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1Container;
@@ -29,6 +28,7 @@ import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.util.ClientBuilder;
+import io.kubernetes.client.util.Streams;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -124,7 +124,7 @@ public class PodLogsTest {
             .withQueryParam("timestamps", equalTo("false")));
 
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    ByteStreams.copy(is, bos);
+    Streams.copy(is, bos);
     assertEquals(content, bos.toString());
   }
 }

--- a/util/src/test/java/io/kubernetes/client/Resources.java
+++ b/util/src/test/java/io/kubernetes/client/Resources.java
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client;
+
+import io.kubernetes.client.util.Streams;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.Charset;
+
+public class Resources {
+
+  public static URL getResource(String name) {
+    return Resources.class.getClassLoader().getResource(name);
+  }
+
+  public static String toString(URL url, Charset charset) {
+    try {
+      return Streams.toString(new InputStreamReader(url.openStream(), charset));
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/util/src/test/java/io/kubernetes/client/informer/cache/DeltaFIFOTest.java
+++ b/util/src/test/java/io/kubernetes/client/informer/cache/DeltaFIFOTest.java
@@ -15,7 +15,6 @@ package io.kubernetes.client.informer.cache;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import com.google.common.collect.Lists;
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
@@ -160,7 +159,7 @@ public class DeltaFIFOTest {
     DeltaFIFO deltaFIFO = new DeltaFIFO(Caches::deletionHandlingMetaNamespaceKeyFunc, mockCache);
 
     deltaFIFO.delete(oldPod);
-    deltaFIFO.replace(Lists.newArrayList(newPod), "0");
+    deltaFIFO.replace(Arrays.asList(newPod), "0");
 
     deltaFIFO.pop(
         (deltas) -> {

--- a/util/src/test/java/io/kubernetes/client/util/ClientBuilderTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/ClientBuilderTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import com.google.common.io.Resources;
+import io.kubernetes.client.Resources;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.util.credentials.Authentication;
 import java.io.File;

--- a/util/src/test/java/io/kubernetes/client/util/FilePersisterTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/FilePersisterTest.java
@@ -12,9 +12,9 @@ limitations under the License.
 */
 package io.kubernetes.client.util;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
-import com.google.common.io.Resources;
+import io.kubernetes.client.Resources;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;

--- a/util/src/test/java/io/kubernetes/client/util/SSLUtilsTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/SSLUtilsTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.util;
 
-import com.google.common.io.Resources;
+import io.kubernetes.client.Resources;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;

--- a/util/src/test/java/io/kubernetes/client/util/YamlTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/YamlTest.java
@@ -14,13 +14,13 @@ package io.kubernetes.client.util;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.io.Resources;
+import io.kubernetes.client.Resources;
 import io.kubernetes.client.common.KubernetesType;
 import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;

--- a/util/src/test/java/io/kubernetes/client/util/credentials/ClientCertificateAuthenticationTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/credentials/ClientCertificateAuthenticationTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.util.credentials;
 
-import com.google.common.io.Resources;
+import io.kubernetes.client.Resources;
 import io.kubernetes.client.openapi.ApiClient;
 import java.nio.file.Files;
 import java.nio.file.Paths;

--- a/util/src/test/java/io/kubernetes/client/util/credentials/OpenIDConnectAuthenticationTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/credentials/OpenIDConnectAuthenticationTest.java
@@ -12,12 +12,19 @@ limitations under the License.
 */
 package io.kubernetes.client.util.credentials;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static org.junit.Assert.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.google.common.io.Resources;
+import io.kubernetes.client.Resources;
 import io.kubernetes.client.util.TestUtils;
 import io.kubernetes.client.util.authenticators.OpenIDConnectAuthenticator;
 import java.io.FileInputStream;

--- a/util/src/test/java/io/kubernetes/client/util/credentials/TokenFileAuthenticationTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/credentials/TokenFileAuthenticationTest.java
@@ -12,12 +12,17 @@ limitations under the License.
 */
 package io.kubernetes.client.util.credentials;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.okForContentType;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.google.common.io.Resources;
+import io.kubernetes.client.Resources;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.Configuration;

--- a/util/src/test/java/io/kubernetes/client/util/credentials/UsernamePasswordAuthenticationTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/credentials/UsernamePasswordAuthenticationTest.java
@@ -16,8 +16,8 @@ import static io.kubernetes.client.util.TestUtils.getApiKeyAuthFromClient;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-import com.google.common.base.Charsets;
 import io.kubernetes.client.openapi.ApiClient;
+import java.nio.charset.StandardCharsets;
 import okio.ByteString;
 import org.junit.Test;
 
@@ -26,7 +26,7 @@ public class UsernamePasswordAuthenticationTest {
   private static final String USERNAME = "username";
   private static final String PASSWORD = "password";
   public static final byte[] USERNAME_PASSWORD_BYTES =
-      (USERNAME + ":" + PASSWORD).getBytes(Charsets.ISO_8859_1);
+      (USERNAME + ":" + PASSWORD).getBytes(StandardCharsets.ISO_8859_1);
 
   @Test
   public void testUsernamePasswordProvided() {


### PR DESCRIPTION
There was a regex in the spotless config in top level pom.xml designed to assert that Guava was not being used, but the pattern was wrong. Once you fix that, you either need to rewrite some of the tests that were still using it, or don't apply that rule to tests.