### PR TITLE
Add updateStatus() convenience methods to GenericKubernetesApi

### DIFF
--- a/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesApiTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesApiTest.java
@@ -22,6 +22,7 @@ import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1JobList;
+import io.kubernetes.client.openapi.models.V1JobStatus;
 import io.kubernetes.client.openapi.models.V1ListMeta;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Status;
@@ -150,6 +151,23 @@ public class GenericKubernetesApiTest {
     assertEquals(foo1, jobListResp.getObject());
     assertNull(jobListResp.getStatus());
     verify(1, putRequestedFor(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1")));
+  }
+
+  @Test
+  public void updateStatusNamespacedJobReturningObject() {
+    V1Job foo1 =
+        new V1Job().kind("Job").metadata(new V1ObjectMeta().namespace("default").name("foo1"));
+    foo1.setStatus(new V1JobStatus().failed(1));
+
+    stubFor(
+        patch(urlEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1/status"))
+            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(foo1))));
+    KubernetesApiResponse<V1Job> jobListResp = jobClient.updateStatus(foo1, t -> t.getStatus());
+    assertTrue(jobListResp.isSuccess());
+    assertEquals(foo1, jobListResp.getObject());
+    assertNull(jobListResp.getStatus());
+    verify(
+        1, patchRequestedFor(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1/status")));
   }
 
   @Test


### PR DESCRIPTION
Fixes #1442, as a draft at least. We could refactor it to be more like the Golang API, e.g. 

```java
GenericKubernetesApi<T,L> api = ...;
api.status().update(...);
```

instead of

```java
GenericKubernetesApi<T,L> api = ...;
api.updateStatus(...);
```

WDYT?