### PR TITLE
Support rfc3339 micro-sec (6 digit) timestamp

### DIFF
--- a/e2e/src/test/java/io/kubernetes/client/e2e/extended/leaderelection/LeaderElectorTest.java
+++ b/e2e/src/test/java/io/kubernetes/client/e2e/extended/leaderelection/LeaderElectorTest.java
@@ -26,8 +26,6 @@ import io.kubernetes.client.util.ClientBuilder;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.time.Duration;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -77,21 +75,6 @@ public class LeaderElectorTest {
       apiClient = ClientBuilder.defaultClient();
     } catch (IOException ex) {
       throw new RuntimeException("Couldn't create ApiClient", ex);
-    }
-    // Lease resource requires special care with DateTime
-    if (lockType == LockType.Lease) {
-      // TODO: switch date-time library so that micro-sec timestamp can be serialized
-      // in RFC3339
-      // format w/ correct precision without the hacks
-
-      // This formatter is used for Lease resource spec's acquire/renewTime
-      DateTimeFormatter formatter =
-          new DateTimeFormatterBuilder()
-              .appendOptional(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'"))
-              .appendOptional(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'"))
-              .toFormatter();
-
-      apiClient.setOffsetDateTimeFormat(formatter);
     }
     this.lockType = lockType;
   }

--- a/extended/src/main/java/io/kubernetes/client/extended/leaderelection/resourcelock/LeaseLock.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/leaderelection/resourcelock/LeaseLock.java
@@ -135,15 +135,23 @@ public class LeaseLock implements Lock {
   }
 
   private V1LeaseSpec getLeaseFromRecord(LeaderElectionRecord record) {
-    return new V1LeaseSpec()
-        .acquireTime(
-            OffsetDateTime.ofInstant(
-                Instant.ofEpochMilli(record.getAcquireTime().getTime()), ZoneOffset.UTC))
-        .renewTime(
-            OffsetDateTime.ofInstant(
-                Instant.ofEpochMilli(record.getRenewTime().getTime()), ZoneOffset.UTC))
-        .holderIdentity(record.getHolderIdentity())
-        .leaseDurationSeconds(record.getLeaseDurationSeconds())
-        .leaseTransitions(record.getLeaderTransitions());
+    V1LeaseSpec spec =
+        new V1LeaseSpec()
+            .holderIdentity(record.getHolderIdentity())
+            .leaseDurationSeconds(record.getLeaseDurationSeconds())
+            .leaseTransitions(record.getLeaderTransitions());
+    if (record.getAcquireTime() != null) {
+      spec =
+          spec.acquireTime(
+              OffsetDateTime.ofInstant(
+                  Instant.ofEpochMilli(record.getAcquireTime().getTime()), ZoneOffset.UTC));
+    }
+    if (record.getRenewTime() != null) {
+      spec =
+          spec.renewTime(
+              OffsetDateTime.ofInstant(
+                  Instant.ofEpochMilli(record.getRenewTime().getTime()), ZoneOffset.UTC));
+    }
+    return spec;
   }
 }

--- a/kubernetes/src/main/java/io/kubernetes/client/openapi/JSON.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/openapi/JSON.java
@@ -45,7 +45,7 @@ public class JSON {
 
   private boolean isLenientOnJson = false;
 
-  public static final DateTimeFormatter RFC3339MICRO_FORMATTER =
+  private static final DateTimeFormatter RFC3339MICRO_FORMATTER =
       new DateTimeFormatterBuilder()
           .parseDefaulting(ChronoField.OFFSET_SECONDS, 0)
           .append(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"))

--- a/kubernetes/src/main/java/io/kubernetes/client/openapi/JSON.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/openapi/JSON.java
@@ -32,6 +32,8 @@ import java.text.ParsePosition;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 import java.util.Date;
 import java.util.Map;
 import okio.ByteString;
@@ -42,11 +44,22 @@ public class JSON {
 
   private boolean isLenientOnJson = false;
 
+  public static final DateTimeFormatter RFC3339MICRO_FORMATTER =
+      new DateTimeFormatterBuilder()
+          .parseDefaulting(ChronoField.OFFSET_SECONDS, 0)
+          .append(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"))
+          .optionalStart()
+          .appendFraction(ChronoField.NANO_OF_SECOND, 6, 6, true)
+          .optionalEnd()
+          .appendLiteral("Z")
+          .toFormatter();
+
   private DateTypeAdapter dateTypeAdapter = new DateTypeAdapter();
 
   private SqlDateTypeAdapter sqlDateTypeAdapter = new SqlDateTypeAdapter();
 
-  private OffsetDateTimeTypeAdapter offsetDateTimeTypeAdapter = new OffsetDateTimeTypeAdapter();
+  private OffsetDateTimeTypeAdapter offsetDateTimeTypeAdapter =
+      new OffsetDateTimeTypeAdapter(RFC3339MICRO_FORMATTER);
 
   private LocalDateTypeAdapter localDateTypeAdapter = new LocalDateTypeAdapter();
 

--- a/kubernetes/src/main/java/io/kubernetes/client/openapi/JSON.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/openapi/JSON.java
@@ -33,6 +33,7 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
 import java.util.Date;
 import java.util.Map;
@@ -244,7 +245,12 @@ public class JSON {
           if (date.endsWith("+0000")) {
             date = date.substring(0, date.length() - 5) + "Z";
           }
-          return OffsetDateTime.parse(date, formatter);
+          try {
+            return OffsetDateTime.parse(date, formatter);
+          } catch (DateTimeParseException e) {
+            // backward-compatibility for ISO8601 timestamp format
+            return OffsetDateTime.parse(date, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+          }
       }
     }
   }

--- a/kubernetes/src/test/java/io/kubernetes/client/openapi/JSONTest.java
+++ b/kubernetes/src/test/java/io/kubernetes/client/openapi/JSONTest.java
@@ -15,6 +15,7 @@ package io.kubernetes.client.openapi;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
+import java.time.OffsetDateTime;
 import okio.ByteString;
 import org.junit.Test;
 
@@ -35,5 +36,30 @@ public class JSONTest {
     // Check encoded string correctly
     final String decodedText = new String(byteStr.toByteArray());
     assertThat(decodedText, is(plainText));
+  }
+
+  @Test
+  public void testOffsetDateTime1e6Parse() {
+    System.out.println(JSON.RFC3339MICRO_FORMATTER.format(OffsetDateTime.now()));
+    String timeStr = "2018-04-03T11:32:26.123456Z";
+    OffsetDateTime t = OffsetDateTime.parse(timeStr, JSON.RFC3339MICRO_FORMATTER);
+    String serializedTsStr = JSON.RFC3339MICRO_FORMATTER.format(t);
+    assertEquals(timeStr, serializedTsStr);
+  }
+
+  @Test
+  public void testOffsetDateTime1e4Parse() {
+    String timeStr = "2018-04-03T11:32:26.123400Z";
+    OffsetDateTime t = OffsetDateTime.parse(timeStr, JSON.RFC3339MICRO_FORMATTER);
+    String serializedTsStr = JSON.RFC3339MICRO_FORMATTER.format(t);
+    assertEquals(timeStr, serializedTsStr);
+  }
+
+  @Test
+  public void testOffsetDateTimeNoFractionParse() {
+    String timeStr = "2018-04-03T11:32:26Z";
+    OffsetDateTime t = OffsetDateTime.parse(timeStr, JSON.RFC3339MICRO_FORMATTER);
+    String serializedTsStr = JSON.RFC3339MICRO_FORMATTER.format(t);
+    assertEquals("2018-04-03T11:32:26.000000Z", serializedTsStr);
   }
 }

--- a/kubernetes/src/test/java/io/kubernetes/client/openapi/JSONTest.java
+++ b/kubernetes/src/test/java/io/kubernetes/client/openapi/JSONTest.java
@@ -67,9 +67,10 @@ public class JSONTest {
 
   @Test
   public void testOffsetDateTimeNoFractionParse() {
-    String timeStr = "2018-04-03T11:32:26Z";
-    OffsetDateTime t = OffsetDateTime.parse(timeStr, JSON.RFC3339MICRO_FORMATTER);
-    String serializedTsStr = JSON.RFC3339MICRO_FORMATTER.format(t);
-    assertEquals("2018-04-03T11:32:26.000000Z", serializedTsStr);
+    String timeStr = "\"2018-04-03T11:32:26Z\"";
+    OffsetDateTime dateTime = json.deserialize(timeStr, OffsetDateTime.class);
+    String serializedTsStr = json.serialize(dateTime);
+    String expectedStr = "\"2018-04-03T11:32:26.000000Z\"";
+    assertEquals(expectedStr, serializedTsStr);
   }
 }

--- a/kubernetes/src/test/java/io/kubernetes/client/openapi/JSONTest.java
+++ b/kubernetes/src/test/java/io/kubernetes/client/openapi/JSONTest.java
@@ -21,9 +21,10 @@ import org.junit.Test;
 
 public class JSONTest {
 
+  private final JSON json = new JSON();
+
   @Test
   public void testSerializeByteArray() {
-    final JSON json = new JSON();
     final String plainText = "string that contains '=' when encoded";
     final String base64String = json.serialize(plainText.getBytes());
     // serialize returns string surrounded by quotes: "\"[base64]\""
@@ -40,19 +41,28 @@ public class JSONTest {
 
   @Test
   public void testOffsetDateTime1e6Parse() {
-    System.out.println(JSON.RFC3339MICRO_FORMATTER.format(OffsetDateTime.now()));
-    String timeStr = "2018-04-03T11:32:26.123456Z";
-    OffsetDateTime t = OffsetDateTime.parse(timeStr, JSON.RFC3339MICRO_FORMATTER);
-    String serializedTsStr = JSON.RFC3339MICRO_FORMATTER.format(t);
+    String timeStr = "\"2018-04-03T11:32:26.123456Z\"";
+    OffsetDateTime dateTime = json.deserialize(timeStr, OffsetDateTime.class);
+    String serializedTsStr = json.serialize(dateTime);
     assertEquals(timeStr, serializedTsStr);
   }
 
   @Test
   public void testOffsetDateTime1e4Parse() {
-    String timeStr = "2018-04-03T11:32:26.123400Z";
-    OffsetDateTime t = OffsetDateTime.parse(timeStr, JSON.RFC3339MICRO_FORMATTER);
-    String serializedTsStr = JSON.RFC3339MICRO_FORMATTER.format(t);
-    assertEquals(timeStr, serializedTsStr);
+    String timeStr = "\"2018-04-03T11:32:26.1234Z\"";
+    OffsetDateTime dateTime = json.deserialize(timeStr, OffsetDateTime.class);
+    String serializedTsStr = json.serialize(dateTime);
+    String expectedStr = "\"2018-04-03T11:32:26.123400Z\"";
+    assertEquals(expectedStr, serializedTsStr);
+  }
+
+  @Test
+  public void testOffsetDateTime1e3Parse() {
+    String timeStr = "\"2018-04-03T11:32:26.123Z\"";
+    OffsetDateTime dateTime = json.deserialize(timeStr, OffsetDateTime.class);
+    String serializedTsStr = json.serialize(dateTime);
+    String expectedStr = "\"2018-04-03T11:32:26.123000Z\"";
+    assertEquals(expectedStr, serializedTsStr);
   }
 
   @Test


### PR DESCRIPTION
@brendandburns @dsyer 

it's a follow-up of #1418.

this pull will force the timestamp types to be serialized including 6 digit of fraction in order to support the precision of micro-second.

the original kubernetes go types basically accepts two kinds of timestamp in RFC3339:

1. `RFC3339     = "2006-01-02T15:04:05Z07:00"` for the go type [metav1.Time](https://github.com/kubernetes/kubernetes/blob/39483aa0957be65b04686173d2970b508b3974ca/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time.go#L31-L33)
2. `RFC3339Micro = "2006-01-02T15:04:05.000000Z07:00"` for the go type [metav1.MicroTime](https://github.com/kubernetes/kubernetes/blob/39483aa0957be65b04686173d2970b508b3974ca/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time.go#L31-L33)

at the kubernetes server side, (2) can be implicitly casted to (1) if extra precision is provided. ideally java model should discriminate (1) and (2) w/ separate java types so that we can switch the precision dynamically upon serialization. however, that's infeasible for now b/c the published openapi spec from kubernetes server is marking (1) and (2) as the same openapi schema types. 

the bright side is that discriminating time types in different precision w/ different java types can be odd aesthetically..