### PR TITLE
Make Maven reactor build work

### DIFF
--- a/client-java-contrib/cert-manager/pom.xml
+++ b/client-java-contrib/cert-manager/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>io.kubernetes</groupId>
         <artifactId>client-java-parent</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>12.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <!-- the version tracks the release version of the CRDs in the upstream cert-manager project -->
-    <version>11.0.1-SNAPSHOT</version>
+    <version>12.0.0-SNAPSHOT</version>
     <dependencies>
         <dependency>
             <groupId>io.kubernetes</groupId>

--- a/client-java-contrib/prometheus-operator/pom.xml
+++ b/client-java-contrib/prometheus-operator/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>client-java-parent</artifactId>
         <groupId>io.kubernetes</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>12.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>client-java-prometheus-operator-models</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>12.0.0-SNAPSHOT</version>
     <dependencies>
         <dependency>
             <groupId>io.kubernetes</groupId>

--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>client-java-parent</artifactId>
         <groupId>io.kubernetes</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>12.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/examples-release-10/pom.xml
+++ b/examples/examples-release-10/pom.xml
@@ -1,13 +1,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.kubernetes</groupId>
+    <parent>
+        <groupId>io.kubernetes</groupId>
+        <artifactId>client-java-examples-parent</artifactId>
+        <version>12.0.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
     <artifactId>client-java-examples-release-10</artifactId>
     <packaging>bundle</packaging>
     <name>client-java-examples-release-10</name>
-    <version>1.0.0</version>
+    <version>12.0.0-SNAPSHOT</version>
     <properties>
-        <kubernetes.client.version>10.0.1</kubernetes.client.version>
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -27,27 +32,27 @@
         <dependency>
             <groupId>io.kubernetes</groupId>
             <artifactId>client-java-api</artifactId>
-            <version>${kubernetes.client.version}</version>
+            <version>10.0.1</version>
         </dependency>
         <dependency>
             <groupId>io.kubernetes</groupId>
             <artifactId>client-java</artifactId>
-            <version>${kubernetes.client.version}</version>
+            <version>10.0.1</version>
         </dependency>
         <dependency>
             <groupId>io.kubernetes</groupId>
             <artifactId>client-java-extended</artifactId>
-            <version>${kubernetes.client.version}</version>
+            <version>10.0.1</version>
         </dependency>
         <dependency>
             <groupId>io.kubernetes</groupId>
             <artifactId>client-java-spring-integration</artifactId>
-            <version>${kubernetes.client.version}</version>
+            <version>10.0.1</version>
         </dependency>
         <dependency>
             <groupId>io.kubernetes</groupId>
             <artifactId>client-java-proto</artifactId>
-            <version>${kubernetes.client.version}</version>
+            <version>10.0.1</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>

--- a/examples/examples-release-11/pom.xml
+++ b/examples/examples-release-11/pom.xml
@@ -1,20 +1,25 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-	<groupId>io.kubernetes</groupId>
-	<artifactId>client-java-examples-release-11</artifactId>
-	<name>client-java-examples-release-11</name>
-    <version>1.0.0</version>
+    <parent>
+        <groupId>io.kubernetes</groupId>
+        <artifactId>client-java-examples-parent</artifactId>
+        <version>12.0.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>client-java-examples-release-11</artifactId>
+    <name>client-java-examples-release-11</name>
+    <version>12.0.0-SNAPSHOT</version>
     <properties>
-        <kubernetes.client.version>11.0.0</kubernetes.client.version>
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-		<junit.version>4.13.1</junit.version>
-		<spring.boot.version>2.4.1</spring.boot.version>
+        <junit.version>4.13.1</junit.version>
+        <spring.boot.version>2.4.1</spring.boot.version>
     </properties>
 
-	<dependencies>
+    <dependencies>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
@@ -25,72 +30,72 @@
             <artifactId>simpleclient_httpserver</artifactId>
             <version>0.9.0</version>
         </dependency>
-		<dependency>
-			<groupId>io.kubernetes</groupId>
-			<artifactId>client-java-api</artifactId>
-			<version>${kubernetes.client.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.kubernetes</groupId>
-			<artifactId>client-java</artifactId>
-			<version>${kubernetes.client.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.kubernetes</groupId>
-			<artifactId>client-java-extended</artifactId>
-			<version>${kubernetes.client.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.kubernetes</groupId>
-			<artifactId>client-java-spring-integration</artifactId>
-			<version>${kubernetes.client.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>io.kubernetes</groupId>
-			<artifactId>client-java-proto</artifactId>
-			<version>${kubernetes.client.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>commons-cli</groupId>
-			<artifactId>commons-cli</artifactId>
-			<version>1.4</version>
-		</dependency>
-		<dependency>
-			<groupId>io.kubernetes</groupId>
-			<artifactId>client-java-cert-manager-models</artifactId>
-			<version>10.0.1</version>
-		</dependency>
-		<dependency>
-			<groupId>io.kubernetes</groupId>
-			<artifactId>client-java-prometheus-operator-models</artifactId>
-			<version>10.0.1</version>
-		</dependency>
-		<!-- test dependencies -->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>${junit.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock</artifactId>
+        <dependency>
+            <groupId>io.kubernetes</groupId>
+            <artifactId>client-java-api</artifactId>
+            <version>11.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kubernetes</groupId>
+            <artifactId>client-java</artifactId>
+            <version>11.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kubernetes</groupId>
+            <artifactId>client-java-extended</artifactId>
+            <version>11.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kubernetes</groupId>
+            <artifactId>client-java-spring-integration</artifactId>
+            <version>11.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kubernetes</groupId>
+            <artifactId>client-java-proto</artifactId>
+            <version>11.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.4</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kubernetes</groupId>
+            <artifactId>client-java-cert-manager-models</artifactId>
+            <version>10.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kubernetes</groupId>
+            <artifactId>client-java-prometheus-operator-models</artifactId>
+            <version>10.0.1</version>
+        </dependency>
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
             <version>2.27.2</version>
-			<scope>test</scope>
-		</dependency>
-		<!--for spring controller example-->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-			<version>${spring.boot.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-actuator</artifactId>
-			<version>${spring.boot.version}</version>
-		</dependency>
+            <scope>test</scope>
+        </dependency>
+        <!--for spring controller example-->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
 
-	</dependencies>
+    </dependencies>
 
 
 </project>

--- a/examples/examples-release-12/pom.xml
+++ b/examples/examples-release-12/pom.xml
@@ -4,16 +4,16 @@
 	<parent>
 		<groupId>io.kubernetes</groupId>
 		<artifactId>client-java-examples-parent</artifactId>
-		<version>11.0.1-SNAPSHOT</version>
-		<relativePath>../pom.xml</relativePath>
+		<version>12.0.0-SNAPSHOT</version>
+		<relativePath>..</relativePath>
 	</parent>
 
 	<artifactId>client-java-examples-release-12</artifactId>
 	<name>client-java-examples-release-12</name>
 
 	<properties>
-		<kubernetes.prometheus.version>11.0.1-SNAPSHOT</kubernetes.prometheus.version>
-		<kubernetes.cert-manager.version>11.0.1-SNAPSHOT</kubernetes.cert-manager.version>
+		<kubernetes.prometheus.version>12.0.0-SNAPSHOT</kubernetes.prometheus.version>
+		<kubernetes.cert-manager.version>12.0.0-SNAPSHOT</kubernetes.cert-manager.version>
 	</properties>
 
 	<dependencies>
@@ -30,27 +30,27 @@
 		<dependency>
 			<groupId>io.kubernetes</groupId>
 			<artifactId>client-java-api</artifactId>
-			<version>${kubernetes.client.version}</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.kubernetes</groupId>
 			<artifactId>client-java</artifactId>
-			<version>${kubernetes.client.version}</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.kubernetes</groupId>
 			<artifactId>client-java-extended</artifactId>
-			<version>${kubernetes.client.version}</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.kubernetes</groupId>
 			<artifactId>client-java-spring-integration</artifactId>
-			<version>${kubernetes.client.version}</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.kubernetes</groupId>
 			<artifactId>client-java-proto</artifactId>
-			<version>${kubernetes.client.version}</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-cli</groupId>

--- a/examples/examples-release-12/src/main/java/io/kubernetes/client/examples/DynamicClientExample.java
+++ b/examples/examples-release-12/src/main/java/io/kubernetes/client/examples/DynamicClientExample.java
@@ -12,36 +12,31 @@ limitations under the License.
 */
 package io.kubernetes.client.examples;
 
-import java.io.FileReader;
-import java.io.IOException;
-
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.util.ClientBuilder;
-import io.kubernetes.client.util.KubeConfig;
 import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesApi;
 import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
+import java.io.IOException;
 
 public class DynamicClientExample {
 
-	public static void main(String[] args) throws IOException, ApiException {
+  public static void main(String[] args) throws IOException, ApiException {
 
-		ApiClient apiClient = ClientBuilder.standard().build();
+    ApiClient apiClient = ClientBuilder.standard().build();
 
-		// retrieving the latest state of the default namespace
-		DynamicKubernetesApi dynamicApi = new DynamicKubernetesApi("", "v1", "namespaces", apiClient);
-		DynamicKubernetesObject defaultNamespace = dynamicApi.get("default")
-				.throwsApiException()
-				.getObject();
+    // retrieving the latest state of the default namespace
+    DynamicKubernetesApi dynamicApi = new DynamicKubernetesApi("", "v1", "namespaces", apiClient);
+    DynamicKubernetesObject defaultNamespace =
+        dynamicApi.get("default").throwsApiException().getObject();
 
-		// attaching a "foo=bar" label to the default namespace
-		defaultNamespace.setMetadata(defaultNamespace.getMetadata().putLabelsItem("foo", "bar"));
-		DynamicKubernetesObject updatedDefaultNamespace = dynamicApi.update(defaultNamespace)
-				.throwsApiException()
-				.getObject();
+    // attaching a "foo=bar" label to the default namespace
+    defaultNamespace.setMetadata(defaultNamespace.getMetadata().putLabelsItem("foo", "bar"));
+    DynamicKubernetesObject updatedDefaultNamespace =
+        dynamicApi.update(defaultNamespace).throwsApiException().getObject();
 
-		System.out.println(updatedDefaultNamespace);
+    System.out.println(updatedDefaultNamespace);
 
-		apiClient.getHttpClient().connectionPool().evictAll();
-	}
+    apiClient.getHttpClient().connectionPool().evictAll();
+  }
 }

--- a/examples/examples-release-12/src/main/java/io/kubernetes/client/examples/SpringLoadBalancerExample.java
+++ b/examples/examples-release-12/src/main/java/io/kubernetes/client/examples/SpringLoadBalancerExample.java
@@ -12,12 +12,6 @@ limitations under the License.
 */
 package io.kubernetes.client.examples;
 
-import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
 import io.kubernetes.client.extended.network.EndpointsLoadBalancer;
 import io.kubernetes.client.extended.network.LoadBalancer;
 import io.kubernetes.client.extended.network.RoundRobinLoadBalanceStrategy;
@@ -25,6 +19,11 @@ import io.kubernetes.client.informer.SharedInformerFactory;
 import io.kubernetes.client.informer.cache.Lister;
 import io.kubernetes.client.openapi.models.V1Endpoints;
 import io.kubernetes.client.spring.extended.network.endpoints.InformerEndpointsGetter;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 @SpringBootApplication
 public class SpringLoadBalancerExample {
@@ -61,11 +60,8 @@ public class SpringLoadBalancerExample {
     public MyService(Lister<V1Endpoints> lister) {
       InformerEndpointsGetter getter = new InformerEndpointsGetter(lister);
       RoundRobinLoadBalanceStrategy strategy = new RoundRobinLoadBalanceStrategy();
-      defaultKubernetesLoadBalancer = new EndpointsLoadBalancer(
-        () -> getter.get("default", "kubernetes"),
-        strategy
-      );
+      defaultKubernetesLoadBalancer =
+          new EndpointsLoadBalancer(() -> getter.get("default", "kubernetes"), strategy);
     }
-
   }
 }

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,21 +4,20 @@
 	<parent>
 		<groupId>io.kubernetes</groupId>
 		<artifactId>client-java-parent</artifactId>
-		<version>11.0.1-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
-	<version>11.0.1-SNAPSHOT</version>
+	<version>12.0.0-SNAPSHOT</version>
 
 	<artifactId>client-java-examples-parent</artifactId>
 	<packaging>pom</packaging>
 	<name>client-java-examples-parent</name>
 
-	<properties>
-		<kubernetes.client.version>11.0.1-SNAPSHOT</kubernetes.client.version>
-	</properties>
-
 	<modules>
+		<module>examples-release-10</module>
+		<module>examples-release-11</module>
+		<module>examples-release-12</module>
 	</modules>
 
 	<build>

--- a/extended/pom.xml
+++ b/extended/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>client-java-parent</artifactId>
         <groupId>io.kubernetes</groupId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>12.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>io.kubernetes</groupId>
     <artifactId>client-java-parent</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>12.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>client-java-parent</artifactId>
   <groupId>io.kubernetes</groupId>
-  <version>11.0.1-SNAPSHOT</version>
+  <version>12.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Kubernetes Client API</name>
   <url>https://github.com/kubernetes-client/java</url>

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>io.kubernetes</groupId>
 		<artifactId>client-java-parent</artifactId>
-		<version>11.0.1-SNAPSHOT</version>
+		<version>12.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <artifactId>client-java-parent</artifactId>
     <groupId>io.kubernetes</groupId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>12.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.kubernetes</groupId>
         <artifactId>client-java-parent</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>12.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>


### PR DESCRIPTION
This will make IDEs work better (especially VSCode) because
otherwise they cannot compute the classpath for the examples.