### PR TITLE
Dedicated SSL context for client connections

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/SSLUtils.java
+++ b/util/src/main/java/io/kubernetes/client/util/SSLUtils.java
@@ -107,7 +107,7 @@ public class SSLUtils {
     }
     return algo;
   }
-  
+
   public static String recognizePrivateKeyPassword() {
     // Allowing to set Key password same as KeyStore password (if any)
     return System.getProperty("javax.net.ssl.keyStorePassword", "");
@@ -165,12 +165,12 @@ public class SSLUtils {
   }
 
   public static KeyStore createKeyStore(
-      InputStream certInputStream,
-      InputStream keyInputStream,
-      String clientKeyAlgo,
-      char[] clientKeyPassphrase)
-      throws IOException, CertificateException, NoSuchAlgorithmException, InvalidKeySpecException,
-          KeyStoreException {
+    InputStream certInputStream,
+    InputStream keyInputStream,
+    String clientKeyAlgo,
+    char[] clientKeyPassphrase)
+    throws IOException, CertificateException, NoSuchAlgorithmException, InvalidKeySpecException,
+      KeyStoreException {
     CertificateFactory certFactory = CertificateFactory.getInstance("X509");
     X509Certificate cert = (X509Certificate) certFactory.generateCertificate(certInputStream);
 
@@ -185,7 +185,7 @@ public class SSLUtils {
       // (which is BouncyCastle's JKS compatible provider).
       keyStore = KeyStore.getInstance("BKS");
     }
-    
+  
     keyStore.load(null);
     String alias = cert.getSubjectX500Principal().getName();
     keyStore.setKeyEntry(alias, privateKey, clientKeyPassphrase, new X509Certificate[] {cert});

--- a/util/src/main/java/io/kubernetes/client/util/SSLUtils.java
+++ b/util/src/main/java/io/kubernetes/client/util/SSLUtils.java
@@ -51,12 +51,12 @@ public class SSLUtils {
   }
 
   public static KeyManager[] keyManagers(
-      byte[] certData, byte[] keyData, String algo, String passphrase)
+      byte[] certData, byte[] keyData, String algo)
       throws NoSuchAlgorithmException, UnrecoverableKeyException, KeyStoreException,
           CertificateException, InvalidKeySpecException, IOException {
     KeyManager[] keyManagers = null;
     if (certData != null && keyData != null) {
-      KeyStore keyStore = createKeyStore(certData, keyData, algo, passphrase);
+      KeyStore keyStore = createKeyStore(certData, keyData, algo);
       KeyManagerFactory kmf =
           KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
       kmf.init(keyStore, passphrase.toCharArray());
@@ -66,7 +66,7 @@ public class SSLUtils {
   }
 
   public static KeyStore createKeyStore(
-      byte[] clientCertData, byte[] clientKeyData, String clientKeyAlgo, String clientKeyPassphrase)
+      byte[] clientCertData, byte[] clientKeyData, String clientKeyAlgo)
       throws IOException, CertificateException, NoSuchAlgorithmException, InvalidKeySpecException,
           KeyStoreException {
     try (InputStream certInputStream = new ByteArrayInputStream(clientCertData);
@@ -74,8 +74,7 @@ public class SSLUtils {
       return createKeyStore(
           certInputStream,
           keyInputStream,
-          clientKeyAlgo,
-          clientKeyPassphrase != null ? clientKeyPassphrase.toCharArray() : null);
+          clientKeyAlgo);
     }
   }
 
@@ -97,11 +96,6 @@ public class SSLUtils {
       algo = "RSA"; // PKCS#1 - RSA
     }
     return algo;
-  }
-
-  public static String recognizePrivateKeyPassword() {
-    // Allowing to set Key password same as KeyStore password (if any)
-    return System.getProperty("javax.net.ssl.keyStorePassword", "");
   }
 
   public static PrivateKey loadKey(byte[] privateKeyBytes)
@@ -158,8 +152,7 @@ public class SSLUtils {
   public static KeyStore createKeyStore(
       InputStream certInputStream,
       InputStream keyInputStream,
-      String clientKeyAlgo,
-      char[] clientKeyPassphrase)
+      String clientKeyAlgo)
       throws IOException, CertificateException, NoSuchAlgorithmException, InvalidKeySpecException,
           KeyStoreException {
     CertificateFactory certFactory = CertificateFactory.getInstance("X509");
@@ -179,7 +172,7 @@ public class SSLUtils {
 
     keyStore.load(null);
     String alias = cert.getSubjectX500Principal().getName();
-    keyStore.setKeyEntry(alias, privateKey, clientKeyPassphrase, new X509Certificate[] {cert});
+    keyStore.setKeyEntry(alias, privateKey, "", new X509Certificate[] {cert});
 
     return keyStore;
   }

--- a/util/src/main/java/io/kubernetes/client/util/SSLUtils.java
+++ b/util/src/main/java/io/kubernetes/client/util/SSLUtils.java
@@ -14,8 +14,6 @@ package io.kubernetes.client.util;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -53,16 +51,12 @@ public class SSLUtils {
   }
 
   public static KeyManager[] keyManagers(
-      byte[] certData,
-      byte[] keyData,
-      String algo,
-      String passphrase)
+      byte[] certData, byte[] keyData, String algo, String passphrase)
       throws NoSuchAlgorithmException, UnrecoverableKeyException, KeyStoreException,
           CertificateException, InvalidKeySpecException, IOException {
     KeyManager[] keyManagers = null;
     if (certData != null && keyData != null) {
-      KeyStore keyStore =
-          createKeyStore(certData, keyData, algo, passphrase);
+      KeyStore keyStore = createKeyStore(certData, keyData, algo, passphrase);
       KeyManagerFactory kmf =
           KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
       kmf.init(keyStore, passphrase.toCharArray());
@@ -72,10 +66,7 @@ public class SSLUtils {
   }
 
   public static KeyStore createKeyStore(
-      byte[] clientCertData,
-      byte[] clientKeyData,
-      String clientKeyAlgo,
-      String clientKeyPassphrase)
+      byte[] clientCertData, byte[] clientKeyData, String clientKeyAlgo, String clientKeyPassphrase)
       throws IOException, CertificateException, NoSuchAlgorithmException, InvalidKeySpecException,
           KeyStoreException {
     try (InputStream certInputStream = new ByteArrayInputStream(clientCertData);
@@ -165,12 +156,12 @@ public class SSLUtils {
   }
 
   public static KeyStore createKeyStore(
-    InputStream certInputStream,
-    InputStream keyInputStream,
-    String clientKeyAlgo,
-    char[] clientKeyPassphrase)
-    throws IOException, CertificateException, NoSuchAlgorithmException, InvalidKeySpecException,
-      KeyStoreException {
+      InputStream certInputStream,
+      InputStream keyInputStream,
+      String clientKeyAlgo,
+      char[] clientKeyPassphrase)
+      throws IOException, CertificateException, NoSuchAlgorithmException, InvalidKeySpecException,
+          KeyStoreException {
     CertificateFactory certFactory = CertificateFactory.getInstance("X509");
     X509Certificate cert = (X509Certificate) certFactory.generateCertificate(certInputStream);
 
@@ -185,7 +176,7 @@ public class SSLUtils {
       // (which is BouncyCastle's JKS compatible provider).
       keyStore = KeyStore.getInstance("BKS");
     }
-  
+
     keyStore.load(null);
     String alias = cert.getSubjectX500Principal().getName();
     keyStore.setKeyEntry(alias, privateKey, clientKeyPassphrase, new X509Certificate[] {cert});
@@ -326,5 +317,4 @@ public class SSLUtils {
       }
     }
   }
-
 }

--- a/util/src/main/java/io/kubernetes/client/util/SSLUtils.java
+++ b/util/src/main/java/io/kubernetes/client/util/SSLUtils.java
@@ -107,6 +107,11 @@ public class SSLUtils {
     }
     return algo;
   }
+  
+  public static String recognizePrivateKeyPassword() {
+    // Allowing to set Key password same as KeyStore password (if any)
+    return System.getProperty("javax.net.ssl.keyStorePassword", "");
+  }
 
   public static PrivateKey loadKey(byte[] privateKeyBytes)
       throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {

--- a/util/src/main/java/io/kubernetes/client/util/credentials/ClientCertificateAuthentication.java
+++ b/util/src/main/java/io/kubernetes/client/util/credentials/ClientCertificateAuthentication.java
@@ -38,9 +38,8 @@ public class ClientCertificateAuthentication implements Authentication {
   @Override
   public void provide(ApiClient client) {
     String algo = SSLUtils.recognizePrivateKeyAlgo(key);
-    String keyPassword = SSLUtils.recognizePrivateKeyPassword();
     try {
-      final KeyManager[] keyManagers = SSLUtils.keyManagers(certificate, key, algo, keyPassword);
+      final KeyManager[] keyManagers = SSLUtils.keyManagers(certificate, key, algo);
       client.setKeyManagers(keyManagers);
     } catch (NoSuchAlgorithmException
         | UnrecoverableKeyException

--- a/util/src/main/java/io/kubernetes/client/util/credentials/ClientCertificateAuthentication.java
+++ b/util/src/main/java/io/kubernetes/client/util/credentials/ClientCertificateAuthentication.java
@@ -38,8 +38,9 @@ public class ClientCertificateAuthentication implements Authentication {
   @Override
   public void provide(ApiClient client) {
     String algo = SSLUtils.recognizePrivateKeyAlgo(key);
+    String keyPassword = SSLUtils.recognizePrivateKeyPassword();
     try {
-      final KeyManager[] keyManagers = SSLUtils.keyManagers(certificate, key, algo, "");
+      final KeyManager[] keyManagers = SSLUtils.keyManagers(certificate, key, algo, keyPassword);
       client.setKeyManagers(keyManagers);
     } catch (NoSuchAlgorithmException
         | UnrecoverableKeyException

--- a/util/src/main/java/io/kubernetes/client/util/credentials/ClientCertificateAuthentication.java
+++ b/util/src/main/java/io/kubernetes/client/util/credentials/ClientCertificateAuthentication.java
@@ -39,7 +39,7 @@ public class ClientCertificateAuthentication implements Authentication {
   public void provide(ApiClient client) {
     String algo = SSLUtils.recognizePrivateKeyAlgo(key);
     try {
-      final KeyManager[] keyManagers = SSLUtils.keyManagers(certificate, key, algo, "", null, null);
+      final KeyManager[] keyManagers = SSLUtils.keyManagers(certificate, key, algo, "");
       client.setKeyManagers(keyManagers);
     } catch (NoSuchAlgorithmException
         | UnrecoverableKeyException


### PR DESCRIPTION
PR raised in response to [1539](https://github.com/kubernetes-client/java/issues/1539).

1. Decoupled the SSL context creation by removing part of code where existing KeyStore information is retrieved.
2. Removed unnecessary variables which will no longer be necessary with dedicated SSL context.
3. Added ENV variable based key password; not the optimal way though. please suggest if any existing best practice can be built in here.