### PR TITLE
Cherrypick for RELEASE-11: Fixes event-logger patch content

### DIFF
--- a/extended/src/main/java/io/kubernetes/client/extended/event/legacy/EventLogger.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/event/legacy/EventLogger.java
@@ -40,13 +40,7 @@ public class EventLogger {
       event.getMetadata().setName(lastObserved.name);
       event.getMetadata().setResourceVersion(lastObserved.resourceVersion);
 
-      patch =
-          new V1Patch(
-              String.format(
-                  "{\"message\":\"%s\",\"count\":%d,\"lastTimestamp\":\"%s\"}",
-                  event.getMessage(),
-                  event.getCount(),
-                  Configuration.getDefaultApiClient().getJSON().serialize(now)));
+      patch = buildEventPatch(event.getCount(), event.getMessage(), now);
     }
     EventLog log = new EventLog();
     log.count = event.getCount();
@@ -72,5 +66,12 @@ public class EventLogger {
     private DateTime firstTimestamp;
     private String name;
     private String resourceVersion;
+  }
+
+  static V1Patch buildEventPatch(int count, String message, OffsetDateTime now) {
+    return new V1Patch(
+        String.format(
+            "{\"message\":\"%s\",\"count\":%d,\"lastTimestamp\":%s}",
+            message, count, Configuration.getDefaultApiClient().getJSON().serialize(now)));
   }
 }

--- a/extended/src/main/java/io/kubernetes/client/extended/event/legacy/EventLogger.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/event/legacy/EventLogger.java
@@ -43,7 +43,7 @@ public class EventLogger {
       patch =
           new V1Patch(
               String.format(
-                  "{\"message\":\"%s\",\"count\":\"%d\",\"lastTimestamp\":%s}",
+                  "{\"message\":\"%s\",\"count\":%d,\"lastTimestamp\":\"%s\"}",
                   event.getMessage(),
                   event.getCount(),
                   Configuration.getDefaultApiClient().getJSON().serialize(now)));

--- a/extended/src/test/java/io/kubernetes/client/extended/event/legacy/EventLoggerTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/event/legacy/EventLoggerTest.java
@@ -1,0 +1,32 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.extended.event.legacy;
+
+import static org.junit.Assert.*;
+
+import io.kubernetes.client.custom.V1Patch;
+import java.time.OffsetDateTime;
+import org.junit.Test;
+
+public class EventLoggerTest {
+
+  @Test
+  public void buildEventPatch() {
+    String expectedStr = "2021-03-02T15:02:48.179000Z";
+    OffsetDateTime expected = OffsetDateTime.parse("2021-03-02T15:02:48.179000Z");
+    V1Patch patch = EventLogger.buildEventPatch(1, "foo", expected);
+    assertEquals(
+        "{\"message\":\"foo\",\"count\":1,\"lastTimestamp\":\"" + expectedStr + "\"}",
+        patch.getValue());
+  }
+}


### PR DESCRIPTION
cherry-picking https://github.com/kubernetes-client/java/pull/1559 and https://github.com/kubernetes-client/java/pull/1569 to release-11