### PR TITLE
Fix the build for JODA time

### DIFF
--- a/extended/src/main/java/io/kubernetes/client/extended/event/legacy/EventLogger.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/event/legacy/EventLogger.java
@@ -68,7 +68,7 @@ public class EventLogger {
     private String resourceVersion;
   }
 
-  static V1Patch buildEventPatch(int count, String message, OffsetDateTime now) {
+  static V1Patch buildEventPatch(int count, String message, DateTime now) {
     return new V1Patch(
         String.format(
             "{\"message\":\"%s\",\"count\":%d,\"lastTimestamp\":%s}",

--- a/extended/src/test/java/io/kubernetes/client/extended/event/legacy/EventLoggerTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/event/legacy/EventLoggerTest.java
@@ -15,15 +15,15 @@ package io.kubernetes.client.extended.event.legacy;
 import static org.junit.Assert.*;
 
 import io.kubernetes.client.custom.V1Patch;
-import java.time.OffsetDateTime;
 import org.junit.Test;
+import org.joda.time.DateTime;
 
 public class EventLoggerTest {
 
   @Test
   public void buildEventPatch() {
-    String expectedStr = "2021-03-02T15:02:48.179000Z";
-    OffsetDateTime expected = OffsetDateTime.parse("2021-03-02T15:02:48.179000Z");
+    String expectedStr = "2021-03-02T15:02:48.179Z";
+    DateTime expected = DateTime.parse("2021-03-02T15:02:48.179Z");
     V1Patch patch = EventLogger.buildEventPatch(1, "foo", expected);
     assertEquals(
         "{\"message\":\"foo\",\"count\":1,\"lastTimestamp\":\"" + expectedStr + "\"}",


### PR DESCRIPTION
There was a cherry-pick of an event logger fix, but it was after the switch to OffsetDateTime which isn't present in the 11.0.x branch.