### PR TITLE
Cherrypick for RELEASE-11: Passing actual response status code in error-handler

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/generic/KubernetesApiResponse.java
+++ b/util/src/main/java/io/kubernetes/client/util/generic/KubernetesApiResponse.java
@@ -59,8 +59,8 @@ public class KubernetesApiResponse<DataType extends KubernetesType> {
    */
   public KubernetesApiResponse<DataType> throwsApiException() throws ApiException {
     return onFailure(
-        errorStatus -> {
-          throw new ApiException(errorStatus.toString());
+        (code, errorStatus) -> {
+          throw new ApiException(code, errorStatus.toString());
         });
   }
 
@@ -74,12 +74,12 @@ public class KubernetesApiResponse<DataType extends KubernetesType> {
   public KubernetesApiResponse<DataType> onFailure(ErrorStatusHandler errorStatusHandler)
       throws ApiException {
     if (!isSuccess()) {
-      errorStatusHandler.handle(this.status);
+      errorStatusHandler.handle(this.getHttpStatusCode(), this.status);
     }
     return this;
   }
 
   public interface ErrorStatusHandler {
-    void handle(V1Status errorStatus) throws ApiException;
+    void handle(int code, V1Status errorStatus) throws ApiException;
   }
 }

--- a/util/src/test/java/io/kubernetes/client/util/generic/KubernetesApiResponseTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/generic/KubernetesApiResponseTest.java
@@ -55,7 +55,7 @@ public class KubernetesApiResponseTest {
         podClient
             .delete("default", "foo")
             .onFailure(
-                errStatus -> {
+                (code, errStatus) -> {
                   catched.set(true);
                 })
             .getObject());


### PR DESCRIPTION
Picking https://github.com/kubernetes-client/java/pull/1529 to 11.0.x branch