### PR TITLE
Enforcing read-timeout for informer-factory processor via property "kubernetes.informer.clientReadTimeout" (default 5min)

### DIFF
--- a/spring/src/main/java/io/kubernetes/client/spring/extended/controller/config/KubernetesInformerAutoConfiguration.java
+++ b/spring/src/main/java/io/kubernetes/client/spring/extended/controller/config/KubernetesInformerAutoConfiguration.java
@@ -18,11 +18,15 @@ import io.kubernetes.client.spring.extended.controller.KubernetesInformerFactory
 import io.kubernetes.client.util.ClientBuilder;
 import java.io.IOException;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnKubernetesInformerEnabled
+@EnableConfigurationProperties({
+  KubernetesInformerProperties.class,
+})
 public class KubernetesInformerAutoConfiguration {
 
   @Bean

--- a/spring/src/main/java/io/kubernetes/client/spring/extended/controller/config/KubernetesInformerProperties.java
+++ b/spring/src/main/java/io/kubernetes/client/spring/extended/controller/config/KubernetesInformerProperties.java
@@ -1,0 +1,32 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.spring.extended.controller.config;
+
+import io.kubernetes.client.informer.cache.ReflectorRunnable;
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("kubernetes.informer")
+public class KubernetesInformerProperties {
+
+  private Duration clientReadTimeout = ReflectorRunnable.REFLECTOR_WATCH_CLIENTSIDE_TIMEOUT;
+
+  public Duration getClientReadTimeout() {
+    return clientReadTimeout;
+  }
+
+  public KubernetesInformerProperties setClientReadTimeout(Duration clientReadTimeout) {
+    this.clientReadTimeout = clientReadTimeout;
+    return this;
+  }
+}

--- a/util/src/main/java/io/kubernetes/client/informer/cache/ReflectorRunnable.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/ReflectorRunnable.java
@@ -37,6 +37,8 @@ public class ReflectorRunnable<
         ApiType extends KubernetesObject, ApiListType extends KubernetesListObject>
     implements Runnable {
 
+  public static Duration REFLECTOR_WATCH_CLIENTSIDE_TIMEOUT = Duration.ofMinutes(5);
+
   private static final Logger log = LoggerFactory.getLogger(ReflectorRunnable.class);
 
   private String lastSyncResourceVersion;
@@ -113,7 +115,7 @@ public class ReflectorRunnable<
                   new CallGeneratorParams(
                       Boolean.TRUE,
                       lastSyncResourceVersion,
-                      Long.valueOf(Duration.ofMinutes(5).getSeconds()).intValue()));
+                      Long.valueOf(REFLECTOR_WATCH_CLIENTSIDE_TIMEOUT.getSeconds()).intValue()));
 
           synchronized (this) {
             if (!isActive.get()) {


### PR DESCRIPTION
https://github.com/kubernetes-client/java/blob/d9271d47aa6f00e7e28b3df3281ef4f282442acb/spring/src/main/java/io/kubernetes/client/spring/extended/controller/KubernetesInformerFactoryProcessor.java#L95-L96

these lines were dropped during refactoring informer-processor and this pull adds it back. tho this can workaround by explicitly setting the read-timeout to zero upon instanciating the ApiClient bean.

/cc @brendandburns @dsyer 

