### PR TITLE
Bugfix: Properly handling non-410 ApiExcetion in the reflector

### DIFF
--- a/util/src/main/java/io/kubernetes/client/informer/cache/ReflectorRunnable.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/ReflectorRunnable.java
@@ -160,6 +160,8 @@ public class ReflectorRunnable<
             "ResourceVersion {} expired, will retry w/o resourceVersion at the next time",
             getRelistResourceVersion());
         isLastSyncResourceVersionUnavailable = true;
+      } else {
+        this.exceptionHandler.accept(apiTypeClass, e);
       }
     } catch (Throwable t) {
       this.exceptionHandler.accept(apiTypeClass, t);


### PR DESCRIPTION
In the pull https://github.com/kubernetes-client/java/pull/1543, we added catcher for intercepting 410 status code but the non-410 errors will be missing. this pull makes the reflector properly handles the non-410 codes.