### PR TITLE
bugfix KubectlGetSingle.execute() error

### DIFF
--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlGet.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlGet.java
@@ -97,6 +97,8 @@ public class KubectlGet<ApiType extends KubernetesObject>
 
     @Override
     public ApiType execute() throws KubectlException {
+      refreshDiscovery();
+
       GenericKubernetesApi<ApiType, ? extends KubernetesListObject> api =
           getGenericApi(KubectlGetSingle.this.apiTypeClass);
       try {


### PR DESCRIPTION
Fix the problem of getGenericApi failure when the `KubectlGetSingle.execute()` method is executed for the first time