### PR TITLE
Chore: Removing version from default user-agent header

### DIFF
--- a/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiClient.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiClient.java
@@ -103,7 +103,8 @@ public class ApiClient {
     json = new JSON();
 
     // Set default User-Agent.
-    setUserAgent("Kubernetes Java Client/11.0.1-SNAPSHOT");
+    // TODO: rendering project version & JVM-runtime version in the header
+    setUserAgent("Kubernetes Java Client");
 
     authentications = new HashMap<String, Authentication>();
   }


### PR DESCRIPTION
unless we figure out how to efficiently update the version string (`11.0.1-SNAPSHOT`) somehow..