### PR TITLE
Feat: Jittering informer client-side watch timeout between 5~10 minutes

### DIFF
--- a/spring/src/main/java/io/kubernetes/client/spring/extended/controller/config/KubernetesInformerProperties.java
+++ b/spring/src/main/java/io/kubernetes/client/spring/extended/controller/config/KubernetesInformerProperties.java
@@ -19,7 +19,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("kubernetes.informer")
 public class KubernetesInformerProperties {
 
-  private Duration clientReadTimeout = ReflectorRunnable.REFLECTOR_WATCH_CLIENTSIDE_TIMEOUT;
+  private Duration clientReadTimeout = ReflectorRunnable.REFLECTOR_WATCH_CLIENTSIDE_MAX_TIMEOUT;
 
   public Duration getClientReadTimeout() {
     return clientReadTimeout;

--- a/util/src/main/java/io/kubernetes/client/informer/cache/ReflectorRunnable.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/ReflectorRunnable.java
@@ -39,6 +39,8 @@ public class ReflectorRunnable<
 
   public static Duration REFLECTOR_WATCH_CLIENTSIDE_TIMEOUT = Duration.ofMinutes(5);
 
+  public static Duration REFLECTOR_WATCH_CLIENTSIDE_MAX_TIMEOUT = Duration.ofMinutes(5 * 2);
+
   private static final Logger log = LoggerFactory.getLogger(ReflectorRunnable.class);
 
   private String lastSyncResourceVersion;
@@ -110,12 +112,16 @@ public class ReflectorRunnable<
             log.debug(
                 "{}#Start watch with resource version {}", apiTypeClass, lastSyncResourceVersion);
           }
+
+          long jitteredWatchTimeoutSeconds =
+              Double.valueOf(REFLECTOR_WATCH_CLIENTSIDE_TIMEOUT.getSeconds() * (1 + Math.random()))
+                  .longValue();
           Watchable<ApiType> newWatch =
               listerWatcher.watch(
                   new CallGeneratorParams(
                       Boolean.TRUE,
                       lastSyncResourceVersion,
-                      Long.valueOf(REFLECTOR_WATCH_CLIENTSIDE_TIMEOUT.getSeconds()).intValue()));
+                      Long.valueOf(jitteredWatchTimeoutSeconds).intValue()));
 
           synchronized (this) {
             if (!isActive.get()) {


### PR DESCRIPTION
@cizezsy 

Fixes: #1648 

following prior art from https://github.com/kubernetes/kubernetes/blob/898bb9666c866515aa8d51227759ee757a11f262/staging/src/k8s.io/client-go/tools/cache/reflector.go#L143-L144