### PR TITLE
Added explicit runtime dependency for logback

### DIFF
--- a/examples/examples-release-12/pom.xml
+++ b/examples/examples-release-12/pom.xml
@@ -17,6 +17,11 @@
 	</properties>
 
 	<dependencies>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<scope>runtime</scope>
+		</dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>

--- a/examples/examples-release-13/pom.xml
+++ b/examples/examples-release-13/pom.xml
@@ -17,6 +17,11 @@
 	</properties>
 
 	<dependencies>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<scope>runtime</scope>
+		</dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>


### PR DESCRIPTION
The samples will not log anything when they run without a logging
library. Logback is only in test scope because of the parent pom
(I think). So we need to add it back explicitly.