### PR TITLE
Java 16 compatibility pt1: Reducing inaccessibility impact

### DIFF
--- a/spring/src/main/java/io/kubernetes/client/spring/extended/manifests/KubernetesFromConfigMapProcessor.java
+++ b/spring/src/main/java/io/kubernetes/client/spring/extended/manifests/KubernetesFromConfigMapProcessor.java
@@ -54,6 +54,12 @@ public class KubernetesFromConfigMapProcessor
   public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
 
     for (Field field : bean.getClass().getDeclaredFields()) {
+      // skip if the field if the FromYaml annotation is missing
+      FromConfigMap fromConfigMapAnnotation = field.getAnnotation(FromConfigMap.class);
+      if (fromConfigMapAnnotation == null) {
+        continue;
+      }
+      // injecting
       ReflectionUtils.makeAccessible(field);
       try {
         if (field.get(bean) != null) {
@@ -62,11 +68,6 @@ public class KubernetesFromConfigMapProcessor
       } catch (IllegalAccessException e) {
         log.warn("Failed inject resource for @FromConfigMap annotated field {}", field, e);
         continue;
-      }
-
-      FromConfigMap fromConfigMapAnnotation = field.getAnnotation(FromConfigMap.class);
-      if (fromConfigMapAnnotation == null) {
-        continue; // skip if the field doesn't have the annotation
       }
 
       if (!Map.class.isAssignableFrom(field.getType())) {

--- a/spring/src/main/java/io/kubernetes/client/spring/extended/manifests/KubernetesFromYamlProcessor.java
+++ b/spring/src/main/java/io/kubernetes/client/spring/extended/manifests/KubernetesFromYamlProcessor.java
@@ -60,6 +60,12 @@ public class KubernetesFromYamlProcessor
     }
 
     for (Field field : bean.getClass().getDeclaredFields()) {
+      // skip if the field if the FromYaml annotation is missing
+      fromYamlAnnotation = field.getAnnotation(FromYaml.class);
+      if (fromYamlAnnotation == null) {
+        continue; // skip if the field doesn't have the annotation
+      }
+      // injecting
       ReflectionUtils.makeAccessible(field);
       try {
         if (field.get(bean) != null) {
@@ -68,11 +74,6 @@ public class KubernetesFromYamlProcessor
       } catch (IllegalAccessException e) {
         log.warn("Failed inject resource for @FromYaml annotated field {}", field, e);
         continue;
-      }
-
-      fromYamlAnnotation = field.getAnnotation(FromYaml.class);
-      if (fromYamlAnnotation == null) {
-        continue; // skip if the field doesn't have the annotation
       }
 
       Object loadedObj = loadFromYaml(fromYamlAnnotation.filePath());


### PR DESCRIPTION
@brendandburns in https://github.com/kubernetes-client/java/issues/1638, the spring module is constantly failing due to bumping platform to java 16. this pull will eliminating the impact for those who are not actually using `@FromYaml` or `@FromConfigMap` annotation from spring integration. and we will also a follow-up pull to completely fix the compatibility issue for the annotations.
