### PR TITLE
perf : unify the implement of isDuplicate in FIFODelta with client-go  version

### DIFF
--- a/util/src/main/java/io/kubernetes/client/informer/cache/DeltaFIFO.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/DeltaFIFO.java
@@ -452,13 +452,7 @@ public class DeltaFIFO {
     if (deletionDelta != null) {
       return deletionDelta;
     }
-    if (d1.getLeft() != DeltaType.Deleted
-        && d2.getLeft() != DeltaType.Deleted
-        && StringUtils.equals(
-            d1.getRight().getMetadata().getResourceVersion(),
-            d2.getRight().getMetadata().getResourceVersion())) {
-      return d1;
-    }
+
     return null;
   }
 


### PR DESCRIPTION
Isduplicate in FIDODelta in Java client version is not consistent with the current implementation of client-go.
client-go implementation :
![QAO_~{LVPFY9$D A@TL@OE3](https://user-images.githubusercontent.com/44917563/126095994-ebe2a71e-cc22-490e-9c2f-d5b4f64e1ec4.png)
current java client implementation :
![S)149F1BHSDW{`EJYUS}U(X](https://user-images.githubusercontent.com/44917563/126096111-a2c3bc42-38cc-4c98-9150-1264ab146a5b.png)


