### PR TITLE
support gcp authentication refresh token

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/authenticators/GCPAuthenticator.java
+++ b/util/src/main/java/io/kubernetes/client/util/authenticators/GCPAuthenticator.java
@@ -68,6 +68,10 @@ public class GCPAuthenticator implements Authenticator {
     return (expiry != null && expiry.compareTo(Instant.now()) <= 0);
   }
 
+  public ProcessBuilder getPb() {
+    return new ProcessBuilder();
+  }
+
   @Override
   public Map<String, Object> refresh(Map<String, Object> config) {
     if (!config.containsKey(CMD_ARGS) || !config.containsKey(CMD_PATH))
@@ -76,7 +80,7 @@ public class GCPAuthenticator implements Authenticator {
     String cmdArgs = (String) config.get(CMD_ARGS);
     String fullCmd = cmdPath + cmdArgs;
     try {
-      Process process = new ProcessBuilder().command(Arrays.asList(fullCmd.split(" "))).start();
+      Process process = this.getPb().command(Arrays.asList(fullCmd.split(" "))).start();
       process.waitFor(10, TimeUnit.SECONDS);
       if (process.exitValue() != 0) {
         String stdErr = IOUtils.toString(process.getErrorStream(), StandardCharsets.UTF_8);

--- a/util/src/main/java/io/kubernetes/client/util/authenticators/GCPAuthenticator.java
+++ b/util/src/main/java/io/kubernetes/client/util/authenticators/GCPAuthenticator.java
@@ -79,6 +79,9 @@ public class GCPAuthenticator implements Authenticator {
     try {
       Process process = new ProcessBuilder().command(commandList).start();
       process.waitFor(10, TimeUnit.SECONDS);
+      if(process.exitValue() != 0) {
+        throw new IOException("Process exit code: "+process.exitValue());
+      }
       String output = IOUtils.toString(process.getInputStream(), StandardCharsets.UTF_8);
       String credentialJson = output.substring(output.indexOf("{"), output.lastIndexOf("}")+1);
       Gson gson = new Gson();
@@ -86,7 +89,7 @@ public class GCPAuthenticator implements Authenticator {
       config.put(TOKEN_KEY, jsonMap.get(TOKEN_KEY));
       config.put(EXPIRY_KEY, jsonMap.get(EXPIRY_KEY));
     } catch (IOException | InterruptedException e) {
-      throw new RuntimeException("Could not refresh token");
+      throw new RuntimeException("Could not refresh token", e);
     }
     return config;
   }

--- a/util/src/main/java/io/kubernetes/client/util/authenticators/GCPAuthenticator.java
+++ b/util/src/main/java/io/kubernetes/client/util/authenticators/GCPAuthenticator.java
@@ -12,10 +12,16 @@ limitations under the License.
 */
 package io.kubernetes.client.util.authenticators;
 
+import com.google.gson.Gson;
 import io.kubernetes.client.util.KubeConfig;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.Date;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +33,12 @@ public class GCPAuthenticator implements Authenticator {
   static {
     KubeConfig.registerAuthenticator(new GCPAuthenticator());
   }
+  private static final String ACCESS_TOKEN = "access-token";
+  private static final String EXPIRY = "expiry";
+  private static final String TOKEN_KEY = "token-key";
+  private static final String EXPIRY_KEY = "expiry-key";
+  private static final String CMD_ARGS = "cmd-args";
+  private static final String CMD_PATH = "cmd-path";
 
   private static final Logger log = LoggerFactory.getLogger(GCPAuthenticator.class);
 
@@ -37,12 +49,12 @@ public class GCPAuthenticator implements Authenticator {
 
   @Override
   public String getToken(Map<String, Object> config) {
-    return (String) config.get("access-token");
+    return (String) config.get(ACCESS_TOKEN);
   }
 
   @Override
   public boolean isExpired(Map<String, Object> config) {
-    Object expiryObj = config.get("expiry");
+    Object expiryObj = config.get(EXPIRY);
     Instant expiry = null;
     if (expiryObj instanceof Date) {
       expiry = ((Date) expiryObj).toInstant();
@@ -58,6 +70,24 @@ public class GCPAuthenticator implements Authenticator {
 
   @Override
   public Map<String, Object> refresh(Map<String, Object> config) {
-    throw new IllegalStateException("Unimplemented");
+    if (!config.containsKey(CMD_ARGS) || !config.containsKey(CMD_PATH))
+      throw new RuntimeException("Could not refresh token");
+    String cmd_path= (String) config.get(CMD_PATH);
+    String cmd_args = (String) config.get(CMD_ARGS);
+    List<String> commandList = new ArrayList<>(Arrays.asList(cmd_args.split(" ")));
+    commandList.add(0, cmd_path);
+    try {
+      Process process = new ProcessBuilder().command(commandList).start();
+      process.waitFor(10, TimeUnit.SECONDS);
+      String output = IOUtils.toString(process.getInputStream(), StandardCharsets.UTF_8);
+      String credentialJson = output.substring(output.indexOf("{"), output.lastIndexOf("}")+1);
+      Gson gson = new Gson();
+      Map<String, String> jsonMap = gson.fromJson(credentialJson, Map.class);
+      config.put(TOKEN_KEY, jsonMap.get(TOKEN_KEY));
+      config.put(EXPIRY_KEY, jsonMap.get(EXPIRY_KEY));
+    } catch (IOException | InterruptedException e) {
+      throw new RuntimeException("Could not refresh token");
+    }
+    return config;
   }
 }

--- a/util/src/main/java/io/kubernetes/client/util/authenticators/GCPAuthenticator.java
+++ b/util/src/main/java/io/kubernetes/client/util/authenticators/GCPAuthenticator.java
@@ -42,6 +42,16 @@ public class GCPAuthenticator implements Authenticator {
 
   private static final Logger log = LoggerFactory.getLogger(GCPAuthenticator.class);
 
+  private final ProcessBuilder pb;
+
+  public GCPAuthenticator() {
+    this(new ProcessBuilder());
+  }
+
+  public GCPAuthenticator(ProcessBuilder pb) {
+    this.pb = pb;
+  }
+
   @Override
   public String getName() {
     return "gcp";
@@ -68,10 +78,6 @@ public class GCPAuthenticator implements Authenticator {
     return (expiry != null && expiry.compareTo(Instant.now()) <= 0);
   }
 
-  public ProcessBuilder getPb() {
-    return new ProcessBuilder();
-  }
-
   @Override
   public Map<String, Object> refresh(Map<String, Object> config) {
     if (!config.containsKey(CMD_ARGS) || !config.containsKey(CMD_PATH))
@@ -80,7 +86,7 @@ public class GCPAuthenticator implements Authenticator {
     String cmdArgs = (String) config.get(CMD_ARGS);
     String fullCmd = cmdPath + cmdArgs;
     try {
-      Process process = this.getPb().command(Arrays.asList(fullCmd.split(" "))).start();
+      Process process = this.pb.command(Arrays.asList(fullCmd.split(" "))).start();
       process.waitFor(10, TimeUnit.SECONDS);
       if (process.exitValue() != 0) {
         String stdErr = IOUtils.toString(process.getErrorStream(), StandardCharsets.UTF_8);

--- a/util/src/test/java/io/kubernetes/client/util/KubeConfigTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/KubeConfigTest.java
@@ -190,10 +190,8 @@ public class KubeConfigTest {
       ex.printStackTrace();
       fail("Unexpected exception: " + ex);
     }
-    GCPAuthenticator spyGCPAuth = Mockito.spy(GCPAuthenticator.class);
-    Mockito.when(spyGCPAuth.getPb()).thenReturn(mockPB);
 
-    KubeConfig.registerAuthenticator(spyGCPAuth);
+    KubeConfig.registerAuthenticator(new GCPAuthenticator(mockPB));
     try {
       KubeConfig kc = KubeConfig.loadKubeConfig(new StringReader(gcpConfigExpiredToken));
       assertEquals("new-fake-token", kc.getAccessToken());

--- a/util/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/util/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Related Issues: 
- https://github.com/kubernetes-client/java/issues/290
- https://github.com/kubernetes-client/java/issues/1664

I wrote a "refresh" function because it seems to be using "cmd-path", "cmd-args", "expiry-key", "token-key" to refresh the token.
Need to check that it works on various os platforms.