### PR TITLE
Additional debugging option for printing http2 frames

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/okhttp/HTTP2ConsoleHandler.java
+++ b/util/src/main/java/io/kubernetes/client/util/okhttp/HTTP2ConsoleHandler.java
@@ -1,0 +1,32 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.util.okhttp;
+
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+class HTTP2ConsoleHandler extends ConsoleHandler {
+
+  public HTTP2ConsoleHandler() {
+    setLevel(Level.FINE);
+    setFormatter(new Formatter());
+  }
+
+  public static class Formatter extends java.util.logging.Formatter {
+    @Override
+    public String format(LogRecord record) {
+      return String.format("[%1$tF %1$tT] %2$s %n", record.getMillis(), record.getMessage());
+    }
+  }
+}

--- a/util/src/main/java/io/kubernetes/client/util/okhttp/HTTP2Logging.java
+++ b/util/src/main/java/io/kubernetes/client/util/okhttp/HTTP2Logging.java
@@ -1,0 +1,57 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.util.okhttp;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import okhttp3.internal.concurrent.TaskRunner;
+import okhttp3.internal.http2.Http2;
+
+public class HTTP2Logging {
+
+  private static final HTTP2ConsoleHandler consoleHandler = new HTTP2ConsoleHandler();
+
+  private static boolean debuggingHTTP2 = false;
+  private static final Logger http2Logger = Logger.getLogger(Http2.class.getName());
+
+  private static boolean debuggingTaskRunner = false;
+  private static final Logger taskRunnerLogger = Logger.getLogger(TaskRunner.class.getName());
+
+  public static void enableHTTP2Logging(boolean enable) {
+    if (debuggingHTTP2 == enable) {
+      return;
+    }
+    if (enable) {
+      http2Logger.addHandler(consoleHandler);
+      http2Logger.setLevel(Level.FINEST);
+    } else {
+      http2Logger.removeHandler(consoleHandler);
+      http2Logger.setLevel(Level.INFO);
+    }
+    debuggingHTTP2 = enable;
+  }
+
+  public static void enableTaskRunnerLogging(boolean enable) {
+    if (debuggingTaskRunner == enable) {
+      return;
+    }
+    if (enable) {
+      taskRunnerLogger.addHandler(consoleHandler);
+      taskRunnerLogger.setLevel(Level.FINEST);
+    } else {
+      taskRunnerLogger.removeHandler(consoleHandler);
+      taskRunnerLogger.setLevel(Level.INFO);
+    }
+    debuggingTaskRunner = enable;
+  }
+}


### PR DESCRIPTION
this pull introduces a new utility class `HTTP2Logging` which allows you to enable/disable logging for HTTP2 handshake & streams via the JUL library.

note that the original script is from https://square.github.io/okhttp/debug_logging/, this pull is just converting the kotlin cheatsheet to a static helper. a sample of logging is shown below:


```
[2021-08-11 15:24:20] Q10005 scheduled after  60 s : OkHttp 127.0.0.1 ping 
[2021-08-11 15:24:20] >> CONNECTION 505249202a20485454502f322e300d0a0d0a534d0d0a0d0a 
[2021-08-11 15:24:20] >> 0x00000000     6 SETTINGS       
[2021-08-11 15:24:20] >> 0x00000000     4 WINDOW_UPDATE  
[2021-08-11 15:24:20] Q10008 scheduled after   0 µs: OkHttp 127.0.0.1 
[2021-08-11 15:24:20] Q10008 starting              : OkHttp 127.0.0.1 
[2021-08-11 15:24:20] Q10000 scheduled after   0 µs: OkHttp ConnectionPool 
[2021-08-11 15:24:20] Q10000 starting              : OkHttp ConnectionPool 
[2021-08-11 15:24:20] Q10000 run again after 300 s : OkHttp ConnectionPool 
[2021-08-11 15:24:20] << 0x00000000    45 GOAWAY         
[2021-08-11 15:24:20] Q10000 finished run in 710 µs: OkHttp ConnectionPool 
[2021-08-11 15:24:20] >> 0x00000000     8 GOAWAY         
[2021-08-11 15:24:20] Q10005 canceled              : OkHttp 127.0.0.1 ping 
[2021-08-11 15:24:20] Q10008 finished run in   5 ms: OkHttp 127.0.0.1 
[2021-08-11 15:24:20] Q10000 canceled              : OkHttp ConnectionPool 
```