### PR TITLE
Fix GCPAuthenticator to compose a correct command

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/authenticators/GCPAuthenticator.java
+++ b/util/src/main/java/io/kubernetes/client/util/authenticators/GCPAuthenticator.java
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.IOUtils;
@@ -35,10 +36,10 @@ public class GCPAuthenticator implements Authenticator {
     KubeConfig.registerAuthenticator(new GCPAuthenticator());
   }
 
-  private static final String ACCESS_TOKEN = "access-token";
-  private static final String EXPIRY = "expiry";
-  private static final String CMD_ARGS = "cmd-args";
-  private static final String CMD_PATH = "cmd-path";
+  static final String ACCESS_TOKEN = "access-token";
+  static final String EXPIRY = "expiry";
+  static final String CMD_ARGS = "cmd-args";
+  static final String CMD_PATH = "cmd-path";
 
   private static final Logger log = LoggerFactory.getLogger(GCPAuthenticator.class);
 
@@ -84,9 +85,10 @@ public class GCPAuthenticator implements Authenticator {
       throw new RuntimeException("Could not refresh token");
     String cmdPath = (String) config.get(CMD_PATH);
     String cmdArgs = (String) config.get(CMD_ARGS);
-    String fullCmd = cmdPath + cmdArgs;
+    List<String> fullCmd =
+        Arrays.asList(String.join(" ", cmdPath.trim(), cmdArgs.trim()).split(" "));
     try {
-      Process process = this.pb.command(Arrays.asList(fullCmd.split(" "))).start();
+      Process process = this.pb.command(fullCmd).start();
       process.waitFor(10, TimeUnit.SECONDS);
       if (process.exitValue() != 0) {
         String stdErr = IOUtils.toString(process.getErrorStream(), StandardCharsets.UTF_8);

--- a/util/src/test/java/io/kubernetes/client/util/authenticators/GCPAuthenticatorTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/authenticators/GCPAuthenticatorTest.java
@@ -1,0 +1,186 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.util.authenticators;
+
+import static org.assertj.core.api.Fail.fail;
+import static org.hamcrest.Matchers.is;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class GCPAuthenticatorTest {
+
+  private final String cmdPath = "/usr/lib/google-cloud-sdk/bin/gcloud";
+  private final String cmdArgs = "config config-helper --format=json";
+  private final String[] cmdArgsSplit = cmdArgs.split(" ");
+  private final List<String> expectedCommand =
+      Collections.unmodifiableList(
+          new ArrayList<String>() {
+            {
+              add(cmdPath);
+              add(cmdArgsSplit[0]);
+              add(cmdArgsSplit[1]);
+              add(cmdArgsSplit[2]);
+            }
+          });
+
+  private static final String fakeExecResult =
+      "{\n"
+          + "  \"credential\": {\n"
+          + "    \"access_token\": \"new-fake-token\",\n"
+          + "    \"id_token\": \"id-fake-token\",\n"
+          + "    \"token_expiry\": \"2121-08-05T02:30:24Z\"\n"
+          + "  }\n"
+          + "}";
+
+  private final ProcessBuilder mockPB = Mockito.mock(ProcessBuilder.class);
+  private final GCPAuthenticator gcpAuthenticator = new GCPAuthenticator(mockPB);
+
+  @Before
+  public void setup() {
+    Process mockProcess = Mockito.mock(Process.class);
+    Mockito.when(mockProcess.exitValue()).thenReturn(0);
+    Mockito.when(mockProcess.getInputStream())
+        .thenReturn(new ByteArrayInputStream(fakeExecResult.getBytes(StandardCharsets.UTF_8)));
+    try {
+      Mockito.when(mockPB.command(Mockito.anyList())).thenCallRealMethod();
+      Mockito.when(mockPB.start()).thenReturn(mockProcess);
+      Mockito.when(mockPB.command()).thenCallRealMethod();
+    } catch (IOException ex) {
+      ex.printStackTrace();
+      fail("Unexpected exception: " + ex);
+    }
+  }
+
+  @Test
+  public void testRefresh() {
+    final Map<String, Object> gcpConfig =
+        new HashMap<String, Object>() {
+          {
+            put(GCPAuthenticator.ACCESS_TOKEN, "eyXXX");
+            put(GCPAuthenticator.CMD_PATH, cmdPath);
+            put(GCPAuthenticator.CMD_ARGS, cmdArgs);
+            put(GCPAuthenticator.EXPIRY, "2121-08-05T02:30:24Z");
+          }
+        };
+    gcpAuthenticator.refresh(gcpConfig);
+    List<String> executedCommand = mockPB.command();
+    MatcherAssert.assertThat(executedCommand, is(expectedCommand));
+  }
+
+  @Test
+  public void testRefreshTrailingWhitespaceInPath() {
+    final Map<String, Object> gcpConfig =
+        new HashMap<String, Object>() {
+          {
+            put(GCPAuthenticator.ACCESS_TOKEN, "eyXXX");
+            put(GCPAuthenticator.CMD_PATH, cmdPath + " ");
+            put(GCPAuthenticator.CMD_ARGS, cmdArgs);
+            put(GCPAuthenticator.EXPIRY, "2121-08-05T02:30:24Z");
+          }
+        };
+    gcpAuthenticator.refresh(gcpConfig);
+    List<String> executedCommand = mockPB.command();
+    MatcherAssert.assertThat(executedCommand, is(expectedCommand));
+  }
+
+  @Test
+  public void testRefreshTrailingWhitespaceInArgs() {
+    final Map<String, Object> gcpConfig =
+        new HashMap<String, Object>() {
+          {
+            put(GCPAuthenticator.ACCESS_TOKEN, "eyXXX");
+            put(GCPAuthenticator.CMD_PATH, cmdPath);
+            put(GCPAuthenticator.CMD_ARGS, cmdArgs + " ");
+            put(GCPAuthenticator.EXPIRY, "2121-08-05T02:30:24Z");
+          }
+        };
+    gcpAuthenticator.refresh(gcpConfig);
+    List<String> executedCommand = mockPB.command();
+    MatcherAssert.assertThat(executedCommand, is(expectedCommand));
+  }
+
+  @Test
+  public void testRefreshTrailingWhitespaceInPathAndArgs() {
+    final Map<String, Object> gcpConfig =
+        new HashMap<String, Object>() {
+          {
+            put(GCPAuthenticator.ACCESS_TOKEN, "eyXXX");
+            put(GCPAuthenticator.CMD_PATH, cmdPath + " ");
+            put(GCPAuthenticator.CMD_ARGS, cmdArgs + " ");
+            put(GCPAuthenticator.EXPIRY, "2121-08-05T02:30:24Z");
+          }
+        };
+    gcpAuthenticator.refresh(gcpConfig);
+    List<String> executedCommand = mockPB.command();
+    MatcherAssert.assertThat(executedCommand, is(expectedCommand));
+  }
+
+  @Test
+  public void testRefreshLeadingWhitespaceInPath() {
+    final Map<String, Object> gcpConfig =
+        new HashMap<String, Object>() {
+          {
+            put(GCPAuthenticator.ACCESS_TOKEN, "eyXXX");
+            put(GCPAuthenticator.CMD_PATH, " " + cmdPath);
+            put(GCPAuthenticator.CMD_ARGS, cmdArgs);
+            put(GCPAuthenticator.EXPIRY, "2121-08-05T02:30:24Z");
+          }
+        };
+    gcpAuthenticator.refresh(gcpConfig);
+    List<String> executedCommand = mockPB.command();
+    MatcherAssert.assertThat(executedCommand, is(expectedCommand));
+  }
+
+  @Test
+  public void testRefreshLeadingWhitespaceInArgs() {
+    final Map<String, Object> gcpConfig =
+        new HashMap<String, Object>() {
+          {
+            put(GCPAuthenticator.ACCESS_TOKEN, "eyXXX");
+            put(GCPAuthenticator.CMD_PATH, cmdPath);
+            put(GCPAuthenticator.CMD_ARGS, " " + cmdArgs);
+            put(GCPAuthenticator.EXPIRY, "2121-08-05T02:30:24Z");
+          }
+        };
+    gcpAuthenticator.refresh(gcpConfig);
+    List<String> executedCommand = mockPB.command();
+    MatcherAssert.assertThat(executedCommand, is(expectedCommand));
+  }
+
+  @Test
+  public void testRefreshLeadingWhitespaceInPathAndArgs() {
+    final Map<String, Object> gcpConfig =
+        new HashMap<String, Object>() {
+          {
+            put(GCPAuthenticator.ACCESS_TOKEN, "eyXXX");
+            put(GCPAuthenticator.CMD_PATH, " " + cmdPath);
+            put(GCPAuthenticator.CMD_ARGS, " " + cmdArgs);
+            put(GCPAuthenticator.EXPIRY, "2121-08-05T02:30:24Z");
+          }
+        };
+    gcpAuthenticator.refresh(gcpConfig);
+    List<String> executedCommand = mockPB.command();
+    MatcherAssert.assertThat(executedCommand, is(expectedCommand));
+  }
+}


### PR DESCRIPTION
When trying to authenticate to GCP, the GCPAuthenticator composes a gcloud cmd where the args are added without empty spaces. See issue:
https://github.com/kubernetes-client/java/issues/1821

I wasn't sure about the code style. Unfortunately I couldn't find anything related to it.
