### PR TITLE
Updated WebSocketStreamHandler.write() to properly calculate 'remaining' bytes

### DIFF
--- a/util/src/main/java/io/kubernetes/client/Copy.java
+++ b/util/src/main/java/io/kubernetes/client/Copy.java
@@ -34,7 +34,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.codec.binary.Base64InputStream;
-import org.apache.commons.codec.binary.Base64OutputStream;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
@@ -365,8 +364,7 @@ public class Copy extends Exec {
     // Send encoded archive output stream
     File srcFile = new File(srcPath.toUri());
     try (ArchiveOutputStream archiveOutputStream =
-            new TarArchiveOutputStream(
-                new Base64OutputStream(proc.getOutputStream(), true, 0, null));
+            new TarArchiveOutputStream(proc.getOutputStream());
         FileInputStream input = new FileInputStream(srcFile)) {
       ArchiveEntry tarEntry = new TarArchiveEntry(srcFile, destPath.getFileName().toString());
 
@@ -398,7 +396,7 @@ public class Copy extends Exec {
     final Process proc = execCopyToPod(namespace, pod, container, destPath);
 
     try (ArchiveOutputStream archiveOutputStream =
-        new TarArchiveOutputStream(new Base64OutputStream(proc.getOutputStream(), true, 0, null))) {
+        new TarArchiveOutputStream(proc.getOutputStream())) {
 
       ArchiveEntry tarEntry = new TarArchiveEntry(new File(destPath.getFileName().toString()));
       ((TarArchiveEntry) tarEntry).setSize(src.length);
@@ -417,7 +415,7 @@ public class Copy extends Exec {
     return this.exec(
         namespace,
         pod,
-        new String[] {"sh", "-c", "base64 -d | tar -xmf - -C " + parentPath},
+        new String[] {"sh", "-c", "tar -xmf - -C " + parentPath},
         container,
         true,
         false);

--- a/util/src/main/java/io/kubernetes/client/Copy.java
+++ b/util/src/main/java/io/kubernetes/client/Copy.java
@@ -412,6 +412,7 @@ public class Copy extends Exec {
   private Process execCopyToPod(String namespace, String pod, String container, Path destPath)
       throws ApiException, IOException {
     String parentPath = destPath.getParent() != null ? destPath.getParent().toString() : ".";
+    parentPath = parentPath.replace("\\", "/");
     return this.exec(
         namespace,
         pod,

--- a/util/src/main/java/io/kubernetes/client/util/WebSocketStreamHandler.java
+++ b/util/src/main/java/io/kubernetes/client/util/WebSocketStreamHandler.java
@@ -270,7 +270,7 @@ public class WebSocketStreamHandler implements WebSockets.SocketListener, Closea
           throw new IOException("WebSocket has closed.");
         }
         bytesWritten += bufferSize;
-        remaining -= bytesWritten;
+        remaining -= bufferSize;
       }
     }
   }


### PR DESCRIPTION
Let's try this again! :) 

Fix for #1826: WebSocketStreamHandler.write() to calculate 'remaining' bytes using bufferSize from the current loop iteration instead of the cumulative bytesWritten.

Related to #1822:  Removed the base64 encode/decode steps/streams per comment https://github.com/kubernetes-client/java/issues/1822#issuecomment-900315846 as unnecessary steps to simplify the process.

Also the execCopyToPod() method converts the destPath to a string, but if the client is windows, it sends the path to the 'sh -c **` command using Windows path delimiters.  I added a line to replace any backslashes with forward slashes.