### PR TITLE
Updated WebSocketStreamHandler.write() to calculate 'remaining' bytes properly : Fixed destPath normalization for potential Windows delimiters

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/WebSocketStreamHandler.java
+++ b/util/src/main/java/io/kubernetes/client/util/WebSocketStreamHandler.java
@@ -270,7 +270,7 @@ public class WebSocketStreamHandler implements WebSockets.SocketListener, Closea
           throw new IOException("WebSocket has closed.");
         }
         bytesWritten += bufferSize;
-        remaining -= bytesWritten;
+        remaining -= bufferSize;
       }
     }
   }

--- a/util/src/test/java/io/kubernetes/client/CopyTest.java
+++ b/util/src/test/java/io/kubernetes/client/CopyTest.java
@@ -130,7 +130,7 @@ public class CopyTest {
             .withQueryParam("tty", equalTo("false"))
             .withQueryParam("command", equalTo("sh"))
             .withQueryParam("command", equalTo("-c"))
-            .withQueryParam("command", equalTo("base64 -d | tar -xmf - -C /")));
+            .withQueryParam("command", equalTo("tar -xmf - -C /")));
   }
 
   @Test
@@ -176,7 +176,7 @@ public class CopyTest {
             .withQueryParam("tty", equalTo("false"))
             .withQueryParam("command", equalTo("sh"))
             .withQueryParam("command", equalTo("-c"))
-            .withQueryParam("command", equalTo("base64 -d | tar -xmf - -C /")));
+            .withQueryParam("command", equalTo("tar -xmf - -C /")));
   }
 
   public void testCopyDirectoryFromPod() throws IOException, ApiException, InterruptedException {


### PR DESCRIPTION
Third time's the charm....

- Fix for #1826: Updated WebSocketStreamHandler.write() to calculate 'remaining' bytes using bufferSize from the current loop iteration instead of the cummulative bytesWritten.

- Related to #1822:  Removed the base64 encode/decode steps/streams per comment at https://github.com/kubernetes-client/java/issues/1822#issuecomment-900315846

- Related to #1822:  Added path normalization to convert potential windows path delimiters to linux delimiters.  The copyFileToPod() variants take a java Path instance for both source and destination.  Since the destination is Linux, when I set destPath = Paths.get("/tmp/foo.txt");, converting that to a string to send to the tar command ends up sending "\tmp" as the parentPath which is not valid for linux. 

