### PR TITLE
Cherry-pick(release-13): Stale watch event should be handled properly

### DIFF
--- a/util/src/main/java/io/kubernetes/client/informer/cache/ReflectorRunnable.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/ReflectorRunnable.java
@@ -16,6 +16,7 @@ import io.kubernetes.client.common.KubernetesListObject;
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.informer.EventType;
 import io.kubernetes.client.informer.ListerWatcher;
+import io.kubernetes.client.informer.exception.WatchExpiredException;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.V1ListMeta;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -150,8 +151,10 @@ public class ReflectorRunnable<
             continue;
           }
           if ((t instanceof RuntimeException)
+              && t.getMessage() != null
               && t.getMessage().contains("IO Exception during hasNext")) {
             log.info("{}#Read timeout retry list and watch", this.apiTypeClass);
+            // IO timeout should be taken as a normal case
             return;
           }
           this.exceptionHandler.accept(apiTypeClass, t);
@@ -160,6 +163,8 @@ public class ReflectorRunnable<
           closeWatch();
         }
       }
+    } catch (WatchExpiredException e) {
+      return;
     } catch (ApiException e) {
       if (e.getCode() == HttpURLConnection.HTTP_GONE) {
         log.info(
@@ -233,7 +238,7 @@ public class ReflectorRunnable<
       if (eventType.get() == EventType.ERROR) {
         if (item.status != null && item.status.getCode() == HttpURLConnection.HTTP_GONE) {
           log.info("Watch connection expired: {}", item.status.getMessage());
-          return;
+          throw new WatchExpiredException();
         } else {
           String errorMessage =
               String.format("got ERROR event and its status: %s", item.status.toString());

--- a/util/src/main/java/io/kubernetes/client/informer/cache/ReflectorRunnable.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/ReflectorRunnable.java
@@ -132,6 +132,12 @@ public class ReflectorRunnable<
             watch = newWatch;
           }
           watchHandler(newWatch);
+        } catch (WatchExpiredException e) {
+          // Watch calls were failed due to expired resource-version. Returning
+          // to unwind the list-watch loops so that we can respawn a new round
+          // of list-watching.
+          log.info("{}#Watch expired, will re-list-watch soon", this.apiTypeClass);
+          return;
         } catch (Throwable t) {
           if (isConnectException(t)) {
             // If this is "connection refused" error, it means that most likely
@@ -163,8 +169,6 @@ public class ReflectorRunnable<
           closeWatch();
         }
       }
-    } catch (WatchExpiredException e) {
-      return;
     } catch (ApiException e) {
       if (e.getCode() == HttpURLConnection.HTTP_GONE) {
         log.info(

--- a/util/src/main/java/io/kubernetes/client/informer/exception/WatchExpiredException.java
+++ b/util/src/main/java/io/kubernetes/client/informer/exception/WatchExpiredException.java
@@ -1,0 +1,16 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.informer.exception;
+
+/** A ERROR watch item was returned due to stale resource version. */
+public class WatchExpiredException extends RuntimeException {}


### PR DESCRIPTION
picking https://github.com/kubernetes-client/java/pull/1832 to release-13

cc @brendandburns @haoming-db 

i will bump a patch version after this gets into 13 branch