### PR TITLE
Tweak call for CoreV1 group properly

### DIFF
--- a/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlApplyTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlApplyTest.java
@@ -12,9 +12,12 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.kubectl;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.patch;
+import static com.github.tomakehurst.wiremock.client.WireMock.patchRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;

--- a/util/src/main/java/io/kubernetes/client/util/generic/GenericKubernetesApi.java
+++ b/util/src/main/java/io/kubernetes/client/util/generic/GenericKubernetesApi.java
@@ -824,7 +824,17 @@ public class GenericKubernetesApi<
       return call;
     }
     HttpUrl url = call.request().url();
-    HttpUrl tweakedUrl = url.newBuilder().removePathSegment(1).setPathSegment(0, "api").build();
+    String basePath = customObjectsApi.getApiClient().getBasePath();
+    // count segments in the basePath
+    int offset = 0;
+    for (int i = basePath.indexOf("://") + 3; i < basePath.length(); ++i) {
+      if (basePath.charAt(i) == '/') {
+        ++offset;
+      }
+    }
+    HttpUrl tweakedUrl =
+        url.newBuilder().removePathSegment(offset + 1).setPathSegment(offset, "api").build();
+
     return this.customObjectsApi
         .getApiClient()
         .getHttpClient()


### PR DESCRIPTION
Fix #1838

If `basePath` contains multiple segments (like using java client with rancher clusters), it would tweak the call incorrectly and break the request url, see https://github.com/kubernetes-client/java/issues/1838#issuecomment-913290787

So it should calculate the segment indexes to be modified instead of hardcoding them to 0 and 1.