### PR TITLE
Return specific api type in patchContent and patchType

### DIFF
--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlPatch.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlPatch.java
@@ -30,12 +30,12 @@ public class KubectlPatch<ApiType extends KubernetesObject>
     super(apiTypeClass);
   }
 
-  public KubectlPatch patchContent(V1Patch patchContent) {
+  public KubectlPatch<ApiType> patchContent(V1Patch patchContent) {
     this.patchContent = patchContent;
     return this;
   }
 
-  public KubectlPatch patchType(String patchType) {
+  public KubectlPatch<ApiType> patchType(String patchType) {
     this.patchType = patchType;
     return this;
   }

--- a/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlPatchTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlPatchTest.java
@@ -1,0 +1,98 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.extended.kubectl;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.patch;
+import static com.github.tomakehurst.wiremock.client.WireMock.patchRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.junit.Assert.assertNotNull;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
+import io.kubernetes.client.custom.V1Patch;
+import io.kubernetes.client.extended.kubectl.exception.KubectlException;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.models.V1ConfigMap;
+import io.kubernetes.client.util.ClientBuilder;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class KubectlPatchTest {
+
+  private static final String DISCOVERY_API =
+      KubectlPatchTest.class.getClassLoader().getResource("discovery-api.json").getPath();
+
+  private static final String DISCOVERY_APIV1 =
+      KubectlPatchTest.class.getClassLoader().getResource("discovery-api-v1.json").getPath();
+
+  private static final String DISCOVERY_APIS =
+      KubectlPatchTest.class.getClassLoader().getResource("discovery-apis.json").getPath();
+
+  private ApiClient apiClient;
+
+  @Rule public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
+
+  @Before
+  public void setup() throws IOException {
+    apiClient = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
+  }
+
+  @Test
+  public void testPatchConfigMap() throws KubectlException, IOException {
+    wireMockRule.stubFor(
+        patch(urlPathEqualTo("/api/v1/namespaces/foo/configmaps/bar"))
+            .withHeader(
+                "Content-Type", new EqualToPattern(V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withBody("{\"metadata\":{\"name\":\"bar\",\"namespace\":\"foo\"}}")));
+    wireMockRule.stubFor(
+        get(urlPathEqualTo("/api"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withBody(new String(Files.readAllBytes(Paths.get(DISCOVERY_API))))));
+    wireMockRule.stubFor(
+        get(urlPathEqualTo("/apis"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withBody(new String(Files.readAllBytes(Paths.get(DISCOVERY_APIS))))));
+    wireMockRule.stubFor(
+        get(urlPathEqualTo("/api/v1"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withBody(new String(Files.readAllBytes(Paths.get(DISCOVERY_APIV1))))));
+
+    V1ConfigMap configMap =
+        Kubectl.patch(V1ConfigMap.class)
+            .namespace("foo")
+            .name("bar")
+            .patchType(V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH)
+            .patchContent(new V1Patch("{\"data\":{\"key\":\"value\"}}"))
+            .apiClient(apiClient)
+            .execute();
+    wireMockRule.verify(
+        1, patchRequestedFor(urlPathEqualTo("/api/v1/namespaces/foo/configmaps/bar")));
+    assertNotNull(configMap);
+  }
+}


### PR DESCRIPTION
Fix #1887

Attach `ApiType` to `KubectlPatch` in `patchContent` and `patchType`