### PR TITLE
Guard against NPE in manageRelationFromResourceToSubResources from Discovery class

### DIFF
--- a/util/src/main/java/io/kubernetes/client/Discovery.java
+++ b/util/src/main/java/io/kubernetes/client/Discovery.java
@@ -116,8 +116,11 @@ public class Discovery {
               getSubResourceNameIfPossible(r.getName())
                   .ifPresent(
                       subResourceName -> {
-                        subResources.computeIfAbsent(getMajorResourceName(r.getName()), majorResourceName -> new HashSet<>())
-                                .add(subResourceName);
+                        subResources
+                            .computeIfAbsent(
+                                getMajorResourceName(r.getName()),
+                                majorResourceName -> new HashSet<>())
+                            .add(subResourceName);
                       });
             });
     return subResources;

--- a/util/src/main/java/io/kubernetes/client/Discovery.java
+++ b/util/src/main/java/io/kubernetes/client/Discovery.java
@@ -116,7 +116,8 @@ public class Discovery {
               getSubResourceNameIfPossible(r.getName())
                   .ifPresent(
                       subResourceName -> {
-                        subResources.get(getMajorResourceName(r.getName())).add(subResourceName);
+                        subResources.computeIfAbsent(getMajorResourceName(r.getName()), majorResourceName -> new HashSet<>())
+                                .add(subResourceName);
                       });
             });
     return subResources;


### PR DESCRIPTION
Issue: https://github.com/kubernetes-client/java/issues/1886

This code is added to have defense against null pointer exception in manageRelationFromResourceToSubResources method in discovery class

