### PR TITLE
Fix arguments to dockerfiles

### DIFF
--- a/client-java-contrib/Dockerfile.gen
+++ b/client-java-contrib/Dockerfile.gen
@@ -1,9 +1,8 @@
-FROM ghcr.io/yue9944882/crd-model-gen-base:v1.0.0
+ARG BASE_IMAGE=ghcr.io/yue9944882/crd-model-gen-base:v1.0.0
+FROM ${BASE_IMAGE}
 # TODO: move this to kubernetes-client group after the permission issue fixed
 
-ARG OPENAPI_GENERATOR_COMMIT
 ARG GENERATION_XML_FILE
-ARG OPENAPI_GENERATOR_USER_ORG=OpenAPITools
 
 # Copy required files
 COPY openapi-generator/generate_client_in_container.sh /generate_client.sh

--- a/client-java-contrib/Dockerfile.gen-base
+++ b/client-java-contrib/Dockerfile.gen-base
@@ -1,5 +1,8 @@
 FROM maven:3.5-jdk-8-slim
 
+ARG OPENAPI_GENERATOR_COMMIT
+ARG OPENAPI_GENERATOR_USER_ORG=OpenAPITools
+
 # Install preprocessing script requirements
 RUN apt-get update && apt-get -y install git python-pip && pip install urllib3==1.24.2
 


### PR DESCRIPTION
Couple of issues with Dockerfiles in client-java-contrib:

The base image is a private image in Dockerfile.gen. It should take the base image as an argument with default values.
Dockerfile.gen-base is using variables and doesnt define them as arguments:
${OPENAPI_GENERATOR_USER_ORG}
OPENAPI_GENERATOR_COMMIT
Because of this the Dockerfile doesn't build.

https://github.com/kubernetes-client/java/issues/1897