### PR TITLE
Cherrypick-13: Test: Fixes constant maven download failure by escalating mvn permission

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,7 +42,10 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ matrix.java }}-${{ hashFiles('pom.xml', '**/pom.xml') }}
       - name: Buid with Maven
-        run: mvn -q clean test -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+        run: |
+          sudo mvn clean test \
+            -q \
+            -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
   build-graalvm:
     runs-on: ubuntu-latest
     name: GraalVM Maven Test


### PR DESCRIPTION
picks https://github.com/kubernetes-client/java/pull/1876 to release-13 so that the branch's CI passes