### PR TITLE
Flake: Catching illegal-state-exception in the copy test

### DIFF
--- a/util/src/test/java/io/kubernetes/client/CopyTest.java
+++ b/util/src/test/java/io/kubernetes/client/CopyTest.java
@@ -74,7 +74,7 @@ public class CopyTest {
       // block until the connection is established
       inputStream.read();
       inputStream.close();
-    } catch (IOException | ApiException e) {
+    } catch (IOException | ApiException | IllegalStateException e) {
       e.printStackTrace();
     }
 


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-client/java/issues/1862