### PR TITLE
[fix] avoided thread.sleep usage and added semaphore as replacement

### DIFF
--- a/extended/src/test/java/io/kubernetes/client/extended/workqueue/ratelimiter/BucketRateLimiterTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/workqueue/ratelimiter/BucketRateLimiterTest.java
@@ -16,9 +16,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import org.apache.commons.lang3.concurrent.TimedSemaphore;
 
 public class BucketRateLimiterTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
@@ -46,15 +50,16 @@ public class BucketRateLimiterTest {
   @Test
   public void testBucketRateLimiterTokenAdded() throws InterruptedException {
     RateLimiter<String> rateLimiter = new BucketRateLimiter<>(2, 1, Duration.ofSeconds(2));
+    TimedSemaphore timedSemaphore = new TimedSemaphore(4, TimeUnit.SECONDS, 1);
 
+    timedSemaphore.acquire();
     assertEquals(Duration.ZERO, rateLimiter.when("one"));
     assertEquals(Duration.ZERO, rateLimiter.when("one"));
 
     Duration waitDuration = rateLimiter.when("one");
     assertTrue(waitDuration.getSeconds() > 0);
 
-    Thread.sleep(4000);
-
+    timedSemaphore.acquire();
     assertEquals(Duration.ZERO, rateLimiter.when("two"));
 
     waitDuration = rateLimiter.when("two");


### PR DESCRIPTION
Avoided `Thread.sleep()` and rather used `TimedSemphore()` to perform waiting and then let task happen

PR is to fix one of the issue under this PR umbrella https://github.com/kubernetes-client/java/issues/1223