### PR TITLE
chore: 'adopt' --> 'temurin'

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8.0.x
       - name: Verify Format and License
         run: mvn spotless:check
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Cache local Maven repository
         uses: actions/cache@v2.1.6
@@ -81,7 +81,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11.0.x
       - name: Cache local Maven repository
         uses: actions/cache@v2.1.6


### PR DESCRIPTION
https://github.com/actions/setup-java/blob/main/README.md

```
NOTE: Adopt OpenJDK got moved to Eclipse Temurin and won't be 
updated anymore. It is highly recommended to migrate workflows 
from adopt to temurin to keep receiving software and security updates.
```
