### PR TITLE
GCPAuthenticator support without gcloud

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,12 @@
         <artifactId>jsr305</artifactId>
         <version>${jsr305.version}</version>
       </dependency>
+      <dependency>
+        <groupId>com.google.auth</groupId>
+        <artifactId>google-auth-library-oauth2-http</artifactId>
+        <version>1.3.0</version>
+        <optional>true</optional>
+      </dependency>
 
 
       <!-- tests -->

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -84,6 +84,11 @@
             <groupId>org.bitbucket.b_c</groupId>
             <artifactId>jose4j</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.auth</groupId>
+            <artifactId>google-auth-library-oauth2-http</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
https://github.com/kubernetes-client/java/issues/290#issuecomment-979515942

https://cloud.google.com/kubernetes-engine/docs/how-to/api-server-authentication#environments-without-gcloud
