### PR TITLE
gh-action: Upload snapshot as post-commit job

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,29 @@
+name: Upload Snapshot
+
+on:
+  push:
+    branches:
+      - master
+      - release-*
+  workflow_dispatch: {}
+
+jobs:
+  verify:
+    name: latest-images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: 8.0.x
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Publish to Apache Maven Central
+        run: ./mvnw deploy
+        env:
+          OSSRH_USERNAME: ${{ secrets.SNAPSHOT_UPLOAD_USER }}
+          OSSRH_TOKEN: ${{ secrets.SNAPSHOT_UPLOAD_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSWORD }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - release-*
   workflow_dispatch: {}
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Client Capabilities](https://img.shields.io/badge/Kubernetes%20client-Silver-blue.svg?style=flat&colorB=C0C0C0&colorA=306CE8)](http://bit.ly/kubernetes-client-capabilities-badge)
 [![Client Support Level](https://img.shields.io/badge/kubernetes%20client-beta-green.svg?style=flat&colorA=306CE8)](http://bit.ly/kubernetes-client-support-badge)
 [![Maven Central](https://img.shields.io/maven-central/v/io.kubernetes/client-java.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22io.kubernetes%22%20AND%20a:%22client-java%22)
+![Sonatype Nexus (Snapshots)](https://img.shields.io/nexus/s/io.kubernetes/client-java?label=Maven%20Snapshot&server=https%3A%2F%2Foss.sonatype.org)
 
 Java client for the [kubernetes](http://kubernetes.io/) API.
 


### PR DESCRIPTION
@brendandburns i added my jira account credentials and gpg keys in the repo secrets to push snapshots. github claims that these secrets are perfectly protected 🤞

if this works well, we can move the maven release job as another job triggered by simple git tags. so we don't need to deal with the fiddly release process manually anymore!