### PR TITLE
Fix arrayIndexOutOfBounds exception for overloaded addModelMap method

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
+++ b/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
@@ -89,10 +89,11 @@ public class ModelMapper {
   @Deprecated
   public static void addModelMap(String apiGroupVersion, String kind, Class<?> clazz) {
     String[] parts = apiGroupVersion.split("/");
-    if (parts.length == 1) { // legacy api group
+    if (parts.length <= 1) { // legacy api group
       addModelMap("", apiGroupVersion, kind, clazz);
+    } else {
+      addModelMap(parts[0], parts[1], kind, clazz);
     }
-    addModelMap(parts[0], parts[1], kind, clazz);
   }
 
   /**

--- a/util/src/test/java/io/kubernetes/client/util/ModelMapperTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/ModelMapperTest.java
@@ -51,6 +51,11 @@ public class ModelMapperTest {
 
     assertNull(ModelMapper.getApiTypeClass("example.io/v1", "Tofu"));
     assertNull(ModelMapper.getApiTypeClass("example.io", "v1", "Tofu"));
+
+    assertNull(ModelMapper.getApiTypeClass("v1", "Togu"));
+    ModelMapper.addModelMap("v1", "Togu", objClass);
+    assertEquals(objClass, ModelMapper.getApiTypeClass("", "v1", "Togu"));
+    assertEquals(objClass, ModelMapper.getApiTypeClass("v1", "Togu"));
   }
 
   @Test


### PR DESCRIPTION
Fix `java.lang.ArrayIndexOutOfBoundsException` from YamlExample

Repro case:
```
# from $REPO_DIR/examples/examples-release-15
../../mvnw exec:java -Dexec.mainClass="io.kubernetes.client.examples.YamlExample"
```