### PR TITLE
Adding an manual release job that applies to release branches publishing maven releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: Maven Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        type: string
+        required: true
+        description: The POM release version of this release.
+      nextDevelopmentVersion:
+        type: string
+        required: true
+        description: The next POM development version with suffix "-SNAPSHOT", will be the next development version after the release is done.
+      dry-run:
+        type: boolean
+        required: true
+        description: Dry run, will not push branches or upload the artifacts.
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate Input
+        run: |
+          echo "${{ github.ref_type }}" | perl -ne 'die unless m/^branch$/'
+          echo "${{ github.ref_name }}" | perl -ne 'die unless m/^release-\d+$/'
+          echo "${{ github.event.inputs.releaseVersion }}" | perl -ne 'die unless m/^\d+\.\d+\.\d+$/'
+          echo "${{ github.event.inputs.nextDevelopmentVersion }}" | perl -ne 'die unless m/^\d+\.\d+\.\d+-SNAPSHOT$/'
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Check Actor
+        run: |
+          # Release actor should be in the OWNER list
+          cat OWNERS | grep ${{ github.actor }}
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: 8.0.x
+          server-id: ossrh
+          server-username: OSSRH_USERNAME
+          server-password: OSSRH_TOKEN
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE
+      - name: Prepare
+        run: |
+          export GPG_TTY=$(tty)
+          (echo 5; echo y; echo save) | gpg --command-fd 0 --no-tty --pinentry-mode loopback --passphrase ${{ secrets.GPG_PASSWORD }} --no-greeting --edit-key 'Kubernetes Client Publishers' trust
+          (echo 0; echo y; echo save) | gpg --command-fd 0 --no-tty --pinentry-mode loopback --passphrase ${{ secrets.GPG_PASSWORD }} --no-greeting --edit-key 'Kubernetes Client Publishers' expire
+          git config user.email "k8s.ci.robot@gmail.com"
+          git config user.name "Kubernetes Prow Robot"
+      - name: Check Current Version
+        run: |
+          mvn -q \
+            -Dexec.executable=echo \
+            -Dexec.args='${project.version}' \
+            --non-recursive \
+            exec:exec | perl -ne 'die unless m/${{ github.event.inputs.releaseVersion }}-SNAPSHOT/'
+      - name: Release Prepare
+        run: |
+          mvn --batch-mode \
+            release:prepare \
+            -Dtag=v${{ github.event.inputs.releaseVersion }} \
+            -DconnectionUrl=https://${{ github.token }}@github.com/${{ github.repository }}.git \
+            -DreleaseVersion=${{ github.event.inputs.releaseVersion }} \
+            -DdevelopmentVersion=${{ github.event.inputs.nextDevelopmentVersion }} \
+            -DpushChanges=false
+      - name: Release Perform
+        if: ${{ github.event.inputs.dry-run != 'true' }}
+        env:
+          OSSRH_USERNAME: ${{ secrets.SNAPSHOT_UPLOAD_USER }}
+          OSSRH_TOKEN: ${{ secrets.SNAPSHOT_UPLOAD_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSWORD }}
+        run: |
+          # The tests are already executed in the prepare, skipping
+          mvn -DlocalCheckout=true -Darguments=-DskipTests release:perform
+          git push https://${{ github.token }}@github.com/${{ github.repository }}.git ${{ github.ref_name }}:${{ github.ref_name }}
+          git push https://${{ github.token }}@github.com/${{ github.repository }}.git v${{ github.event.inputs.releaseVersion }}
+      - name: Publish Release
+        if: ${{ github.event.inputs.dry-run != 'true' }}
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: v${{ github.event.inputs.releaseVersion }}

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,6 +10,55 @@ Releases are done on an as-needed basis, and this doc applies only to
 This does _not_ describe the process of cherry-picking changes onto release
 branches.
 
+## Release via Github Action
+
+Maintainers meet the following requirements will be able to perform automated
+release to maven central via Github Action job named "Maven Release":
+
+* Has "collaborator" permission or greater access (otherwise the can't run the
+  job manually).
+* Should be in the OWNERS file.
+
+### Steps
+
+#### Make sure the release job runs on the release branch
+
+When cutting the next major release, firstly we need to fork out a new release
+branch named `release-<major>`. So the release job will execute the maven 
+release plugin and push generated releasing commits to the release branch
+if the `release:prepare` process finishes successfully. Note that if we're 
+bumping a new patch version from an existing release branch, this step can be
+omitted.
+
+#### Filling release job input manually
+
+The github action job will require three manual input:
+
+* The POM releasing version, must be a valid semver `X.Y.Z` (without "v" prefix).
+* The next development POM version, conventionally we should bump a patch 
+  version from the current release version and add a `-SNAPSHOT` suffix. i.e.
+  `X.Y.(Z+1)-SNAPSHOT`.
+* Dry-Run: Indicating whether the release job will push the generated release
+  commits to the release branch and actually upload the artifacts.
+  
+Filling the inputs, then click "Run" to start the job. 
+
+> Note that during the release process, no commits shall be added the release
+> branch.
+
+#### Release note, announcements
+
+After the release job successfully finishes, we're supposed to see two generated
+commits automatically added to the release branch:
+
+1. Bump the previous development version to the target release version.
+2. Bump the release version to the next development version.
+
+And a git tag `vX.Y.Z` will also be pushed on the commit (1), a GITHUB release
+will also be packed on the tag.
+
+In the end, don't forget to clarify the release notes on the GITHUB release.
+
 ## One time setup
 
 You will need to have the following in place:


### PR DESCRIPTION
> Signed-off-by: yue9944882 <291271447@qq.com>

@brendandburns i also clarified the usage of the release job in the doc.

<img width="1367" alt="Screen Shot 2021-12-31 at 4 17 00 PM 1" src="https://user-images.githubusercontent.com/12049380/147811932-ef79cf8f-6c35-4bd7-95b4-55c9ea82a677.png">

https://github.com/kubernetes-client/java/pull/2056 is an example of the generated commits by the job. as the next step, we can cherry-pick this release job to the recent release branches and send a release `11.0.4` for https://github.com/kubernetes-client/java/issues/2041