### PR TITLE
Fixes java 16 compability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>uk.org.webcompere</groupId>
+        <artifactId>system-stubs-core</artifactId>
+        <version>2.0.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>com.github.tomakehurst</groupId>
         <artifactId>wiremock</artifactId>
         <version>2.27.2</version>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -109,50 +109,5 @@
       </plugin>
     </plugins>
   </build>
-  <profiles>
-    <profile>
-        <id>surefire-newerJava</id>
-        <activation>
-            <jdk>(1.8,)</jdk>
-        </activation>
-        <build>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <configuration>
-                        <argLine>@{argLine} -Xms512m -Xmx1500m --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED</argLine>
-                        <parallel>methods</parallel>
-                        <perCoreThreadCount>false</perCoreThreadCount>
-                        <threadCount>1</threadCount>
-                        <forkCount>1</forkCount>
-                        <reuseForks>false</reuseForks>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </build>
-    </profile>
-    <profile>
-        <id>surefire-java8</id>
-        <activation>
-            <jdk>1.8</jdk>
-        </activation>
-        <build>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <configuration>
-                        <argLine>@{argLine} -Xms512m -Xmx1500m</argLine>
-                        <parallel>methods</parallel>
-                        <perCoreThreadCount>false</perCoreThreadCount>
-                        <threadCount>1</threadCount>
-                        <forkCount>1</forkCount>
-                        <reuseForks>false</reuseForks>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </build>
-    </profile>
-  </profiles>
+
 </project>

--- a/spring/src/test/java/io/kubernetes/client/spring/extended/controller/KubernetesInformerCreatorTest.java
+++ b/spring/src/test/java/io/kubernetes/client/spring/extended/controller/KubernetesInformerCreatorTest.java
@@ -28,11 +28,11 @@ import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.PostServeAction;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
-import com.google.gson.Gson;
 import io.kubernetes.client.informer.SharedIndexInformer;
 import io.kubernetes.client.informer.SharedInformerFactory;
 import io.kubernetes.client.informer.cache.Lister;
 import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.JSON;
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ConfigMapList;
 import io.kubernetes.client.openapi.models.V1ListMeta;
@@ -135,8 +135,8 @@ public class KubernetesInformerCreatorTest {
                 aResponse()
                     .withStatus(200)
                     .withBody(
-                        new Gson()
-                            .toJson(
+                        new JSON()
+                            .serialize(
                                 new V1PodList()
                                     .metadata(new V1ListMeta().resourceVersion("0"))
                                     .items(Arrays.asList(foo1))))));
@@ -154,8 +154,8 @@ public class KubernetesInformerCreatorTest {
                 aResponse()
                     .withStatus(200)
                     .withBody(
-                        new Gson()
-                            .toJson(
+                        new JSON()
+                            .serialize(
                                 new V1ConfigMapList()
                                     .metadata(new V1ListMeta().resourceVersion("0"))
                                     .items(Arrays.asList(bar1))))));

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -101,8 +101,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-lambda</artifactId>
+            <groupId>uk.org.webcompere</groupId>
+            <artifactId>system-stubs-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -159,52 +159,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>surefire-newerJava</id>
-            <activation>
-                <jdk>(1.8,)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <argLine>
-                                @{argLine} -Xms512m -Xmx1500m --illegal-access=warn --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED
-                            </argLine>
-                            <parallel>methods</parallel>
-                            <perCoreThreadCount>false</perCoreThreadCount>
-                            <threadCount>1</threadCount>
-                            <forkCount>1</forkCount>
-                            <reuseForks>false</reuseForks>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>surefire-java8</id>
-            <activation>
-                <jdk>1.8</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <argLine>@{argLine} -Xms512m -Xmx1500m</argLine>
-                            <parallel>methods</parallel>
-                            <perCoreThreadCount>false</perCoreThreadCount>
-                            <threadCount>1</threadCount>
-                            <forkCount>1</forkCount>
-                            <reuseForks>false</reuseForks>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/util/src/main/java/io/kubernetes/client/util/Watch.java
+++ b/util/src/main/java/io/kubernetes/client/util/Watch.java
@@ -52,6 +52,8 @@ public class Watch<T> implements Watchable<T>, Closeable {
 
     public V1Status status;
 
+    public Response() {}
+
     public Response(String type, T object) {
       this.type = type;
       this.object = object;

--- a/util/src/test/java/io/kubernetes/client/util/ClientBuilderTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/ClientBuilderTest.java
@@ -12,7 +12,6 @@ limitations under the License.
 */
 package io.kubernetes.client.util;
 
-import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
 import static io.kubernetes.client.util.Config.ENV_SERVICE_HOST;
 import static io.kubernetes.client.util.Config.ENV_SERVICE_PORT;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -21,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariable;
 
 import io.kubernetes.client.Resources;
 import io.kubernetes.client.openapi.ApiClient;

--- a/util/src/test/java/io/kubernetes/client/util/ConfigTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/ConfigTest.java
@@ -12,8 +12,8 @@ limitations under the License.
 */
 package io.kubernetes.client.util;
 
-import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
 import static org.junit.Assert.*;
+import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariable;
 
 import io.kubernetes.client.openapi.ApiClient;
 import java.io.File;

--- a/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesApiForCoreApiTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesApiForCoreApiTest.java
@@ -16,9 +16,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.junit.Assert.*;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.google.gson.Gson;
 import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.JSON;
 import io.kubernetes.client.openapi.models.V1ListMeta;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
@@ -36,6 +36,7 @@ public class GenericKubernetesApiForCoreApiTest {
 
   @Rule public WireMockRule wireMockRule = new WireMockRule(8181);
 
+  private JSON json = new JSON();
   private GenericKubernetesApi<V1Pod, V1PodList> podClient;
 
   @Before
@@ -51,7 +52,7 @@ public class GenericKubernetesApiForCoreApiTest {
     V1Status status = new V1Status().kind("Status").code(200).message("good!");
     stubFor(
         delete(urlEqualTo("/api/v1/namespaces/default/pods/foo1"))
-            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(status))));
+            .willReturn(aResponse().withStatus(200).withBody(json.serialize(status))));
 
     KubernetesApiResponse<V1Pod> deletePodResp = podClient.delete("default", "foo1", null);
     assertTrue(deletePodResp.isSuccess());
@@ -67,7 +68,7 @@ public class GenericKubernetesApiForCoreApiTest {
 
     stubFor(
         delete(urlEqualTo("/api/v1/namespaces/default/pods/foo1"))
-            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(foo1))));
+            .willReturn(aResponse().withStatus(200).withBody(json.serialize(foo1))));
 
     KubernetesApiResponse<V1Pod> deletePodResp = podClient.delete("default", "foo1");
     assertTrue(deletePodResp.isSuccess());
@@ -82,7 +83,7 @@ public class GenericKubernetesApiForCoreApiTest {
 
     stubFor(
         delete(urlEqualTo("/api/v1/namespaces/default/pods/foo1"))
-            .willReturn(aResponse().withStatus(403).withBody(new Gson().toJson(status))));
+            .willReturn(aResponse().withStatus(403).withBody(json.serialize(status))));
 
     KubernetesApiResponse<V1Pod> deletePodResp = podClient.delete("default", "foo1");
     assertFalse(deletePodResp.isSuccess());
@@ -97,7 +98,7 @@ public class GenericKubernetesApiForCoreApiTest {
 
     stubFor(
         get(urlPathEqualTo("/api/v1/namespaces/default/pods"))
-            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(podList))));
+            .willReturn(aResponse().withStatus(200).withBody(json.serialize(podList))));
     KubernetesApiResponse<V1PodList> podListResp = podClient.list("default");
     assertTrue(podListResp.isSuccess());
     assertEquals(podList, podListResp.getObject());
@@ -111,7 +112,7 @@ public class GenericKubernetesApiForCoreApiTest {
 
     stubFor(
         get(urlPathEqualTo("/api/v1/pods"))
-            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(podList))));
+            .willReturn(aResponse().withStatus(200).withBody(json.serialize(podList))));
     KubernetesApiResponse<V1PodList> podListResp = podClient.list();
     assertTrue(podListResp.isSuccess());
     assertEquals(podList, podListResp.getObject());
@@ -128,7 +129,7 @@ public class GenericKubernetesApiForCoreApiTest {
 
     stubFor(
         post(urlEqualTo("/api/v1/namespaces/default/pods"))
-            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(foo1))));
+            .willReturn(aResponse().withStatus(200).withBody(json.serialize(foo1))));
     KubernetesApiResponse<V1Pod> podListResp = podClient.create(foo1);
     assertTrue(podListResp.isSuccess());
     assertEquals(foo1, podListResp.getObject());
@@ -143,7 +144,7 @@ public class GenericKubernetesApiForCoreApiTest {
 
     stubFor(
         put(urlEqualTo("/api/v1/namespaces/default/pods/foo1"))
-            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(foo1))));
+            .willReturn(aResponse().withStatus(200).withBody(json.serialize(foo1))));
     KubernetesApiResponse<V1Pod> podListResp = podClient.update(foo1);
     assertTrue(podListResp.isSuccess());
     assertEquals(foo1, podListResp.getObject());
@@ -159,7 +160,7 @@ public class GenericKubernetesApiForCoreApiTest {
     stubFor(
         patch(urlEqualTo("/api/v1/namespaces/default/pods/foo1"))
             .withHeader("Content-Type", containing(V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH))
-            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(foo1))));
+            .willReturn(aResponse().withStatus(200).withBody(json.serialize(foo1))));
     KubernetesApiResponse<V1Pod> podPatchResp =
         podClient.patch("default", "foo1", V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH, v1Patch);
 
@@ -179,7 +180,7 @@ public class GenericKubernetesApiForCoreApiTest {
     stubFor(
         patch(urlEqualTo(prefix + "/api/v1/namespaces/default/pods/foo1"))
             .withHeader("Content-Type", containing(V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH))
-            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(foo1))));
+            .willReturn(aResponse().withStatus(200).withBody(json.serialize(foo1))));
 
     GenericKubernetesApi<V1Pod, V1PodList> rancherPodClient =
         new GenericKubernetesApi<>(

--- a/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesApiTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesApiTest.java
@@ -16,7 +16,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.junit.Assert.*;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.google.gson.Gson;
 import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
@@ -41,6 +40,7 @@ public class GenericKubernetesApiTest {
 
   @Rule public WireMockRule wireMockRule = new WireMockRule(8181);
 
+  private JSON json = new JSON();
   private GenericKubernetesApi<V1Job, V1JobList> jobClient;
 
   @Before
@@ -56,7 +56,7 @@ public class GenericKubernetesApiTest {
     V1Status status = new V1Status().kind("Status").code(200).message("good!");
     stubFor(
         delete(urlEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1"))
-            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(status))));
+            .willReturn(aResponse().withStatus(200).withBody(json.serialize(status))));
 
     KubernetesApiResponse<V1Job> deleteJobResp = jobClient.delete("default", "foo1", null);
     assertTrue(deleteJobResp.isSuccess());
@@ -72,7 +72,7 @@ public class GenericKubernetesApiTest {
 
     stubFor(
         delete(urlEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1"))
-            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(foo1))));
+            .willReturn(aResponse().withStatus(200).withBody(json.serialize(foo1))));
 
     KubernetesApiResponse<V1Job> deleteJobResp = jobClient.delete("default", "foo1");
     assertTrue(deleteJobResp.isSuccess());
@@ -87,7 +87,7 @@ public class GenericKubernetesApiTest {
 
     stubFor(
         delete(urlEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1"))
-            .willReturn(aResponse().withStatus(403).withBody(new Gson().toJson(status))));
+            .willReturn(aResponse().withStatus(403).withBody(json.serialize(status))));
 
     KubernetesApiResponse<V1Job> deleteJobResp = jobClient.delete("default", "foo1");
     assertFalse(deleteJobResp.isSuccess());
@@ -102,7 +102,7 @@ public class GenericKubernetesApiTest {
 
     stubFor(
         get(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs"))
-            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(jobList))));
+            .willReturn(aResponse().withStatus(200).withBody(json.serialize(jobList))));
     KubernetesApiResponse<V1JobList> jobListResp = jobClient.list("default");
     assertTrue(jobListResp.isSuccess());
     assertEquals(jobList, jobListResp.getObject());
@@ -116,7 +116,7 @@ public class GenericKubernetesApiTest {
 
     stubFor(
         get(urlPathEqualTo("/apis/batch/v1/jobs"))
-            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(jobList))));
+            .willReturn(aResponse().withStatus(200).withBody(json.serialize(jobList))));
     KubernetesApiResponse<V1JobList> jobListResp = jobClient.list();
     assertTrue(jobListResp.isSuccess());
     assertEquals(jobList, jobListResp.getObject());
@@ -131,7 +131,7 @@ public class GenericKubernetesApiTest {
 
     stubFor(
         post(urlEqualTo("/apis/batch/v1/namespaces/default/jobs"))
-            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(foo1))));
+            .willReturn(aResponse().withStatus(200).withBody(json.serialize(foo1))));
     KubernetesApiResponse<V1Job> jobListResp = jobClient.create(foo1);
     assertTrue(jobListResp.isSuccess());
     assertEquals(foo1, jobListResp.getObject());
@@ -146,7 +146,7 @@ public class GenericKubernetesApiTest {
 
     stubFor(
         put(urlEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1"))
-            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(foo1))));
+            .willReturn(aResponse().withStatus(200).withBody(json.serialize(foo1))));
     KubernetesApiResponse<V1Job> jobListResp = jobClient.update(foo1);
     assertTrue(jobListResp.isSuccess());
     assertEquals(foo1, jobListResp.getObject());
@@ -179,7 +179,7 @@ public class GenericKubernetesApiTest {
     stubFor(
         patch(urlEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1"))
             .withHeader("Content-Type", containing(V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH))
-            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(foo1))));
+            .willReturn(aResponse().withStatus(200).withBody(json.serialize(foo1))));
     KubernetesApiResponse<V1Job> jobPatchResp =
         jobClient.patch("default", "foo1", V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH, v1Patch);
 
@@ -195,7 +195,7 @@ public class GenericKubernetesApiTest {
 
     stubFor(
         get(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs"))
-            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(jobList))));
+            .willReturn(aResponse().withStatus(200).withBody(json.serialize(jobList))));
     Watchable<V1Job> jobListWatch = jobClient.watch("default", new ListOptions());
     verify(
         1,

--- a/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesGetApiTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesGetApiTest.java
@@ -17,8 +17,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.google.gson.Gson;
 import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.JSON;
 import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1JobList;
 import io.kubernetes.client.openapi.models.V1Status;
@@ -31,6 +31,7 @@ public class GenericKubernetesGetApiTest {
 
   @Rule public WireMockRule wireMockRule = new WireMockRule(8181);
 
+  private JSON json = new JSON();
   private GenericKubernetesApi<V1Job, V1JobList> jobClient; // non-core built-in resource
   private GenericKubernetesApi<FooCustomResource, FooCustomResourceList>
       fooClient; // custom resource
@@ -57,10 +58,10 @@ public class GenericKubernetesGetApiTest {
 
     stubFor(
         get(urlEqualTo("/apis/batch/v1/namespaces/default/jobs/noxu"))
-            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(job))));
+            .willReturn(aResponse().withStatus(200).withBody(json.serialize(job))));
     stubFor(
         get(urlEqualTo("/apis/example.io/v1/namespaces/default/foos/noxu"))
-            .willReturn(aResponse().withStatus(200).withBody(new Gson().toJson(foo))));
+            .willReturn(aResponse().withStatus(200).withBody(json.serialize(foo))));
 
     KubernetesApiResponse<V1Job> jobResp = jobClient.get("default", "noxu");
     KubernetesApiResponse<FooCustomResource> fooResp = fooClient.get("default", "noxu");
@@ -77,10 +78,10 @@ public class GenericKubernetesGetApiTest {
 
     stubFor(
         get(urlEqualTo("/apis/batch/v1/namespaces/default/jobs/noxu"))
-            .willReturn(aResponse().withStatus(403).withBody(new Gson().toJson(forbiddenStatus))));
+            .willReturn(aResponse().withStatus(403).withBody(json.serialize(forbiddenStatus))));
     stubFor(
         get(urlEqualTo("/apis/example.io/v1/namespaces/default/foos/noxu"))
-            .willReturn(aResponse().withStatus(403).withBody(new Gson().toJson(forbiddenStatus))));
+            .willReturn(aResponse().withStatus(403).withBody(json.serialize(forbiddenStatus))));
 
     KubernetesApiResponse<V1Job> jobResp = jobClient.get("default", "noxu");
     KubernetesApiResponse<FooCustomResource> fooResp = fooClient.get("default", "noxu");


### PR DESCRIPTION
1. replacing `com.github.stefanbirkner/system-lambda` w/ `uk.org.webcompere/system-stubs-core`, which is a dropin replacement for the former library that fixes the environment issue.

2. adding a default contructor for `Watch#Response` to avoid gson's reflective dynamic constructor which violates the jdk16 restriction.