### PR TITLE
Bump protobuf-java from 3.19.1 to 3.19.2 for release 14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,8 @@
     <javax.annotation.version>1.3.2</javax.annotation.version>
     <snakeyaml.version>1.29</snakeyaml.version>
     <slf4j.version>1.7.32</slf4j.version>
-    <caffeine.version>2.9.2</caffeine.version>
-    <protobuf.version>3.19.1</protobuf.version>
+    <caffeine.version>2.9.3</caffeine.version>
+    <protobuf.version>3.19.2</protobuf.version>
     <junit.version>4.13</junit.version>
     <bucket4j.version>6.3.0</bucket4j.version>
     <bouncycastle.version>1.69</bouncycastle.version>


### PR DESCRIPTION
Related to issue #2154, cherry pick of [#2061](https://github.com/kubernetes-client/java/pull/2061),

Also updated caffeine version, to solve conflict,

Let me know if I'm missing anything