### PR TITLE
refactor: Use `Collections#isEmpty()` instead of comparing `size()`

### DIFF
--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlDrain.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlDrain.java
@@ -88,7 +88,7 @@ public class KubectlDrain extends KubectlCordon {
     for (V1Pod pod : pods) {
       if (pod.getMetadata().getOwnerReferences() == null) continue;
 
-      if (!force && pod.getMetadata().getOwnerReferences().size() == 0) {
+      if (!force && pod.getMetadata().getOwnerReferences().isEmpty()) {
         throw new KubectlException("Pods unmanaged by a controller are present on the node");
       }
       // Throw if there are daemon set pods and ignore daemon set is false

--- a/extended/src/main/java/io/kubernetes/client/extended/network/EndpointsLoadBalancer.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/network/EndpointsLoadBalancer.java
@@ -66,7 +66,7 @@ public class EndpointsLoadBalancer implements LoadBalancer {
   @Override
   public String getTargetIP() throws NoAvailableAddressException {
     List<String> availableIPs = getAllAvailableIPs();
-    if (availableIPs.size() == 0) {
+    if (availableIPs.isEmpty()) {
       throw new NoAvailableAddressException();
     }
     return this.strategy.chooseIP(availableIPs);
@@ -79,7 +79,7 @@ public class EndpointsLoadBalancer implements LoadBalancer {
       throw new NoAvailableAddressException();
     }
     List<String> availableIPs = getAllAvailableIPs(port);
-    if (availableIPs.size() == 0) {
+    if (availableIPs.isEmpty()) {
       throw new NoAvailableAddressException();
     }
     return this.strategy.chooseIP(availableIPs);

--- a/extended/src/main/java/io/kubernetes/client/extended/network/RoundRobinLoadBalanceStrategy.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/network/RoundRobinLoadBalanceStrategy.java
@@ -21,7 +21,7 @@ public class RoundRobinLoadBalanceStrategy implements LoadBalanceStrategy {
 
   @Override
   public String chooseIP(List<String> availableIPs) {
-    if (availableIPs == null || availableIPs.size() == 0) {
+    if (availableIPs == null || availableIPs.isEmpty()) {
       throw new IllegalArgumentException("failed choosing IP target: empty candidates");
     }
     int len = availableIPs.size();

--- a/extended/src/main/java/io/kubernetes/client/extended/pager/Pager.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/pager/Pager.java
@@ -117,8 +117,7 @@ public class Pager<ApiType extends KubernetesObject, ApiListType extends Kuberne
      */
     @Override
     public boolean hasNext() {
-      if (listObjectCurrentPage.getItems() == null
-          || listObjectCurrentPage.getItems().size() == 0) {
+      if (listObjectCurrentPage.getItems() == null || listObjectCurrentPage.getItems().isEmpty()) {
         return false;
       }
       if (!started) {

--- a/extended/src/main/java/io/kubernetes/client/extended/workqueue/DefaultWorkQueue.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/workqueue/DefaultWorkQueue.java
@@ -72,10 +72,10 @@ public class DefaultWorkQueue<T> implements WorkQueue<T> {
 
   @Override
   public synchronized T get() throws InterruptedException {
-    while (queue.size() == 0 && !shuttingDown) {
+    while (queue.isEmpty() && !shuttingDown) {
       this.wait();
     }
-    if (queue.size() == 0) {
+    if (queue.isEmpty()) {
       // We must be shutting down
       return null;
     }

--- a/extended/src/test/java/io/kubernetes/client/extended/workqueue/DefaultDelayingQueueTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/workqueue/DefaultDelayingQueueTest.java
@@ -147,6 +147,6 @@ public class DefaultDelayingQueueTest {
 
   private boolean waitForWaitingQueueToFill(DefaultDelayingQueue queue) {
     return Wait.poll(
-        Duration.ofMillis(10), Duration.ofSeconds(10), () -> queue.waitingForAddQueue.size() == 0);
+        Duration.ofMillis(10), Duration.ofSeconds(10), () -> queue.waitingForAddQueue.isEmpty());
   }
 }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/CoreV1EventListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/CoreV1EventListFluentImpl.java
@@ -256,7 +256,7 @@ public class CoreV1EventListFluentImpl<A extends CoreV1EventListFluent<A>> exten
   }
 
   public io.kubernetes.client.openapi.models.CoreV1EventListFluent.ItemsNested<A> editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/EventsV1EventListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/EventsV1EventListFluentImpl.java
@@ -259,7 +259,7 @@ public class EventsV1EventListFluentImpl<A extends EventsV1EventListFluent<A>> e
 
   public io.kubernetes.client.openapi.models.EventsV1EventListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1APIGroupFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1APIGroupFluentImpl.java
@@ -382,7 +382,7 @@ public class V1APIGroupFluentImpl<A extends V1APIGroupFluent<A>> extends BaseFlu
 
   public io.kubernetes.client.openapi.models.V1APIGroupFluent.ServerAddressByClientCIDRsNested<A>
       editFirstServerAddressByClientCIDR() {
-    if (serverAddressByClientCIDRs.size() == 0)
+    if (serverAddressByClientCIDRs.isEmpty())
       throw new RuntimeException("Can't edit first serverAddressByClientCIDRs. The list is empty.");
     return setNewServerAddressByClientCIDRLike(0, buildServerAddressByClientCIDR(0));
   }
@@ -638,7 +638,7 @@ public class V1APIGroupFluentImpl<A extends V1APIGroupFluent<A>> extends BaseFlu
   }
 
   public io.kubernetes.client.openapi.models.V1APIGroupFluent.VersionsNested<A> editFirstVersion() {
-    if (versions.size() == 0)
+    if (versions.isEmpty())
       throw new RuntimeException("Can't edit first versions. The list is empty.");
     return setNewVersionLike(0, buildVersion(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1APIGroupListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1APIGroupListFluentImpl.java
@@ -254,8 +254,7 @@ public class V1APIGroupListFluentImpl<A extends V1APIGroupListFluent<A>> extends
   }
 
   public io.kubernetes.client.openapi.models.V1APIGroupListFluent.GroupsNested<A> editFirstGroup() {
-    if (groups.size() == 0)
-      throw new RuntimeException("Can't edit first groups. The list is empty.");
+    if (groups.isEmpty()) throw new RuntimeException("Can't edit first groups. The list is empty.");
     return setNewGroupLike(0, buildGroup(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1APIResourceListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1APIResourceListFluentImpl.java
@@ -289,7 +289,7 @@ public class V1APIResourceListFluentImpl<A extends V1APIResourceListFluent<A>> e
 
   public io.kubernetes.client.openapi.models.V1APIResourceListFluent.ResourcesNested<A>
       editFirstResource() {
-    if (resources.size() == 0)
+    if (resources.isEmpty())
       throw new RuntimeException("Can't edit first resources. The list is empty.");
     return setNewResourceLike(0, buildResource(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1APIServiceListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1APIServiceListFluentImpl.java
@@ -256,7 +256,7 @@ public class V1APIServiceListFluentImpl<A extends V1APIServiceListFluent<A>> ext
   }
 
   public io.kubernetes.client.openapi.models.V1APIServiceListFluent.ItemsNested<A> editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1APIServiceStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1APIServiceStatusFluentImpl.java
@@ -249,7 +249,7 @@ public class V1APIServiceStatusFluentImpl<A extends V1APIServiceStatusFluent<A>>
 
   public io.kubernetes.client.openapi.models.V1APIServiceStatusFluent.ConditionsNested<A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1APIVersionsFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1APIVersionsFluentImpl.java
@@ -302,7 +302,7 @@ public class V1APIVersionsFluentImpl<A extends V1APIVersionsFluent<A>> extends B
 
   public io.kubernetes.client.openapi.models.V1APIVersionsFluent.ServerAddressByClientCIDRsNested<A>
       editFirstServerAddressByClientCIDR() {
-    if (serverAddressByClientCIDRs.size() == 0)
+    if (serverAddressByClientCIDRs.isEmpty())
       throw new RuntimeException("Can't edit first serverAddressByClientCIDRs. The list is empty.");
     return setNewServerAddressByClientCIDRLike(0, buildServerAddressByClientCIDR(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1AggregationRuleFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1AggregationRuleFluentImpl.java
@@ -247,7 +247,7 @@ public class V1AggregationRuleFluentImpl<A extends V1AggregationRuleFluent<A>> e
 
   public io.kubernetes.client.openapi.models.V1AggregationRuleFluent.ClusterRoleSelectorsNested<A>
       editFirstClusterRoleSelector() {
-    if (clusterRoleSelectors.size() == 0)
+    if (clusterRoleSelectors.isEmpty())
       throw new RuntimeException("Can't edit first clusterRoleSelectors. The list is empty.");
     return setNewClusterRoleSelectorLike(0, buildClusterRoleSelector(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CSIDriverListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CSIDriverListFluentImpl.java
@@ -256,7 +256,7 @@ public class V1CSIDriverListFluentImpl<A extends V1CSIDriverListFluent<A>> exten
   }
 
   public io.kubernetes.client.openapi.models.V1CSIDriverListFluent.ItemsNested<A> editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CSIDriverSpecFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CSIDriverSpecFluentImpl.java
@@ -334,7 +334,7 @@ public class V1CSIDriverSpecFluentImpl<A extends V1CSIDriverSpecFluent<A>> exten
 
   public io.kubernetes.client.openapi.models.V1CSIDriverSpecFluent.TokenRequestsNested<A>
       editFirstTokenRequest() {
-    if (tokenRequests.size() == 0)
+    if (tokenRequests.isEmpty())
       throw new RuntimeException("Can't edit first tokenRequests. The list is empty.");
     return setNewTokenRequestLike(0, buildTokenRequest(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CSINodeListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CSINodeListFluentImpl.java
@@ -251,7 +251,7 @@ public class V1CSINodeListFluentImpl<A extends V1CSINodeListFluent<A>> extends B
   }
 
   public io.kubernetes.client.openapi.models.V1CSINodeListFluent.ItemsNested<A> editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CSINodeSpecFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CSINodeSpecFluentImpl.java
@@ -237,7 +237,7 @@ public class V1CSINodeSpecFluentImpl<A extends V1CSINodeSpecFluent<A>> extends B
 
   public io.kubernetes.client.openapi.models.V1CSINodeSpecFluent.DriversNested<A>
       editFirstDriver() {
-    if (drivers.size() == 0)
+    if (drivers.isEmpty())
       throw new RuntimeException("Can't edit first drivers. The list is empty.");
     return setNewDriverLike(0, buildDriver(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CertificateSigningRequestListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CertificateSigningRequestListFluentImpl.java
@@ -274,7 +274,7 @@ public class V1CertificateSigningRequestListFluentImpl<
 
   public io.kubernetes.client.openapi.models.V1CertificateSigningRequestListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CertificateSigningRequestStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CertificateSigningRequestStatusFluentImpl.java
@@ -366,7 +366,7 @@ public class V1CertificateSigningRequestStatusFluentImpl<
               .ConditionsNested<
           A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ClusterRoleBindingFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ClusterRoleBindingFluentImpl.java
@@ -387,7 +387,7 @@ public class V1ClusterRoleBindingFluentImpl<A extends V1ClusterRoleBindingFluent
 
   public io.kubernetes.client.openapi.models.V1ClusterRoleBindingFluent.SubjectsNested<A>
       editFirstSubject() {
-    if (subjects.size() == 0)
+    if (subjects.isEmpty())
       throw new RuntimeException("Can't edit first subjects. The list is empty.");
     return setNewSubjectLike(0, buildSubject(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ClusterRoleBindingListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ClusterRoleBindingListFluentImpl.java
@@ -267,7 +267,7 @@ public class V1ClusterRoleBindingListFluentImpl<A extends V1ClusterRoleBindingLi
 
   public io.kubernetes.client.openapi.models.V1ClusterRoleBindingListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ClusterRoleFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ClusterRoleFluentImpl.java
@@ -381,7 +381,7 @@ public class V1ClusterRoleFluentImpl<A extends V1ClusterRoleFluent<A>> extends B
   }
 
   public io.kubernetes.client.openapi.models.V1ClusterRoleFluent.RulesNested<A> editFirstRule() {
-    if (rules.size() == 0) throw new RuntimeException("Can't edit first rules. The list is empty.");
+    if (rules.isEmpty()) throw new RuntimeException("Can't edit first rules. The list is empty.");
     return setNewRuleLike(0, buildRule(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ClusterRoleListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ClusterRoleListFluentImpl.java
@@ -258,7 +258,7 @@ public class V1ClusterRoleListFluentImpl<A extends V1ClusterRoleListFluent<A>> e
 
   public io.kubernetes.client.openapi.models.V1ClusterRoleListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ComponentStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ComponentStatusFluentImpl.java
@@ -270,7 +270,7 @@ public class V1ComponentStatusFluentImpl<A extends V1ComponentStatusFluent<A>> e
 
   public io.kubernetes.client.openapi.models.V1ComponentStatusFluent.ConditionsNested<A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ComponentStatusListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ComponentStatusListFluentImpl.java
@@ -259,7 +259,7 @@ public class V1ComponentStatusListFluentImpl<A extends V1ComponentStatusListFlue
 
   public io.kubernetes.client.openapi.models.V1ComponentStatusListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ConfigMapListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ConfigMapListFluentImpl.java
@@ -256,7 +256,7 @@ public class V1ConfigMapListFluentImpl<A extends V1ConfigMapListFluent<A>> exten
   }
 
   public io.kubernetes.client.openapi.models.V1ConfigMapListFluent.ItemsNested<A> editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ConfigMapProjectionFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ConfigMapProjectionFluentImpl.java
@@ -243,7 +243,7 @@ public class V1ConfigMapProjectionFluentImpl<A extends V1ConfigMapProjectionFlue
 
   public io.kubernetes.client.openapi.models.V1ConfigMapProjectionFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ConfigMapVolumeSourceFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ConfigMapVolumeSourceFluentImpl.java
@@ -259,7 +259,7 @@ public class V1ConfigMapVolumeSourceFluentImpl<A extends V1ConfigMapVolumeSource
 
   public io.kubernetes.client.openapi.models.V1ConfigMapVolumeSourceFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ContainerFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ContainerFluentImpl.java
@@ -524,7 +524,7 @@ public class V1ContainerFluentImpl<A extends V1ContainerFluent<A>> extends BaseF
   }
 
   public io.kubernetes.client.openapi.models.V1ContainerFluent.EnvNested<A> editFirstEnv() {
-    if (env.size() == 0) throw new RuntimeException("Can't edit first env. The list is empty.");
+    if (env.isEmpty()) throw new RuntimeException("Can't edit first env. The list is empty.");
     return setNewEnvLike(0, buildEnv(0));
   }
 
@@ -755,7 +755,7 @@ public class V1ContainerFluentImpl<A extends V1ContainerFluent<A>> extends BaseF
   }
 
   public io.kubernetes.client.openapi.models.V1ContainerFluent.EnvFromNested<A> editFirstEnvFrom() {
-    if (envFrom.size() == 0)
+    if (envFrom.isEmpty())
       throw new RuntimeException("Can't edit first envFrom. The list is empty.");
     return setNewEnvFromLike(0, buildEnvFrom(0));
   }
@@ -1132,7 +1132,7 @@ public class V1ContainerFluentImpl<A extends V1ContainerFluent<A>> extends BaseF
   }
 
   public io.kubernetes.client.openapi.models.V1ContainerFluent.PortsNested<A> editFirstPort() {
-    if (ports.size() == 0) throw new RuntimeException("Can't edit first ports. The list is empty.");
+    if (ports.isEmpty()) throw new RuntimeException("Can't edit first ports. The list is empty.");
     return setNewPortLike(0, buildPort(0));
   }
 
@@ -1655,7 +1655,7 @@ public class V1ContainerFluentImpl<A extends V1ContainerFluent<A>> extends BaseF
 
   public io.kubernetes.client.openapi.models.V1ContainerFluent.VolumeDevicesNested<A>
       editFirstVolumeDevice() {
-    if (volumeDevices.size() == 0)
+    if (volumeDevices.isEmpty())
       throw new RuntimeException("Can't edit first volumeDevices. The list is empty.");
     return setNewVolumeDeviceLike(0, buildVolumeDevice(0));
   }
@@ -1895,7 +1895,7 @@ public class V1ContainerFluentImpl<A extends V1ContainerFluent<A>> extends BaseF
 
   public io.kubernetes.client.openapi.models.V1ContainerFluent.VolumeMountsNested<A>
       editFirstVolumeMount() {
-    if (volumeMounts.size() == 0)
+    if (volumeMounts.isEmpty())
       throw new RuntimeException("Can't edit first volumeMounts. The list is empty.");
     return setNewVolumeMountLike(0, buildVolumeMount(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ControllerRevisionListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ControllerRevisionListFluentImpl.java
@@ -267,7 +267,7 @@ public class V1ControllerRevisionListFluentImpl<A extends V1ControllerRevisionLi
 
   public io.kubernetes.client.openapi.models.V1ControllerRevisionListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CronJobListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CronJobListFluentImpl.java
@@ -251,7 +251,7 @@ public class V1CronJobListFluentImpl<A extends V1CronJobListFluent<A>> extends B
   }
 
   public io.kubernetes.client.openapi.models.V1CronJobListFluent.ItemsNested<A> editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CronJobStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CronJobStatusFluentImpl.java
@@ -245,8 +245,7 @@ public class V1CronJobStatusFluentImpl<A extends V1CronJobStatusFluent<A>> exten
 
   public io.kubernetes.client.openapi.models.V1CronJobStatusFluent.ActiveNested<A>
       editFirstActive() {
-    if (active.size() == 0)
-      throw new RuntimeException("Can't edit first active. The list is empty.");
+    if (active.isEmpty()) throw new RuntimeException("Can't edit first active. The list is empty.");
     return setNewActiveLike(0, buildActive(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CustomResourceDefinitionListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CustomResourceDefinitionListFluentImpl.java
@@ -275,7 +275,7 @@ public class V1CustomResourceDefinitionListFluentImpl<
 
   public io.kubernetes.client.openapi.models.V1CustomResourceDefinitionListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CustomResourceDefinitionSpecFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CustomResourceDefinitionSpecFluentImpl.java
@@ -434,7 +434,7 @@ public class V1CustomResourceDefinitionSpecFluentImpl<
 
   public io.kubernetes.client.openapi.models.V1CustomResourceDefinitionSpecFluent.VersionsNested<A>
       editFirstVersion() {
-    if (versions.size() == 0)
+    if (versions.isEmpty())
       throw new RuntimeException("Can't edit first versions. The list is empty.");
     return setNewVersionLike(0, buildVersion(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CustomResourceDefinitionStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CustomResourceDefinitionStatusFluentImpl.java
@@ -350,7 +350,7 @@ public class V1CustomResourceDefinitionStatusFluentImpl<
               .ConditionsNested<
           A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CustomResourceDefinitionVersionFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1CustomResourceDefinitionVersionFluentImpl.java
@@ -303,7 +303,7 @@ public class V1CustomResourceDefinitionVersionFluentImpl<
               .AdditionalPrinterColumnsNested<
           A>
       editFirstAdditionalPrinterColumn() {
-    if (additionalPrinterColumns.size() == 0)
+    if (additionalPrinterColumns.isEmpty())
       throw new RuntimeException("Can't edit first additionalPrinterColumns. The list is empty.");
     return setNewAdditionalPrinterColumnLike(0, buildAdditionalPrinterColumn(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1DaemonSetListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1DaemonSetListFluentImpl.java
@@ -256,7 +256,7 @@ public class V1DaemonSetListFluentImpl<A extends V1DaemonSetListFluent<A>> exten
   }
 
   public io.kubernetes.client.openapi.models.V1DaemonSetListFluent.ItemsNested<A> editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1DaemonSetStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1DaemonSetStatusFluentImpl.java
@@ -288,7 +288,7 @@ public class V1DaemonSetStatusFluentImpl<A extends V1DaemonSetStatusFluent<A>> e
 
   public io.kubernetes.client.openapi.models.V1DaemonSetStatusFluent.ConditionsNested<A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1DeploymentListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1DeploymentListFluentImpl.java
@@ -256,7 +256,7 @@ public class V1DeploymentListFluentImpl<A extends V1DeploymentListFluent<A>> ext
   }
 
   public io.kubernetes.client.openapi.models.V1DeploymentListFluent.ItemsNested<A> editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1DeploymentStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1DeploymentStatusFluentImpl.java
@@ -297,7 +297,7 @@ public class V1DeploymentStatusFluentImpl<A extends V1DeploymentStatusFluent<A>>
 
   public io.kubernetes.client.openapi.models.V1DeploymentStatusFluent.ConditionsNested<A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1DownwardAPIProjectionFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1DownwardAPIProjectionFluentImpl.java
@@ -247,7 +247,7 @@ public class V1DownwardAPIProjectionFluentImpl<A extends V1DownwardAPIProjection
 
   public io.kubernetes.client.openapi.models.V1DownwardAPIProjectionFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1DownwardAPIVolumeSourceFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1DownwardAPIVolumeSourceFluentImpl.java
@@ -263,7 +263,7 @@ public class V1DownwardAPIVolumeSourceFluentImpl<A extends V1DownwardAPIVolumeSo
 
   public io.kubernetes.client.openapi.models.V1DownwardAPIVolumeSourceFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1EndpointHintsFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1EndpointHintsFluentImpl.java
@@ -239,7 +239,7 @@ public class V1EndpointHintsFluentImpl<A extends V1EndpointHintsFluent<A>> exten
 
   public io.kubernetes.client.openapi.models.V1EndpointHintsFluent.ForZonesNested<A>
       editFirstForZone() {
-    if (forZones.size() == 0)
+    if (forZones.isEmpty())
       throw new RuntimeException("Can't edit first forZones. The list is empty.");
     return setNewForZoneLike(0, buildForZone(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1EndpointSliceFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1EndpointSliceFluentImpl.java
@@ -281,7 +281,7 @@ public class V1EndpointSliceFluentImpl<A extends V1EndpointSliceFluent<A>> exten
 
   public io.kubernetes.client.openapi.models.V1EndpointSliceFluent.EndpointsNested<A>
       editFirstEndpoint() {
-    if (endpoints.size() == 0)
+    if (endpoints.isEmpty())
       throw new RuntimeException("Can't edit first endpoints. The list is empty.");
     return setNewEndpointLike(0, buildEndpoint(0));
   }
@@ -590,7 +590,7 @@ public class V1EndpointSliceFluentImpl<A extends V1EndpointSliceFluent<A>> exten
   }
 
   public io.kubernetes.client.openapi.models.V1EndpointSliceFluent.PortsNested<A> editFirstPort() {
-    if (ports.size() == 0) throw new RuntimeException("Can't edit first ports. The list is empty.");
+    if (ports.isEmpty()) throw new RuntimeException("Can't edit first ports. The list is empty.");
     return setNewPortLike(0, buildPort(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1EndpointSliceListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1EndpointSliceListFluentImpl.java
@@ -259,7 +259,7 @@ public class V1EndpointSliceListFluentImpl<A extends V1EndpointSliceListFluent<A
 
   public io.kubernetes.client.openapi.models.V1EndpointSliceListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1EndpointSubsetFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1EndpointSubsetFluentImpl.java
@@ -250,7 +250,7 @@ public class V1EndpointSubsetFluentImpl<A extends V1EndpointSubsetFluent<A>> ext
 
   public io.kubernetes.client.openapi.models.V1EndpointSubsetFluent.AddressesNested<A>
       editFirstAddress() {
-    if (addresses.size() == 0)
+    if (addresses.isEmpty())
       throw new RuntimeException("Can't edit first addresses. The list is empty.");
     return setNewAddressLike(0, buildAddress(0));
   }
@@ -495,7 +495,7 @@ public class V1EndpointSubsetFluentImpl<A extends V1EndpointSubsetFluent<A>> ext
 
   public io.kubernetes.client.openapi.models.V1EndpointSubsetFluent.NotReadyAddressesNested<A>
       editFirstNotReadyAddress() {
-    if (notReadyAddresses.size() == 0)
+    if (notReadyAddresses.isEmpty())
       throw new RuntimeException("Can't edit first notReadyAddresses. The list is empty.");
     return setNewNotReadyAddressLike(0, buildNotReadyAddress(0));
   }
@@ -730,7 +730,7 @@ public class V1EndpointSubsetFluentImpl<A extends V1EndpointSubsetFluent<A>> ext
   }
 
   public io.kubernetes.client.openapi.models.V1EndpointSubsetFluent.PortsNested<A> editFirstPort() {
-    if (ports.size() == 0) throw new RuntimeException("Can't edit first ports. The list is empty.");
+    if (ports.isEmpty()) throw new RuntimeException("Can't edit first ports. The list is empty.");
     return setNewPortLike(0, buildPort(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1EndpointsFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1EndpointsFluentImpl.java
@@ -326,7 +326,7 @@ public class V1EndpointsFluentImpl<A extends V1EndpointsFluent<A>> extends BaseF
   }
 
   public io.kubernetes.client.openapi.models.V1EndpointsFluent.SubsetsNested<A> editFirstSubset() {
-    if (subsets.size() == 0)
+    if (subsets.isEmpty())
       throw new RuntimeException("Can't edit first subsets. The list is empty.");
     return setNewSubsetLike(0, buildSubset(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1EndpointsListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1EndpointsListFluentImpl.java
@@ -255,7 +255,7 @@ public class V1EndpointsListFluentImpl<A extends V1EndpointsListFluent<A>> exten
   }
 
   public io.kubernetes.client.openapi.models.V1EndpointsListFluent.ItemsNested<A> editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1EphemeralContainerFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1EphemeralContainerFluentImpl.java
@@ -530,7 +530,7 @@ public class V1EphemeralContainerFluentImpl<A extends V1EphemeralContainerFluent
 
   public io.kubernetes.client.openapi.models.V1EphemeralContainerFluent.EnvNested<A>
       editFirstEnv() {
-    if (env.size() == 0) throw new RuntimeException("Can't edit first env. The list is empty.");
+    if (env.isEmpty()) throw new RuntimeException("Can't edit first env. The list is empty.");
     return setNewEnvLike(0, buildEnv(0));
   }
 
@@ -765,7 +765,7 @@ public class V1EphemeralContainerFluentImpl<A extends V1EphemeralContainerFluent
 
   public io.kubernetes.client.openapi.models.V1EphemeralContainerFluent.EnvFromNested<A>
       editFirstEnvFrom() {
-    if (envFrom.size() == 0)
+    if (envFrom.isEmpty())
       throw new RuntimeException("Can't edit first envFrom. The list is empty.");
     return setNewEnvFromLike(0, buildEnvFrom(0));
   }
@@ -1149,7 +1149,7 @@ public class V1EphemeralContainerFluentImpl<A extends V1EphemeralContainerFluent
 
   public io.kubernetes.client.openapi.models.V1EphemeralContainerFluent.PortsNested<A>
       editFirstPort() {
-    if (ports.size() == 0) throw new RuntimeException("Can't edit first ports. The list is empty.");
+    if (ports.isEmpty()) throw new RuntimeException("Can't edit first ports. The list is empty.");
     return setNewPortLike(0, buildPort(0));
   }
 
@@ -1689,7 +1689,7 @@ public class V1EphemeralContainerFluentImpl<A extends V1EphemeralContainerFluent
 
   public io.kubernetes.client.openapi.models.V1EphemeralContainerFluent.VolumeDevicesNested<A>
       editFirstVolumeDevice() {
-    if (volumeDevices.size() == 0)
+    if (volumeDevices.isEmpty())
       throw new RuntimeException("Can't edit first volumeDevices. The list is empty.");
     return setNewVolumeDeviceLike(0, buildVolumeDevice(0));
   }
@@ -1929,7 +1929,7 @@ public class V1EphemeralContainerFluentImpl<A extends V1EphemeralContainerFluent
 
   public io.kubernetes.client.openapi.models.V1EphemeralContainerFluent.VolumeMountsNested<A>
       editFirstVolumeMount() {
-    if (volumeMounts.size() == 0)
+    if (volumeMounts.isEmpty())
       throw new RuntimeException("Can't edit first volumeMounts. The list is empty.");
     return setNewVolumeMountLike(0, buildVolumeMount(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1HTTPGetActionFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1HTTPGetActionFluentImpl.java
@@ -266,7 +266,7 @@ public class V1HTTPGetActionFluentImpl<A extends V1HTTPGetActionFluent<A>> exten
 
   public io.kubernetes.client.openapi.models.V1HTTPGetActionFluent.HttpHeadersNested<A>
       editFirstHttpHeader() {
-    if (httpHeaders.size() == 0)
+    if (httpHeaders.isEmpty())
       throw new RuntimeException("Can't edit first httpHeaders. The list is empty.");
     return setNewHttpHeaderLike(0, buildHttpHeader(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1HTTPIngressRuleValueFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1HTTPIngressRuleValueFluentImpl.java
@@ -237,7 +237,7 @@ public class V1HTTPIngressRuleValueFluentImpl<A extends V1HTTPIngressRuleValueFl
 
   public io.kubernetes.client.openapi.models.V1HTTPIngressRuleValueFluent.PathsNested<A>
       editFirstPath() {
-    if (paths.size() == 0) throw new RuntimeException("Can't edit first paths. The list is empty.");
+    if (paths.isEmpty()) throw new RuntimeException("Can't edit first paths. The list is empty.");
     return setNewPathLike(0, buildPath(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1HorizontalPodAutoscalerListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1HorizontalPodAutoscalerListFluentImpl.java
@@ -272,7 +272,7 @@ public class V1HorizontalPodAutoscalerListFluentImpl<
 
   public io.kubernetes.client.openapi.models.V1HorizontalPodAutoscalerListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1IngressClassListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1IngressClassListFluentImpl.java
@@ -259,7 +259,7 @@ public class V1IngressClassListFluentImpl<A extends V1IngressClassListFluent<A>>
 
   public io.kubernetes.client.openapi.models.V1IngressClassListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1IngressListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1IngressListFluentImpl.java
@@ -251,7 +251,7 @@ public class V1IngressListFluentImpl<A extends V1IngressListFluent<A>> extends B
   }
 
   public io.kubernetes.client.openapi.models.V1IngressListFluent.ItemsNested<A> editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1IngressSpecFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1IngressSpecFluentImpl.java
@@ -311,7 +311,7 @@ public class V1IngressSpecFluentImpl<A extends V1IngressSpecFluent<A>> extends B
   }
 
   public io.kubernetes.client.openapi.models.V1IngressSpecFluent.RulesNested<A> editFirstRule() {
-    if (rules.size() == 0) throw new RuntimeException("Can't edit first rules. The list is empty.");
+    if (rules.isEmpty()) throw new RuntimeException("Can't edit first rules. The list is empty.");
     return setNewRuleLike(0, buildRule(0));
   }
 
@@ -536,7 +536,7 @@ public class V1IngressSpecFluentImpl<A extends V1IngressSpecFluent<A>> extends B
   }
 
   public io.kubernetes.client.openapi.models.V1IngressSpecFluent.TlsNested<A> editFirstTl() {
-    if (tls.size() == 0) throw new RuntimeException("Can't edit first tls. The list is empty.");
+    if (tls.isEmpty()) throw new RuntimeException("Can't edit first tls. The list is empty.");
     return setNewTlLike(0, buildTl(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1JSONSchemaPropsFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1JSONSchemaPropsFluentImpl.java
@@ -401,7 +401,7 @@ public class V1JSONSchemaPropsFluentImpl<A extends V1JSONSchemaPropsFluent<A>> e
 
   public io.kubernetes.client.openapi.models.V1JSONSchemaPropsFluent.AllOfNested<A>
       editFirstAllOf() {
-    if (allOf.size() == 0) throw new RuntimeException("Can't edit first allOf. The list is empty.");
+    if (allOf.isEmpty()) throw new RuntimeException("Can't edit first allOf. The list is empty.");
     return setNewAllOfLike(0, buildAllOf(0));
   }
 
@@ -635,7 +635,7 @@ public class V1JSONSchemaPropsFluentImpl<A extends V1JSONSchemaPropsFluent<A>> e
 
   public io.kubernetes.client.openapi.models.V1JSONSchemaPropsFluent.AnyOfNested<A>
       editFirstAnyOf() {
-    if (anyOf.size() == 0) throw new RuntimeException("Can't edit first anyOf. The list is empty.");
+    if (anyOf.isEmpty()) throw new RuntimeException("Can't edit first anyOf. The list is empty.");
     return setNewAnyOfLike(0, buildAnyOf(0));
   }
 
@@ -1457,7 +1457,7 @@ public class V1JSONSchemaPropsFluentImpl<A extends V1JSONSchemaPropsFluent<A>> e
 
   public io.kubernetes.client.openapi.models.V1JSONSchemaPropsFluent.OneOfNested<A>
       editFirstOneOf() {
-    if (oneOf.size() == 0) throw new RuntimeException("Can't edit first oneOf. The list is empty.");
+    if (oneOf.isEmpty()) throw new RuntimeException("Can't edit first oneOf. The list is empty.");
     return setNewOneOfLike(0, buildOneOf(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1JobListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1JobListFluentImpl.java
@@ -248,7 +248,7 @@ public class V1JobListFluentImpl<A extends V1JobListFluent<A>> extends BaseFluen
   }
 
   public io.kubernetes.client.openapi.models.V1JobListFluent.ItemsNested<A> editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1JobStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1JobStatusFluentImpl.java
@@ -307,7 +307,7 @@ public class V1JobStatusFluentImpl<A extends V1JobStatusFluent<A>> extends BaseF
 
   public io.kubernetes.client.openapi.models.V1JobStatusFluent.ConditionsNested<A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1LabelSelectorFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1LabelSelectorFluentImpl.java
@@ -266,7 +266,7 @@ public class V1LabelSelectorFluentImpl<A extends V1LabelSelectorFluent<A>> exten
 
   public io.kubernetes.client.openapi.models.V1LabelSelectorFluent.MatchExpressionsNested<A>
       editFirstMatchExpression() {
-    if (matchExpressions.size() == 0)
+    if (matchExpressions.isEmpty())
       throw new RuntimeException("Can't edit first matchExpressions. The list is empty.");
     return setNewMatchExpressionLike(0, buildMatchExpression(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1LeaseListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1LeaseListFluentImpl.java
@@ -249,7 +249,7 @@ public class V1LeaseListFluentImpl<A extends V1LeaseListFluent<A>> extends BaseF
   }
 
   public io.kubernetes.client.openapi.models.V1LeaseListFluent.ItemsNested<A> editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1LimitRangeListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1LimitRangeListFluentImpl.java
@@ -256,7 +256,7 @@ public class V1LimitRangeListFluentImpl<A extends V1LimitRangeListFluent<A>> ext
   }
 
   public io.kubernetes.client.openapi.models.V1LimitRangeListFluent.ItemsNested<A> editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1LimitRangeSpecFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1LimitRangeSpecFluentImpl.java
@@ -237,8 +237,7 @@ public class V1LimitRangeSpecFluentImpl<A extends V1LimitRangeSpecFluent<A>> ext
 
   public io.kubernetes.client.openapi.models.V1LimitRangeSpecFluent.LimitsNested<A>
       editFirstLimit() {
-    if (limits.size() == 0)
-      throw new RuntimeException("Can't edit first limits. The list is empty.");
+    if (limits.isEmpty()) throw new RuntimeException("Can't edit first limits. The list is empty.");
     return setNewLimitLike(0, buildLimit(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1LoadBalancerIngressFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1LoadBalancerIngressFluentImpl.java
@@ -269,7 +269,7 @@ public class V1LoadBalancerIngressFluentImpl<A extends V1LoadBalancerIngressFlue
 
   public io.kubernetes.client.openapi.models.V1LoadBalancerIngressFluent.PortsNested<A>
       editFirstPort() {
-    if (ports.size() == 0) throw new RuntimeException("Can't edit first ports. The list is empty.");
+    if (ports.isEmpty()) throw new RuntimeException("Can't edit first ports. The list is empty.");
     return setNewPortLike(0, buildPort(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1LoadBalancerStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1LoadBalancerStatusFluentImpl.java
@@ -245,7 +245,7 @@ public class V1LoadBalancerStatusFluentImpl<A extends V1LoadBalancerStatusFluent
 
   public io.kubernetes.client.openapi.models.V1LoadBalancerStatusFluent.IngressNested<A>
       editFirstIngress() {
-    if (ingress.size() == 0)
+    if (ingress.isEmpty())
       throw new RuntimeException("Can't edit first ingress. The list is empty.");
     return setNewIngressLike(0, buildIngress(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1MutatingWebhookConfigurationFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1MutatingWebhookConfigurationFluentImpl.java
@@ -335,7 +335,7 @@ public class V1MutatingWebhookConfigurationFluentImpl<
 
   public io.kubernetes.client.openapi.models.V1MutatingWebhookConfigurationFluent.WebhooksNested<A>
       editFirstWebhook() {
-    if (webhooks.size() == 0)
+    if (webhooks.isEmpty())
       throw new RuntimeException("Can't edit first webhooks. The list is empty.");
     return setNewWebhookLike(0, buildWebhook(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1MutatingWebhookConfigurationListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1MutatingWebhookConfigurationListFluentImpl.java
@@ -277,7 +277,7 @@ public class V1MutatingWebhookConfigurationListFluentImpl<
 
   public io.kubernetes.client.openapi.models.V1MutatingWebhookConfigurationListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1MutatingWebhookFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1MutatingWebhookFluentImpl.java
@@ -620,7 +620,7 @@ public class V1MutatingWebhookFluentImpl<A extends V1MutatingWebhookFluent<A>> e
 
   public io.kubernetes.client.openapi.models.V1MutatingWebhookFluent.RulesNested<A>
       editFirstRule() {
-    if (rules.size() == 0) throw new RuntimeException("Can't edit first rules. The list is empty.");
+    if (rules.isEmpty()) throw new RuntimeException("Can't edit first rules. The list is empty.");
     return setNewRuleLike(0, buildRule(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NamespaceListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NamespaceListFluentImpl.java
@@ -256,7 +256,7 @@ public class V1NamespaceListFluentImpl<A extends V1NamespaceListFluent<A>> exten
   }
 
   public io.kubernetes.client.openapi.models.V1NamespaceListFluent.ItemsNested<A> editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NamespaceStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NamespaceStatusFluentImpl.java
@@ -252,7 +252,7 @@ public class V1NamespaceStatusFluentImpl<A extends V1NamespaceStatusFluent<A>> e
 
   public io.kubernetes.client.openapi.models.V1NamespaceStatusFluent.ConditionsNested<A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NetworkPolicyEgressRuleFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NetworkPolicyEgressRuleFluentImpl.java
@@ -243,7 +243,7 @@ public class V1NetworkPolicyEgressRuleFluentImpl<A extends V1NetworkPolicyEgress
 
   public io.kubernetes.client.openapi.models.V1NetworkPolicyEgressRuleFluent.PortsNested<A>
       editFirstPort() {
-    if (ports.size() == 0) throw new RuntimeException("Can't edit first ports. The list is empty.");
+    if (ports.isEmpty()) throw new RuntimeException("Can't edit first ports. The list is empty.");
     return setNewPortLike(0, buildPort(0));
   }
 
@@ -478,7 +478,7 @@ public class V1NetworkPolicyEgressRuleFluentImpl<A extends V1NetworkPolicyEgress
 
   public io.kubernetes.client.openapi.models.V1NetworkPolicyEgressRuleFluent.ToNested<A>
       editFirstTo() {
-    if (to.size() == 0) throw new RuntimeException("Can't edit first to. The list is empty.");
+    if (to.isEmpty()) throw new RuntimeException("Can't edit first to. The list is empty.");
     return setNewToLike(0, buildTo(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NetworkPolicyIngressRuleFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NetworkPolicyIngressRuleFluentImpl.java
@@ -242,7 +242,7 @@ public class V1NetworkPolicyIngressRuleFluentImpl<A extends V1NetworkPolicyIngre
 
   public io.kubernetes.client.openapi.models.V1NetworkPolicyIngressRuleFluent.FromNested<A>
       editFirstFrom() {
-    if (from.size() == 0) throw new RuntimeException("Can't edit first from. The list is empty.");
+    if (from.isEmpty()) throw new RuntimeException("Can't edit first from. The list is empty.");
     return setNewFromLike(0, buildFrom(0));
   }
 
@@ -479,7 +479,7 @@ public class V1NetworkPolicyIngressRuleFluentImpl<A extends V1NetworkPolicyIngre
 
   public io.kubernetes.client.openapi.models.V1NetworkPolicyIngressRuleFluent.PortsNested<A>
       editFirstPort() {
-    if (ports.size() == 0) throw new RuntimeException("Can't edit first ports. The list is empty.");
+    if (ports.isEmpty()) throw new RuntimeException("Can't edit first ports. The list is empty.");
     return setNewPortLike(0, buildPort(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NetworkPolicyListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NetworkPolicyListFluentImpl.java
@@ -259,7 +259,7 @@ public class V1NetworkPolicyListFluentImpl<A extends V1NetworkPolicyListFluent<A
 
   public io.kubernetes.client.openapi.models.V1NetworkPolicyListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NetworkPolicySpecFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NetworkPolicySpecFluentImpl.java
@@ -259,8 +259,7 @@ public class V1NetworkPolicySpecFluentImpl<A extends V1NetworkPolicySpecFluent<A
 
   public io.kubernetes.client.openapi.models.V1NetworkPolicySpecFluent.EgressNested<A>
       editFirstEgress() {
-    if (egress.size() == 0)
-      throw new RuntimeException("Can't edit first egress. The list is empty.");
+    if (egress.isEmpty()) throw new RuntimeException("Can't edit first egress. The list is empty.");
     return setNewEgressLike(0, buildEgress(0));
   }
 
@@ -510,7 +509,7 @@ public class V1NetworkPolicySpecFluentImpl<A extends V1NetworkPolicySpecFluent<A
 
   public io.kubernetes.client.openapi.models.V1NetworkPolicySpecFluent.IngressNested<A>
       editFirstIngress() {
-    if (ingress.size() == 0)
+    if (ingress.isEmpty())
       throw new RuntimeException("Can't edit first ingress. The list is empty.");
     return setNewIngressLike(0, buildIngress(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NodeAffinityFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NodeAffinityFluentImpl.java
@@ -299,7 +299,7 @@ public class V1NodeAffinityFluentImpl<A extends V1NodeAffinityFluent<A>> extends
               .PreferredDuringSchedulingIgnoredDuringExecutionNested<
           A>
       editFirstPreferredDuringSchedulingIgnoredDuringExecution() {
-    if (preferredDuringSchedulingIgnoredDuringExecution.size() == 0)
+    if (preferredDuringSchedulingIgnoredDuringExecution.isEmpty())
       throw new RuntimeException(
           "Can't edit first preferredDuringSchedulingIgnoredDuringExecution. The list is empty.");
     return setNewPreferredDuringSchedulingIgnoredDuringExecutionLike(

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NodeListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NodeListFluentImpl.java
@@ -249,7 +249,7 @@ public class V1NodeListFluentImpl<A extends V1NodeListFluent<A>> extends BaseFlu
   }
 
   public io.kubernetes.client.openapi.models.V1NodeListFluent.ItemsNested<A> editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NodeSelectorFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NodeSelectorFluentImpl.java
@@ -246,7 +246,7 @@ public class V1NodeSelectorFluentImpl<A extends V1NodeSelectorFluent<A>> extends
 
   public io.kubernetes.client.openapi.models.V1NodeSelectorFluent.NodeSelectorTermsNested<A>
       editFirstNodeSelectorTerm() {
-    if (nodeSelectorTerms.size() == 0)
+    if (nodeSelectorTerms.isEmpty())
       throw new RuntimeException("Can't edit first nodeSelectorTerms. The list is empty.");
     return setNewNodeSelectorTermLike(0, buildNodeSelectorTerm(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NodeSelectorTermFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NodeSelectorTermFluentImpl.java
@@ -263,7 +263,7 @@ public class V1NodeSelectorTermFluentImpl<A extends V1NodeSelectorTermFluent<A>>
 
   public io.kubernetes.client.openapi.models.V1NodeSelectorTermFluent.MatchExpressionsNested<A>
       editFirstMatchExpression() {
-    if (matchExpressions.size() == 0)
+    if (matchExpressions.isEmpty())
       throw new RuntimeException("Can't edit first matchExpressions. The list is empty.");
     return setNewMatchExpressionLike(0, buildMatchExpression(0));
   }
@@ -520,7 +520,7 @@ public class V1NodeSelectorTermFluentImpl<A extends V1NodeSelectorTermFluent<A>>
 
   public io.kubernetes.client.openapi.models.V1NodeSelectorTermFluent.MatchFieldsNested<A>
       editFirstMatchField() {
-    if (matchFields.size() == 0)
+    if (matchFields.isEmpty())
       throw new RuntimeException("Can't edit first matchFields. The list is empty.");
     return setNewMatchFieldLike(0, buildMatchField(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NodeSpecFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NodeSpecFluentImpl.java
@@ -456,8 +456,7 @@ public class V1NodeSpecFluentImpl<A extends V1NodeSpecFluent<A>> extends BaseFlu
   }
 
   public io.kubernetes.client.openapi.models.V1NodeSpecFluent.TaintsNested<A> editFirstTaint() {
-    if (taints.size() == 0)
-      throw new RuntimeException("Can't edit first taints. The list is empty.");
+    if (taints.isEmpty()) throw new RuntimeException("Can't edit first taints. The list is empty.");
     return setNewTaintLike(0, buildTaint(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NodeStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1NodeStatusFluentImpl.java
@@ -274,7 +274,7 @@ public class V1NodeStatusFluentImpl<A extends V1NodeStatusFluent<A>> extends Bas
 
   public io.kubernetes.client.openapi.models.V1NodeStatusFluent.AddressesNested<A>
       editFirstAddress() {
-    if (addresses.size() == 0)
+    if (addresses.isEmpty())
       throw new RuntimeException("Can't edit first addresses. The list is empty.");
     return setNewAddressLike(0, buildAddress(0));
   }
@@ -642,7 +642,7 @@ public class V1NodeStatusFluentImpl<A extends V1NodeStatusFluent<A>> extends Bas
 
   public io.kubernetes.client.openapi.models.V1NodeStatusFluent.ConditionsNested<A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }
@@ -984,8 +984,7 @@ public class V1NodeStatusFluentImpl<A extends V1NodeStatusFluent<A>> extends Bas
   }
 
   public io.kubernetes.client.openapi.models.V1NodeStatusFluent.ImagesNested<A> editFirstImage() {
-    if (images.size() == 0)
-      throw new RuntimeException("Can't edit first images. The list is empty.");
+    if (images.isEmpty()) throw new RuntimeException("Can't edit first images. The list is empty.");
     return setNewImageLike(0, buildImage(0));
   }
 
@@ -1291,7 +1290,7 @@ public class V1NodeStatusFluentImpl<A extends V1NodeStatusFluent<A>> extends Bas
 
   public io.kubernetes.client.openapi.models.V1NodeStatusFluent.VolumesAttachedNested<A>
       editFirstVolumesAttached() {
-    if (volumesAttached.size() == 0)
+    if (volumesAttached.isEmpty())
       throw new RuntimeException("Can't edit first volumesAttached. The list is empty.");
     return setNewVolumesAttachedLike(0, buildVolumesAttached(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ObjectMetaFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ObjectMetaFluentImpl.java
@@ -617,7 +617,7 @@ public class V1ObjectMetaFluentImpl<A extends V1ObjectMetaFluent<A>> extends Bas
 
   public io.kubernetes.client.openapi.models.V1ObjectMetaFluent.ManagedFieldsNested<A>
       editFirstManagedField() {
-    if (managedFields.size() == 0)
+    if (managedFields.isEmpty())
       throw new RuntimeException("Can't edit first managedFields. The list is empty.");
     return setNewManagedFieldLike(0, buildManagedField(0));
   }
@@ -887,7 +887,7 @@ public class V1ObjectMetaFluentImpl<A extends V1ObjectMetaFluent<A>> extends Bas
 
   public io.kubernetes.client.openapi.models.V1ObjectMetaFluent.OwnerReferencesNested<A>
       editFirstOwnerReference() {
-    if (ownerReferences.size() == 0)
+    if (ownerReferences.isEmpty())
       throw new RuntimeException("Can't edit first ownerReferences. The list is empty.");
     return setNewOwnerReferenceLike(0, buildOwnerReference(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PersistentVolumeClaimListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PersistentVolumeClaimListFluentImpl.java
@@ -271,7 +271,7 @@ public class V1PersistentVolumeClaimListFluentImpl<A extends V1PersistentVolumeC
 
   public io.kubernetes.client.openapi.models.V1PersistentVolumeClaimListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PersistentVolumeClaimStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PersistentVolumeClaimStatusFluentImpl.java
@@ -533,7 +533,7 @@ public class V1PersistentVolumeClaimStatusFluentImpl<
 
   public io.kubernetes.client.openapi.models.V1PersistentVolumeClaimStatusFluent.ConditionsNested<A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PersistentVolumeListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PersistentVolumeListFluentImpl.java
@@ -259,7 +259,7 @@ public class V1PersistentVolumeListFluentImpl<A extends V1PersistentVolumeListFl
 
   public io.kubernetes.client.openapi.models.V1PersistentVolumeListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PodAffinityFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PodAffinityFluentImpl.java
@@ -301,7 +301,7 @@ public class V1PodAffinityFluentImpl<A extends V1PodAffinityFluent<A>> extends B
               .PreferredDuringSchedulingIgnoredDuringExecutionNested<
           A>
       editFirstPreferredDuringSchedulingIgnoredDuringExecution() {
-    if (preferredDuringSchedulingIgnoredDuringExecution.size() == 0)
+    if (preferredDuringSchedulingIgnoredDuringExecution.isEmpty())
       throw new RuntimeException(
           "Can't edit first preferredDuringSchedulingIgnoredDuringExecution. The list is empty.");
     return setNewPreferredDuringSchedulingIgnoredDuringExecutionLike(
@@ -597,7 +597,7 @@ public class V1PodAffinityFluentImpl<A extends V1PodAffinityFluent<A>> extends B
               .RequiredDuringSchedulingIgnoredDuringExecutionNested<
           A>
       editFirstRequiredDuringSchedulingIgnoredDuringExecution() {
-    if (requiredDuringSchedulingIgnoredDuringExecution.size() == 0)
+    if (requiredDuringSchedulingIgnoredDuringExecution.isEmpty())
       throw new RuntimeException(
           "Can't edit first requiredDuringSchedulingIgnoredDuringExecution. The list is empty.");
     return setNewRequiredDuringSchedulingIgnoredDuringExecutionLike(

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PodAntiAffinityFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PodAntiAffinityFluentImpl.java
@@ -303,7 +303,7 @@ public class V1PodAntiAffinityFluentImpl<A extends V1PodAntiAffinityFluent<A>> e
               .PreferredDuringSchedulingIgnoredDuringExecutionNested<
           A>
       editFirstPreferredDuringSchedulingIgnoredDuringExecution() {
-    if (preferredDuringSchedulingIgnoredDuringExecution.size() == 0)
+    if (preferredDuringSchedulingIgnoredDuringExecution.isEmpty())
       throw new RuntimeException(
           "Can't edit first preferredDuringSchedulingIgnoredDuringExecution. The list is empty.");
     return setNewPreferredDuringSchedulingIgnoredDuringExecutionLike(
@@ -600,7 +600,7 @@ public class V1PodAntiAffinityFluentImpl<A extends V1PodAntiAffinityFluent<A>> e
               .RequiredDuringSchedulingIgnoredDuringExecutionNested<
           A>
       editFirstRequiredDuringSchedulingIgnoredDuringExecution() {
-    if (requiredDuringSchedulingIgnoredDuringExecution.size() == 0)
+    if (requiredDuringSchedulingIgnoredDuringExecution.isEmpty())
       throw new RuntimeException(
           "Can't edit first requiredDuringSchedulingIgnoredDuringExecution. The list is empty.");
     return setNewRequiredDuringSchedulingIgnoredDuringExecutionLike(

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PodDNSConfigFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PodDNSConfigFluentImpl.java
@@ -366,7 +366,7 @@ public class V1PodDNSConfigFluentImpl<A extends V1PodDNSConfigFluent<A>> extends
 
   public io.kubernetes.client.openapi.models.V1PodDNSConfigFluent.OptionsNested<A>
       editFirstOption() {
-    if (options.size() == 0)
+    if (options.isEmpty())
       throw new RuntimeException("Can't edit first options. The list is empty.");
     return setNewOptionLike(0, buildOption(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PodDisruptionBudgetListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PodDisruptionBudgetListFluentImpl.java
@@ -268,7 +268,7 @@ public class V1PodDisruptionBudgetListFluentImpl<A extends V1PodDisruptionBudget
 
   public io.kubernetes.client.openapi.models.V1PodDisruptionBudgetListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PodDisruptionBudgetStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PodDisruptionBudgetStatusFluentImpl.java
@@ -263,7 +263,7 @@ public class V1PodDisruptionBudgetStatusFluentImpl<A extends V1PodDisruptionBudg
 
   public io.kubernetes.client.openapi.models.V1PodDisruptionBudgetStatusFluent.ConditionsNested<A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PodListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PodListFluentImpl.java
@@ -248,7 +248,7 @@ public class V1PodListFluentImpl<A extends V1PodListFluent<A>> extends BaseFluen
   }
 
   public io.kubernetes.client.openapi.models.V1PodListFluent.ItemsNested<A> editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PodSecurityContextFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PodSecurityContextFluentImpl.java
@@ -552,7 +552,7 @@ public class V1PodSecurityContextFluentImpl<A extends V1PodSecurityContextFluent
 
   public io.kubernetes.client.openapi.models.V1PodSecurityContextFluent.SysctlsNested<A>
       editFirstSysctl() {
-    if (sysctls.size() == 0)
+    if (sysctls.isEmpty())
       throw new RuntimeException("Can't edit first sysctls. The list is empty.");
     return setNewSysctlLike(0, buildSysctl(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PodSpecFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PodSpecFluentImpl.java
@@ -429,7 +429,7 @@ public class V1PodSpecFluentImpl<A extends V1PodSpecFluent<A>> extends BaseFluen
 
   public io.kubernetes.client.openapi.models.V1PodSpecFluent.ContainersNested<A>
       editFirstContainer() {
-    if (containers.size() == 0)
+    if (containers.isEmpty())
       throw new RuntimeException("Can't edit first containers. The list is empty.");
     return setNewContainerLike(0, buildContainer(0));
   }
@@ -760,7 +760,7 @@ public class V1PodSpecFluentImpl<A extends V1PodSpecFluent<A>> extends BaseFluen
 
   public io.kubernetes.client.openapi.models.V1PodSpecFluent.EphemeralContainersNested<A>
       editFirstEphemeralContainer() {
-    if (ephemeralContainers.size() == 0)
+    if (ephemeralContainers.isEmpty())
       throw new RuntimeException("Can't edit first ephemeralContainers. The list is empty.");
     return setNewEphemeralContainerLike(0, buildEphemeralContainer(0));
   }
@@ -1002,7 +1002,7 @@ public class V1PodSpecFluentImpl<A extends V1PodSpecFluent<A>> extends BaseFluen
 
   public io.kubernetes.client.openapi.models.V1PodSpecFluent.HostAliasesNested<A>
       editFirstHostAlias() {
-    if (hostAliases.size() == 0)
+    if (hostAliases.isEmpty())
       throw new RuntimeException("Can't edit first hostAliases. The list is empty.");
     return setNewHostAliasLike(0, buildHostAlias(0));
   }
@@ -1309,7 +1309,7 @@ public class V1PodSpecFluentImpl<A extends V1PodSpecFluent<A>> extends BaseFluen
 
   public io.kubernetes.client.openapi.models.V1PodSpecFluent.ImagePullSecretsNested<A>
       editFirstImagePullSecret() {
-    if (imagePullSecrets.size() == 0)
+    if (imagePullSecrets.isEmpty())
       throw new RuntimeException("Can't edit first imagePullSecrets. The list is empty.");
     return setNewImagePullSecretLike(0, buildImagePullSecret(0));
   }
@@ -1553,7 +1553,7 @@ public class V1PodSpecFluentImpl<A extends V1PodSpecFluent<A>> extends BaseFluen
 
   public io.kubernetes.client.openapi.models.V1PodSpecFluent.InitContainersNested<A>
       editFirstInitContainer() {
-    if (initContainers.size() == 0)
+    if (initContainers.isEmpty())
       throw new RuntimeException("Can't edit first initContainers. The list is empty.");
     return setNewInitContainerLike(0, buildInitContainer(0));
   }
@@ -2027,7 +2027,7 @@ public class V1PodSpecFluentImpl<A extends V1PodSpecFluent<A>> extends BaseFluen
 
   public io.kubernetes.client.openapi.models.V1PodSpecFluent.ReadinessGatesNested<A>
       editFirstReadinessGate() {
-    if (readinessGates.size() == 0)
+    if (readinessGates.isEmpty())
       throw new RuntimeException("Can't edit first readinessGates. The list is empty.");
     return setNewReadinessGateLike(0, buildReadinessGate(0));
   }
@@ -2441,7 +2441,7 @@ public class V1PodSpecFluentImpl<A extends V1PodSpecFluent<A>> extends BaseFluen
 
   public io.kubernetes.client.openapi.models.V1PodSpecFluent.TolerationsNested<A>
       editFirstToleration() {
-    if (tolerations.size() == 0)
+    if (tolerations.isEmpty())
       throw new RuntimeException("Can't edit first tolerations. The list is empty.");
     return setNewTolerationLike(0, buildToleration(0));
   }
@@ -2706,7 +2706,7 @@ public class V1PodSpecFluentImpl<A extends V1PodSpecFluent<A>> extends BaseFluen
 
   public io.kubernetes.client.openapi.models.V1PodSpecFluent.TopologySpreadConstraintsNested<A>
       editFirstTopologySpreadConstraint() {
-    if (topologySpreadConstraints.size() == 0)
+    if (topologySpreadConstraints.isEmpty())
       throw new RuntimeException("Can't edit first topologySpreadConstraints. The list is empty.");
     return setNewTopologySpreadConstraintLike(0, buildTopologySpreadConstraint(0));
   }
@@ -2935,7 +2935,7 @@ public class V1PodSpecFluentImpl<A extends V1PodSpecFluent<A>> extends BaseFluen
   }
 
   public io.kubernetes.client.openapi.models.V1PodSpecFluent.VolumesNested<A> editFirstVolume() {
-    if (volumes.size() == 0)
+    if (volumes.isEmpty())
       throw new RuntimeException("Can't edit first volumes. The list is empty.");
     return setNewVolumeLike(0, buildVolume(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PodStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PodStatusFluentImpl.java
@@ -281,7 +281,7 @@ public class V1PodStatusFluentImpl<A extends V1PodStatusFluent<A>> extends BaseF
 
   public io.kubernetes.client.openapi.models.V1PodStatusFluent.ConditionsNested<A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }
@@ -526,7 +526,7 @@ public class V1PodStatusFluentImpl<A extends V1PodStatusFluent<A>> extends BaseF
 
   public io.kubernetes.client.openapi.models.V1PodStatusFluent.ContainerStatusesNested<A>
       editFirstContainerStatus() {
-    if (containerStatuses.size() == 0)
+    if (containerStatuses.isEmpty())
       throw new RuntimeException("Can't edit first containerStatuses. The list is empty.");
     return setNewContainerStatusLike(0, buildContainerStatus(0));
   }
@@ -783,7 +783,7 @@ public class V1PodStatusFluentImpl<A extends V1PodStatusFluent<A>> extends BaseF
 
   public io.kubernetes.client.openapi.models.V1PodStatusFluent.EphemeralContainerStatusesNested<A>
       editFirstEphemeralContainerStatus() {
-    if (ephemeralContainerStatuses.size() == 0)
+    if (ephemeralContainerStatuses.isEmpty())
       throw new RuntimeException("Can't edit first ephemeralContainerStatuses. The list is empty.");
     return setNewEphemeralContainerStatusLike(0, buildEphemeralContainerStatus(0));
   }
@@ -1046,7 +1046,7 @@ public class V1PodStatusFluentImpl<A extends V1PodStatusFluent<A>> extends BaseF
 
   public io.kubernetes.client.openapi.models.V1PodStatusFluent.InitContainerStatusesNested<A>
       editFirstInitContainerStatus() {
-    if (initContainerStatuses.size() == 0)
+    if (initContainerStatuses.isEmpty())
       throw new RuntimeException("Can't edit first initContainerStatuses. The list is empty.");
     return setNewInitContainerStatusLike(0, buildInitContainerStatus(0));
   }
@@ -1323,8 +1323,7 @@ public class V1PodStatusFluentImpl<A extends V1PodStatusFluent<A>> extends BaseF
   }
 
   public io.kubernetes.client.openapi.models.V1PodStatusFluent.PodIPsNested<A> editFirstPodIP() {
-    if (podIPs.size() == 0)
-      throw new RuntimeException("Can't edit first podIPs. The list is empty.");
+    if (podIPs.isEmpty()) throw new RuntimeException("Can't edit first podIPs. The list is empty.");
     return setNewPodIPLike(0, buildPodIP(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PodTemplateListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PodTemplateListFluentImpl.java
@@ -258,7 +258,7 @@ public class V1PodTemplateListFluentImpl<A extends V1PodTemplateListFluent<A>> e
 
   public io.kubernetes.client.openapi.models.V1PodTemplateListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PriorityClassListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1PriorityClassListFluentImpl.java
@@ -259,7 +259,7 @@ public class V1PriorityClassListFluentImpl<A extends V1PriorityClassListFluent<A
 
   public io.kubernetes.client.openapi.models.V1PriorityClassListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ProjectedVolumeSourceFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ProjectedVolumeSourceFluentImpl.java
@@ -258,7 +258,7 @@ public class V1ProjectedVolumeSourceFluentImpl<A extends V1ProjectedVolumeSource
 
   public io.kubernetes.client.openapi.models.V1ProjectedVolumeSourceFluent.SourcesNested<A>
       editFirstSource() {
-    if (sources.size() == 0)
+    if (sources.isEmpty())
       throw new RuntimeException("Can't edit first sources. The list is empty.");
     return setNewSourceLike(0, buildSource(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ReplicaSetListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ReplicaSetListFluentImpl.java
@@ -256,7 +256,7 @@ public class V1ReplicaSetListFluentImpl<A extends V1ReplicaSetListFluent<A>> ext
   }
 
   public io.kubernetes.client.openapi.models.V1ReplicaSetListFluent.ItemsNested<A> editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ReplicaSetStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ReplicaSetStatusFluentImpl.java
@@ -277,7 +277,7 @@ public class V1ReplicaSetStatusFluentImpl<A extends V1ReplicaSetStatusFluent<A>>
 
   public io.kubernetes.client.openapi.models.V1ReplicaSetStatusFluent.ConditionsNested<A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ReplicationControllerListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ReplicationControllerListFluentImpl.java
@@ -271,7 +271,7 @@ public class V1ReplicationControllerListFluentImpl<A extends V1ReplicationContro
 
   public io.kubernetes.client.openapi.models.V1ReplicationControllerListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ReplicationControllerStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ReplicationControllerStatusFluentImpl.java
@@ -295,7 +295,7 @@ public class V1ReplicationControllerStatusFluentImpl<
 
   public io.kubernetes.client.openapi.models.V1ReplicationControllerStatusFluent.ConditionsNested<A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ResourceQuotaListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ResourceQuotaListFluentImpl.java
@@ -260,7 +260,7 @@ public class V1ResourceQuotaListFluentImpl<A extends V1ResourceQuotaListFluent<A
 
   public io.kubernetes.client.openapi.models.V1ResourceQuotaListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1RoleBindingFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1RoleBindingFluentImpl.java
@@ -383,7 +383,7 @@ public class V1RoleBindingFluentImpl<A extends V1RoleBindingFluent<A>> extends B
 
   public io.kubernetes.client.openapi.models.V1RoleBindingFluent.SubjectsNested<A>
       editFirstSubject() {
-    if (subjects.size() == 0)
+    if (subjects.isEmpty())
       throw new RuntimeException("Can't edit first subjects. The list is empty.");
     return setNewSubjectLike(0, buildSubject(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1RoleBindingListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1RoleBindingListFluentImpl.java
@@ -259,7 +259,7 @@ public class V1RoleBindingListFluentImpl<A extends V1RoleBindingListFluent<A>> e
 
   public io.kubernetes.client.openapi.models.V1RoleBindingListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1RoleFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1RoleFluentImpl.java
@@ -319,7 +319,7 @@ public class V1RoleFluentImpl<A extends V1RoleFluent<A>> extends BaseFluent<A>
   }
 
   public io.kubernetes.client.openapi.models.V1RoleFluent.RulesNested<A> editFirstRule() {
-    if (rules.size() == 0) throw new RuntimeException("Can't edit first rules. The list is empty.");
+    if (rules.isEmpty()) throw new RuntimeException("Can't edit first rules. The list is empty.");
     return setNewRuleLike(0, buildRule(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1RoleListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1RoleListFluentImpl.java
@@ -249,7 +249,7 @@ public class V1RoleListFluentImpl<A extends V1RoleListFluent<A>> extends BaseFlu
   }
 
   public io.kubernetes.client.openapi.models.V1RoleListFluent.ItemsNested<A> editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1RuntimeClassListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1RuntimeClassListFluentImpl.java
@@ -258,7 +258,7 @@ public class V1RuntimeClassListFluentImpl<A extends V1RuntimeClassListFluent<A>>
 
   public io.kubernetes.client.openapi.models.V1RuntimeClassListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1SchedulingFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1SchedulingFluentImpl.java
@@ -307,7 +307,7 @@ public class V1SchedulingFluentImpl<A extends V1SchedulingFluent<A>> extends Bas
 
   public io.kubernetes.client.openapi.models.V1SchedulingFluent.TolerationsNested<A>
       editFirstToleration() {
-    if (tolerations.size() == 0)
+    if (tolerations.isEmpty())
       throw new RuntimeException("Can't edit first tolerations. The list is empty.");
     return setNewTolerationLike(0, buildToleration(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ScopeSelectorFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ScopeSelectorFluentImpl.java
@@ -268,7 +268,7 @@ public class V1ScopeSelectorFluentImpl<A extends V1ScopeSelectorFluent<A>> exten
 
   public io.kubernetes.client.openapi.models.V1ScopeSelectorFluent.MatchExpressionsNested<A>
       editFirstMatchExpression() {
-    if (matchExpressions.size() == 0)
+    if (matchExpressions.isEmpty())
       throw new RuntimeException("Can't edit first matchExpressions. The list is empty.");
     return setNewMatchExpressionLike(0, buildMatchExpression(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1SecretListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1SecretListFluentImpl.java
@@ -249,7 +249,7 @@ public class V1SecretListFluentImpl<A extends V1SecretListFluent<A>> extends Bas
   }
 
   public io.kubernetes.client.openapi.models.V1SecretListFluent.ItemsNested<A> editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1SecretProjectionFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1SecretProjectionFluentImpl.java
@@ -242,7 +242,7 @@ public class V1SecretProjectionFluentImpl<A extends V1SecretProjectionFluent<A>>
 
   public io.kubernetes.client.openapi.models.V1SecretProjectionFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1SecretVolumeSourceFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1SecretVolumeSourceFluentImpl.java
@@ -259,7 +259,7 @@ public class V1SecretVolumeSourceFluentImpl<A extends V1SecretVolumeSourceFluent
 
   public io.kubernetes.client.openapi.models.V1SecretVolumeSourceFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ServiceAccountFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ServiceAccountFluentImpl.java
@@ -297,7 +297,7 @@ public class V1ServiceAccountFluentImpl<A extends V1ServiceAccountFluent<A>> ext
 
   public io.kubernetes.client.openapi.models.V1ServiceAccountFluent.ImagePullSecretsNested<A>
       editFirstImagePullSecret() {
-    if (imagePullSecrets.size() == 0)
+    if (imagePullSecrets.isEmpty())
       throw new RuntimeException("Can't edit first imagePullSecrets. The list is empty.");
     return setNewImagePullSecretLike(0, buildImagePullSecret(0));
   }
@@ -606,7 +606,7 @@ public class V1ServiceAccountFluentImpl<A extends V1ServiceAccountFluent<A>> ext
 
   public io.kubernetes.client.openapi.models.V1ServiceAccountFluent.SecretsNested<A>
       editFirstSecret() {
-    if (secrets.size() == 0)
+    if (secrets.isEmpty())
       throw new RuntimeException("Can't edit first secrets. The list is empty.");
     return setNewSecretLike(0, buildSecret(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ServiceAccountListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ServiceAccountListFluentImpl.java
@@ -260,7 +260,7 @@ public class V1ServiceAccountListFluentImpl<A extends V1ServiceAccountListFluent
 
   public io.kubernetes.client.openapi.models.V1ServiceAccountListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ServiceListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ServiceListFluentImpl.java
@@ -251,7 +251,7 @@ public class V1ServiceListFluentImpl<A extends V1ServiceListFluent<A>> extends B
   }
 
   public io.kubernetes.client.openapi.models.V1ServiceListFluent.ItemsNested<A> editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ServiceSpecFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ServiceSpecFluentImpl.java
@@ -881,7 +881,7 @@ public class V1ServiceSpecFluentImpl<A extends V1ServiceSpecFluent<A>> extends B
   }
 
   public io.kubernetes.client.openapi.models.V1ServiceSpecFluent.PortsNested<A> editFirstPort() {
-    if (ports.size() == 0) throw new RuntimeException("Can't edit first ports. The list is empty.");
+    if (ports.isEmpty()) throw new RuntimeException("Can't edit first ports. The list is empty.");
     return setNewPortLike(0, buildPort(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ServiceStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ServiceStatusFluentImpl.java
@@ -244,7 +244,7 @@ public class V1ServiceStatusFluentImpl<A extends V1ServiceStatusFluent<A>> exten
 
   public io.kubernetes.client.openapi.models.V1ServiceStatusFluent.ConditionsNested<A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1StatefulSetListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1StatefulSetListFluentImpl.java
@@ -258,7 +258,7 @@ public class V1StatefulSetListFluentImpl<A extends V1StatefulSetListFluent<A>> e
 
   public io.kubernetes.client.openapi.models.V1StatefulSetListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1StatefulSetSpecFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1StatefulSetSpecFluentImpl.java
@@ -616,7 +616,7 @@ public class V1StatefulSetSpecFluentImpl<A extends V1StatefulSetSpecFluent<A>> e
 
   public io.kubernetes.client.openapi.models.V1StatefulSetSpecFluent.VolumeClaimTemplatesNested<A>
       editFirstVolumeClaimTemplate() {
-    if (volumeClaimTemplates.size() == 0)
+    if (volumeClaimTemplates.isEmpty())
       throw new RuntimeException("Can't edit first volumeClaimTemplates. The list is empty.");
     return setNewVolumeClaimTemplateLike(0, buildVolumeClaimTemplate(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1StatefulSetStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1StatefulSetStatusFluentImpl.java
@@ -307,7 +307,7 @@ public class V1StatefulSetStatusFluentImpl<A extends V1StatefulSetStatusFluent<A
 
   public io.kubernetes.client.openapi.models.V1StatefulSetStatusFluent.ConditionsNested<A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1StatusDetailsFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1StatusDetailsFluentImpl.java
@@ -252,8 +252,7 @@ public class V1StatusDetailsFluentImpl<A extends V1StatusDetailsFluent<A>> exten
 
   public io.kubernetes.client.openapi.models.V1StatusDetailsFluent.CausesNested<A>
       editFirstCause() {
-    if (causes.size() == 0)
-      throw new RuntimeException("Can't edit first causes. The list is empty.");
+    if (causes.isEmpty()) throw new RuntimeException("Can't edit first causes. The list is empty.");
     return setNewCauseLike(0, buildCause(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1StorageClassFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1StorageClassFluentImpl.java
@@ -300,7 +300,7 @@ public class V1StorageClassFluentImpl<A extends V1StorageClassFluent<A>> extends
 
   public io.kubernetes.client.openapi.models.V1StorageClassFluent.AllowedTopologiesNested<A>
       editFirstAllowedTopology() {
-    if (allowedTopologies.size() == 0)
+    if (allowedTopologies.isEmpty())
       throw new RuntimeException("Can't edit first allowedTopologies. The list is empty.");
     return setNewAllowedTopologyLike(0, buildAllowedTopology(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1StorageClassListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1StorageClassListFluentImpl.java
@@ -259,7 +259,7 @@ public class V1StorageClassListFluentImpl<A extends V1StorageClassListFluent<A>>
 
   public io.kubernetes.client.openapi.models.V1StorageClassListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1SubjectRulesReviewStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1SubjectRulesReviewStatusFluentImpl.java
@@ -290,7 +290,7 @@ public class V1SubjectRulesReviewStatusFluentImpl<A extends V1SubjectRulesReview
               .NonResourceRulesNested<
           A>
       editFirstNonResourceRule() {
-    if (nonResourceRules.size() == 0)
+    if (nonResourceRules.isEmpty())
       throw new RuntimeException("Can't edit first nonResourceRules. The list is empty.");
     return setNewNonResourceRuleLike(0, buildNonResourceRule(0));
   }
@@ -536,7 +536,7 @@ public class V1SubjectRulesReviewStatusFluentImpl<A extends V1SubjectRulesReview
 
   public io.kubernetes.client.openapi.models.V1SubjectRulesReviewStatusFluent.ResourceRulesNested<A>
       editFirstResourceRule() {
-    if (resourceRules.size() == 0)
+    if (resourceRules.isEmpty())
       throw new RuntimeException("Can't edit first resourceRules. The list is empty.");
     return setNewResourceRuleLike(0, buildResourceRule(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1TopologySelectorTermFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1TopologySelectorTermFluentImpl.java
@@ -278,7 +278,7 @@ public class V1TopologySelectorTermFluentImpl<A extends V1TopologySelectorTermFl
               .MatchLabelExpressionsNested<
           A>
       editFirstMatchLabelExpression() {
-    if (matchLabelExpressions.size() == 0)
+    if (matchLabelExpressions.isEmpty())
       throw new RuntimeException("Can't edit first matchLabelExpressions. The list is empty.");
     return setNewMatchLabelExpressionLike(0, buildMatchLabelExpression(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ValidatingWebhookConfigurationFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ValidatingWebhookConfigurationFluentImpl.java
@@ -343,7 +343,7 @@ public class V1ValidatingWebhookConfigurationFluentImpl<
   public io.kubernetes.client.openapi.models.V1ValidatingWebhookConfigurationFluent.WebhooksNested<
           A>
       editFirstWebhook() {
-    if (webhooks.size() == 0)
+    if (webhooks.isEmpty())
       throw new RuntimeException("Can't edit first webhooks. The list is empty.");
     return setNewWebhookLike(0, buildWebhook(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ValidatingWebhookConfigurationListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ValidatingWebhookConfigurationListFluentImpl.java
@@ -283,7 +283,7 @@ public class V1ValidatingWebhookConfigurationListFluentImpl<
   public io.kubernetes.client.openapi.models.V1ValidatingWebhookConfigurationListFluent.ItemsNested<
           A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ValidatingWebhookFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1ValidatingWebhookFluentImpl.java
@@ -605,7 +605,7 @@ public class V1ValidatingWebhookFluentImpl<A extends V1ValidatingWebhookFluent<A
 
   public io.kubernetes.client.openapi.models.V1ValidatingWebhookFluent.RulesNested<A>
       editFirstRule() {
-    if (rules.size() == 0) throw new RuntimeException("Can't edit first rules. The list is empty.");
+    if (rules.isEmpty()) throw new RuntimeException("Can't edit first rules. The list is empty.");
     return setNewRuleLike(0, buildRule(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1VolumeAttachmentListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1VolumeAttachmentListFluentImpl.java
@@ -260,7 +260,7 @@ public class V1VolumeAttachmentListFluentImpl<A extends V1VolumeAttachmentListFl
 
   public io.kubernetes.client.openapi.models.V1VolumeAttachmentListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1alpha1CSIStorageCapacityListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1alpha1CSIStorageCapacityListFluentImpl.java
@@ -274,7 +274,7 @@ public class V1alpha1CSIStorageCapacityListFluentImpl<
 
   public io.kubernetes.client.openapi.models.V1alpha1CSIStorageCapacityListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1alpha1RuntimeClassListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1alpha1RuntimeClassListFluentImpl.java
@@ -268,7 +268,7 @@ public class V1alpha1RuntimeClassListFluentImpl<A extends V1alpha1RuntimeClassLi
 
   public io.kubernetes.client.openapi.models.V1alpha1RuntimeClassListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1alpha1SchedulingFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1alpha1SchedulingFluentImpl.java
@@ -308,7 +308,7 @@ public class V1alpha1SchedulingFluentImpl<A extends V1alpha1SchedulingFluent<A>>
 
   public io.kubernetes.client.openapi.models.V1alpha1SchedulingFluent.TolerationsNested<A>
       editFirstToleration() {
-    if (tolerations.size() == 0)
+    if (tolerations.isEmpty())
       throw new RuntimeException("Can't edit first tolerations. The list is empty.");
     return setNewTolerationLike(0, buildToleration(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1alpha1StorageVersionListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1alpha1StorageVersionListFluentImpl.java
@@ -271,7 +271,7 @@ public class V1alpha1StorageVersionListFluentImpl<A extends V1alpha1StorageVersi
 
   public io.kubernetes.client.openapi.models.V1alpha1StorageVersionListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1alpha1StorageVersionStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1alpha1StorageVersionStatusFluentImpl.java
@@ -282,7 +282,7 @@ public class V1alpha1StorageVersionStatusFluentImpl<A extends V1alpha1StorageVer
 
   public io.kubernetes.client.openapi.models.V1alpha1StorageVersionStatusFluent.ConditionsNested<A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }
@@ -556,7 +556,7 @@ public class V1alpha1StorageVersionStatusFluentImpl<A extends V1alpha1StorageVer
               .StorageVersionsNested<
           A>
       editFirstStorageVersion() {
-    if (storageVersions.size() == 0)
+    if (storageVersions.isEmpty())
       throw new RuntimeException("Can't edit first storageVersions. The list is empty.");
     return setNewStorageVersionLike(0, buildStorageVersion(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1CSIStorageCapacityListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1CSIStorageCapacityListFluentImpl.java
@@ -272,7 +272,7 @@ public class V1beta1CSIStorageCapacityListFluentImpl<
 
   public io.kubernetes.client.openapi.models.V1beta1CSIStorageCapacityListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1CronJobListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1CronJobListFluentImpl.java
@@ -258,7 +258,7 @@ public class V1beta1CronJobListFluentImpl<A extends V1beta1CronJobListFluent<A>>
 
   public io.kubernetes.client.openapi.models.V1beta1CronJobListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1CronJobStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1CronJobStatusFluentImpl.java
@@ -247,8 +247,7 @@ public class V1beta1CronJobStatusFluentImpl<A extends V1beta1CronJobStatusFluent
 
   public io.kubernetes.client.openapi.models.V1beta1CronJobStatusFluent.ActiveNested<A>
       editFirstActive() {
-    if (active.size() == 0)
-      throw new RuntimeException("Can't edit first active. The list is empty.");
+    if (active.isEmpty()) throw new RuntimeException("Can't edit first active. The list is empty.");
     return setNewActiveLike(0, buildActive(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1EndpointHintsFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1EndpointHintsFluentImpl.java
@@ -241,7 +241,7 @@ public class V1beta1EndpointHintsFluentImpl<A extends V1beta1EndpointHintsFluent
 
   public io.kubernetes.client.openapi.models.V1beta1EndpointHintsFluent.ForZonesNested<A>
       editFirstForZone() {
-    if (forZones.size() == 0)
+    if (forZones.isEmpty())
       throw new RuntimeException("Can't edit first forZones. The list is empty.");
     return setNewForZoneLike(0, buildForZone(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1EndpointSliceFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1EndpointSliceFluentImpl.java
@@ -284,7 +284,7 @@ public class V1beta1EndpointSliceFluentImpl<A extends V1beta1EndpointSliceFluent
 
   public io.kubernetes.client.openapi.models.V1beta1EndpointSliceFluent.EndpointsNested<A>
       editFirstEndpoint() {
-    if (endpoints.size() == 0)
+    if (endpoints.isEmpty())
       throw new RuntimeException("Can't edit first endpoints. The list is empty.");
     return setNewEndpointLike(0, buildEndpoint(0));
   }
@@ -589,7 +589,7 @@ public class V1beta1EndpointSliceFluentImpl<A extends V1beta1EndpointSliceFluent
 
   public io.kubernetes.client.openapi.models.V1beta1EndpointSliceFluent.PortsNested<A>
       editFirstPort() {
-    if (ports.size() == 0) throw new RuntimeException("Can't edit first ports. The list is empty.");
+    if (ports.isEmpty()) throw new RuntimeException("Can't edit first ports. The list is empty.");
     return setNewPortLike(0, buildPort(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1EndpointSliceListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1EndpointSliceListFluentImpl.java
@@ -268,7 +268,7 @@ public class V1beta1EndpointSliceListFluentImpl<A extends V1beta1EndpointSliceLi
 
   public io.kubernetes.client.openapi.models.V1beta1EndpointSliceListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1EventListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1EventListFluentImpl.java
@@ -256,7 +256,7 @@ public class V1beta1EventListFluentImpl<A extends V1beta1EventListFluent<A>> ext
   }
 
   public io.kubernetes.client.openapi.models.V1beta1EventListFluent.ItemsNested<A> editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1FSGroupStrategyOptionsFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1FSGroupStrategyOptionsFluentImpl.java
@@ -243,8 +243,7 @@ public class V1beta1FSGroupStrategyOptionsFluentImpl<
 
   public io.kubernetes.client.openapi.models.V1beta1FSGroupStrategyOptionsFluent.RangesNested<A>
       editFirstRange() {
-    if (ranges.size() == 0)
-      throw new RuntimeException("Can't edit first ranges. The list is empty.");
+    if (ranges.isEmpty()) throw new RuntimeException("Can't edit first ranges. The list is empty.");
     return setNewRangeLike(0, buildRange(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1FlowSchemaListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1FlowSchemaListFluentImpl.java
@@ -260,7 +260,7 @@ public class V1beta1FlowSchemaListFluentImpl<A extends V1beta1FlowSchemaListFlue
 
   public io.kubernetes.client.openapi.models.V1beta1FlowSchemaListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1FlowSchemaSpecFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1FlowSchemaSpecFluentImpl.java
@@ -417,7 +417,7 @@ public class V1beta1FlowSchemaSpecFluentImpl<A extends V1beta1FlowSchemaSpecFlue
 
   public io.kubernetes.client.openapi.models.V1beta1FlowSchemaSpecFluent.RulesNested<A>
       editFirstRule() {
-    if (rules.size() == 0) throw new RuntimeException("Can't edit first rules. The list is empty.");
+    if (rules.isEmpty()) throw new RuntimeException("Can't edit first rules. The list is empty.");
     return setNewRuleLike(0, buildRule(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1FlowSchemaStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1FlowSchemaStatusFluentImpl.java
@@ -255,7 +255,7 @@ public class V1beta1FlowSchemaStatusFluentImpl<A extends V1beta1FlowSchemaStatus
 
   public io.kubernetes.client.openapi.models.V1beta1FlowSchemaStatusFluent.ConditionsNested<A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1PodDisruptionBudgetListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1PodDisruptionBudgetListFluentImpl.java
@@ -274,7 +274,7 @@ public class V1beta1PodDisruptionBudgetListFluentImpl<
 
   public io.kubernetes.client.openapi.models.V1beta1PodDisruptionBudgetListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1PodDisruptionBudgetStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1PodDisruptionBudgetStatusFluentImpl.java
@@ -272,7 +272,7 @@ public class V1beta1PodDisruptionBudgetStatusFluentImpl<
               .ConditionsNested<
           A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1PodSecurityPolicyListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1PodSecurityPolicyListFluentImpl.java
@@ -270,7 +270,7 @@ public class V1beta1PodSecurityPolicyListFluentImpl<A extends V1beta1PodSecurity
 
   public io.kubernetes.client.openapi.models.V1beta1PodSecurityPolicyListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1PodSecurityPolicySpecFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1PodSecurityPolicySpecFluentImpl.java
@@ -349,7 +349,7 @@ public class V1beta1PodSecurityPolicySpecFluentImpl<A extends V1beta1PodSecurity
               .AllowedCSIDriversNested<
           A>
       editFirstAllowedCSIDriver() {
-    if (allowedCSIDrivers.size() == 0)
+    if (allowedCSIDrivers.isEmpty())
       throw new RuntimeException("Can't edit first allowedCSIDrivers. The list is empty.");
     return setNewAllowedCSIDriverLike(0, buildAllowedCSIDriver(0));
   }
@@ -740,7 +740,7 @@ public class V1beta1PodSecurityPolicySpecFluentImpl<A extends V1beta1PodSecurity
               .AllowedFlexVolumesNested<
           A>
       editFirstAllowedFlexVolume() {
-    if (allowedFlexVolumes.size() == 0)
+    if (allowedFlexVolumes.isEmpty())
       throw new RuntimeException("Can't edit first allowedFlexVolumes. The list is empty.");
     return setNewAllowedFlexVolumeLike(0, buildAllowedFlexVolume(0));
   }
@@ -1009,7 +1009,7 @@ public class V1beta1PodSecurityPolicySpecFluentImpl<A extends V1beta1PodSecurity
               .AllowedHostPathsNested<
           A>
       editFirstAllowedHostPath() {
-    if (allowedHostPaths.size() == 0)
+    if (allowedHostPaths.isEmpty())
       throw new RuntimeException("Can't edit first allowedHostPaths. The list is empty.");
     return setNewAllowedHostPathLike(0, buildAllowedHostPath(0));
   }
@@ -1839,7 +1839,7 @@ public class V1beta1PodSecurityPolicySpecFluentImpl<A extends V1beta1PodSecurity
 
   public io.kubernetes.client.openapi.models.V1beta1PodSecurityPolicySpecFluent.HostPortsNested<A>
       editFirstHostPort() {
-    if (hostPorts.size() == 0)
+    if (hostPorts.isEmpty())
       throw new RuntimeException("Can't edit first hostPorts. The list is empty.");
     return setNewHostPortLike(0, buildHostPort(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1PolicyRulesWithSubjectsFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1PolicyRulesWithSubjectsFluentImpl.java
@@ -283,7 +283,7 @@ public class V1beta1PolicyRulesWithSubjectsFluentImpl<
               .NonResourceRulesNested<
           A>
       editFirstNonResourceRule() {
-    if (nonResourceRules.size() == 0)
+    if (nonResourceRules.isEmpty())
       throw new RuntimeException("Can't edit first nonResourceRules. The list is empty.");
     return setNewNonResourceRuleLike(0, buildNonResourceRule(0));
   }
@@ -553,7 +553,7 @@ public class V1beta1PolicyRulesWithSubjectsFluentImpl<
               .ResourceRulesNested<
           A>
       editFirstResourceRule() {
-    if (resourceRules.size() == 0)
+    if (resourceRules.isEmpty())
       throw new RuntimeException("Can't edit first resourceRules. The list is empty.");
     return setNewResourceRuleLike(0, buildResourceRule(0));
   }
@@ -797,7 +797,7 @@ public class V1beta1PolicyRulesWithSubjectsFluentImpl<
 
   public io.kubernetes.client.openapi.models.V1beta1PolicyRulesWithSubjectsFluent.SubjectsNested<A>
       editFirstSubject() {
-    if (subjects.size() == 0)
+    if (subjects.isEmpty())
       throw new RuntimeException("Can't edit first subjects. The list is empty.");
     return setNewSubjectLike(0, buildSubject(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1PriorityLevelConfigurationListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1PriorityLevelConfigurationListFluentImpl.java
@@ -288,7 +288,7 @@ public class V1beta1PriorityLevelConfigurationListFluentImpl<
               .ItemsNested<
           A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1PriorityLevelConfigurationStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1PriorityLevelConfigurationStatusFluentImpl.java
@@ -303,7 +303,7 @@ public class V1beta1PriorityLevelConfigurationStatusFluentImpl<
               .ConditionsNested<
           A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1RunAsGroupStrategyOptionsFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1RunAsGroupStrategyOptionsFluentImpl.java
@@ -243,8 +243,7 @@ public class V1beta1RunAsGroupStrategyOptionsFluentImpl<
 
   public io.kubernetes.client.openapi.models.V1beta1RunAsGroupStrategyOptionsFluent.RangesNested<A>
       editFirstRange() {
-    if (ranges.size() == 0)
-      throw new RuntimeException("Can't edit first ranges. The list is empty.");
+    if (ranges.isEmpty()) throw new RuntimeException("Can't edit first ranges. The list is empty.");
     return setNewRangeLike(0, buildRange(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1RunAsUserStrategyOptionsFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1RunAsUserStrategyOptionsFluentImpl.java
@@ -243,8 +243,7 @@ public class V1beta1RunAsUserStrategyOptionsFluentImpl<
 
   public io.kubernetes.client.openapi.models.V1beta1RunAsUserStrategyOptionsFluent.RangesNested<A>
       editFirstRange() {
-    if (ranges.size() == 0)
-      throw new RuntimeException("Can't edit first ranges. The list is empty.");
+    if (ranges.isEmpty()) throw new RuntimeException("Can't edit first ranges. The list is empty.");
     return setNewRangeLike(0, buildRange(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1RuntimeClassListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1RuntimeClassListFluentImpl.java
@@ -263,7 +263,7 @@ public class V1beta1RuntimeClassListFluentImpl<A extends V1beta1RuntimeClassList
 
   public io.kubernetes.client.openapi.models.V1beta1RuntimeClassListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1SchedulingFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1SchedulingFluentImpl.java
@@ -308,7 +308,7 @@ public class V1beta1SchedulingFluentImpl<A extends V1beta1SchedulingFluent<A>> e
 
   public io.kubernetes.client.openapi.models.V1beta1SchedulingFluent.TolerationsNested<A>
       editFirstToleration() {
-    if (tolerations.size() == 0)
+    if (tolerations.isEmpty())
       throw new RuntimeException("Can't edit first tolerations. The list is empty.");
     return setNewTolerationLike(0, buildToleration(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1SupplementalGroupsStrategyOptionsFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta1SupplementalGroupsStrategyOptionsFluentImpl.java
@@ -251,8 +251,7 @@ public class V1beta1SupplementalGroupsStrategyOptionsFluentImpl<
               .RangesNested<
           A>
       editFirstRange() {
-    if (ranges.size() == 0)
-      throw new RuntimeException("Can't edit first ranges. The list is empty.");
+    if (ranges.isEmpty()) throw new RuntimeException("Can't edit first ranges. The list is empty.");
     return setNewRangeLike(0, buildRange(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta2FlowSchemaListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta2FlowSchemaListFluentImpl.java
@@ -260,7 +260,7 @@ public class V1beta2FlowSchemaListFluentImpl<A extends V1beta2FlowSchemaListFlue
 
   public io.kubernetes.client.openapi.models.V1beta2FlowSchemaListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta2FlowSchemaSpecFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta2FlowSchemaSpecFluentImpl.java
@@ -416,7 +416,7 @@ public class V1beta2FlowSchemaSpecFluentImpl<A extends V1beta2FlowSchemaSpecFlue
 
   public io.kubernetes.client.openapi.models.V1beta2FlowSchemaSpecFluent.RulesNested<A>
       editFirstRule() {
-    if (rules.size() == 0) throw new RuntimeException("Can't edit first rules. The list is empty.");
+    if (rules.isEmpty()) throw new RuntimeException("Can't edit first rules. The list is empty.");
     return setNewRuleLike(0, buildRule(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta2FlowSchemaStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta2FlowSchemaStatusFluentImpl.java
@@ -256,7 +256,7 @@ public class V1beta2FlowSchemaStatusFluentImpl<A extends V1beta2FlowSchemaStatus
 
   public io.kubernetes.client.openapi.models.V1beta2FlowSchemaStatusFluent.ConditionsNested<A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta2PolicyRulesWithSubjectsFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta2PolicyRulesWithSubjectsFluentImpl.java
@@ -283,7 +283,7 @@ public class V1beta2PolicyRulesWithSubjectsFluentImpl<
               .NonResourceRulesNested<
           A>
       editFirstNonResourceRule() {
-    if (nonResourceRules.size() == 0)
+    if (nonResourceRules.isEmpty())
       throw new RuntimeException("Can't edit first nonResourceRules. The list is empty.");
     return setNewNonResourceRuleLike(0, buildNonResourceRule(0));
   }
@@ -552,7 +552,7 @@ public class V1beta2PolicyRulesWithSubjectsFluentImpl<
               .ResourceRulesNested<
           A>
       editFirstResourceRule() {
-    if (resourceRules.size() == 0)
+    if (resourceRules.isEmpty())
       throw new RuntimeException("Can't edit first resourceRules. The list is empty.");
     return setNewResourceRuleLike(0, buildResourceRule(0));
   }
@@ -796,7 +796,7 @@ public class V1beta2PolicyRulesWithSubjectsFluentImpl<
 
   public io.kubernetes.client.openapi.models.V1beta2PolicyRulesWithSubjectsFluent.SubjectsNested<A>
       editFirstSubject() {
-    if (subjects.size() == 0)
+    if (subjects.isEmpty())
       throw new RuntimeException("Can't edit first subjects. The list is empty.");
     return setNewSubjectLike(0, buildSubject(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta2PriorityLevelConfigurationListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta2PriorityLevelConfigurationListFluentImpl.java
@@ -290,7 +290,7 @@ public class V1beta2PriorityLevelConfigurationListFluentImpl<
               .ItemsNested<
           A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta2PriorityLevelConfigurationStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V1beta2PriorityLevelConfigurationStatusFluentImpl.java
@@ -303,7 +303,7 @@ public class V1beta2PriorityLevelConfigurationStatusFluentImpl<
               .ConditionsNested<
           A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V2HPAScalingRulesFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V2HPAScalingRulesFluentImpl.java
@@ -250,7 +250,7 @@ public class V2HPAScalingRulesFluentImpl<A extends V2HPAScalingRulesFluent<A>> e
 
   public io.kubernetes.client.openapi.models.V2HPAScalingRulesFluent.PoliciesNested<A>
       editFirstPolicy() {
-    if (policies.size() == 0)
+    if (policies.isEmpty())
       throw new RuntimeException("Can't edit first policies. The list is empty.");
     return setNewPolicyLike(0, buildPolicy(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V2HorizontalPodAutoscalerListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V2HorizontalPodAutoscalerListFluentImpl.java
@@ -273,7 +273,7 @@ public class V2HorizontalPodAutoscalerListFluentImpl<
 
   public io.kubernetes.client.openapi.models.V2HorizontalPodAutoscalerListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V2HorizontalPodAutoscalerSpecFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V2HorizontalPodAutoscalerSpecFluentImpl.java
@@ -324,7 +324,7 @@ public class V2HorizontalPodAutoscalerSpecFluentImpl<
 
   public io.kubernetes.client.openapi.models.V2HorizontalPodAutoscalerSpecFluent.MetricsNested<A>
       editFirstMetric() {
-    if (metrics.size() == 0)
+    if (metrics.isEmpty())
       throw new RuntimeException("Can't edit first metrics. The list is empty.");
     return setNewMetricLike(0, buildMetric(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V2HorizontalPodAutoscalerStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V2HorizontalPodAutoscalerStatusFluentImpl.java
@@ -290,7 +290,7 @@ public class V2HorizontalPodAutoscalerStatusFluentImpl<
   public io.kubernetes.client.openapi.models.V2HorizontalPodAutoscalerStatusFluent.ConditionsNested<
           A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }
@@ -542,7 +542,7 @@ public class V2HorizontalPodAutoscalerStatusFluentImpl<
               .CurrentMetricsNested<
           A>
       editFirstCurrentMetric() {
-    if (currentMetrics.size() == 0)
+    if (currentMetrics.isEmpty())
       throw new RuntimeException("Can't edit first currentMetrics. The list is empty.");
     return setNewCurrentMetricLike(0, buildCurrentMetric(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V2beta1HorizontalPodAutoscalerListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V2beta1HorizontalPodAutoscalerListFluentImpl.java
@@ -277,7 +277,7 @@ public class V2beta1HorizontalPodAutoscalerListFluentImpl<
 
   public io.kubernetes.client.openapi.models.V2beta1HorizontalPodAutoscalerListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V2beta1HorizontalPodAutoscalerSpecFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V2beta1HorizontalPodAutoscalerSpecFluentImpl.java
@@ -269,7 +269,7 @@ public class V2beta1HorizontalPodAutoscalerSpecFluentImpl<
   public io.kubernetes.client.openapi.models.V2beta1HorizontalPodAutoscalerSpecFluent.MetricsNested<
           A>
       editFirstMetric() {
-    if (metrics.size() == 0)
+    if (metrics.isEmpty())
       throw new RuntimeException("Can't edit first metrics. The list is empty.");
     return setNewMetricLike(0, buildMetric(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V2beta1HorizontalPodAutoscalerStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V2beta1HorizontalPodAutoscalerStatusFluentImpl.java
@@ -304,7 +304,7 @@ public class V2beta1HorizontalPodAutoscalerStatusFluentImpl<
               .ConditionsNested<
           A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }
@@ -562,7 +562,7 @@ public class V2beta1HorizontalPodAutoscalerStatusFluentImpl<
               .CurrentMetricsNested<
           A>
       editFirstCurrentMetric() {
-    if (currentMetrics.size() == 0)
+    if (currentMetrics.isEmpty())
       throw new RuntimeException("Can't edit first currentMetrics. The list is empty.");
     return setNewCurrentMetricLike(0, buildCurrentMetric(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V2beta2HPAScalingRulesFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V2beta2HPAScalingRulesFluentImpl.java
@@ -259,7 +259,7 @@ public class V2beta2HPAScalingRulesFluentImpl<A extends V2beta2HPAScalingRulesFl
 
   public io.kubernetes.client.openapi.models.V2beta2HPAScalingRulesFluent.PoliciesNested<A>
       editFirstPolicy() {
-    if (policies.size() == 0)
+    if (policies.isEmpty())
       throw new RuntimeException("Can't edit first policies. The list is empty.");
     return setNewPolicyLike(0, buildPolicy(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V2beta2HorizontalPodAutoscalerListFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V2beta2HorizontalPodAutoscalerListFluentImpl.java
@@ -277,7 +277,7 @@ public class V2beta2HorizontalPodAutoscalerListFluentImpl<
 
   public io.kubernetes.client.openapi.models.V2beta2HorizontalPodAutoscalerListFluent.ItemsNested<A>
       editFirstItem() {
-    if (items.size() == 0) throw new RuntimeException("Can't edit first items. The list is empty.");
+    if (items.isEmpty()) throw new RuntimeException("Can't edit first items. The list is empty.");
     return setNewItemLike(0, buildItem(0));
   }
 

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V2beta2HorizontalPodAutoscalerSpecFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V2beta2HorizontalPodAutoscalerSpecFluentImpl.java
@@ -341,7 +341,7 @@ public class V2beta2HorizontalPodAutoscalerSpecFluentImpl<
   public io.kubernetes.client.openapi.models.V2beta2HorizontalPodAutoscalerSpecFluent.MetricsNested<
           A>
       editFirstMetric() {
-    if (metrics.size() == 0)
+    if (metrics.isEmpty())
       throw new RuntimeException("Can't edit first metrics. The list is empty.");
     return setNewMetricLike(0, buildMetric(0));
   }

--- a/fluent/src/main/java/io/kubernetes/client/openapi/models/V2beta2HorizontalPodAutoscalerStatusFluentImpl.java
+++ b/fluent/src/main/java/io/kubernetes/client/openapi/models/V2beta2HorizontalPodAutoscalerStatusFluentImpl.java
@@ -304,7 +304,7 @@ public class V2beta2HorizontalPodAutoscalerStatusFluentImpl<
               .ConditionsNested<
           A>
       editFirstCondition() {
-    if (conditions.size() == 0)
+    if (conditions.isEmpty())
       throw new RuntimeException("Can't edit first conditions. The list is empty.");
     return setNewConditionLike(0, buildCondition(0));
   }
@@ -562,7 +562,7 @@ public class V2beta2HorizontalPodAutoscalerStatusFluentImpl<
               .CurrentMetricsNested<
           A>
       editFirstCurrentMetric() {
-    if (currentMetrics.size() == 0)
+    if (currentMetrics.isEmpty())
       throw new RuntimeException("Can't edit first currentMetrics. The list is empty.");
     return setNewCurrentMetricLike(0, buildCurrentMetric(0));
   }

--- a/util/src/main/java/io/kubernetes/client/informer/cache/DeltaFIFO.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/DeltaFIFO.java
@@ -385,7 +385,7 @@ public class DeltaFIFO {
     if (obj instanceof Deque) {
       Deque<MutablePair<DeltaType, KubernetesObject>> deltas =
           (Deque<MutablePair<DeltaType, KubernetesObject>>) obj;
-      if (deltas.size() == 0) {
+      if (deltas.isEmpty()) {
         throw new NoSuchElementException("0 length Deltas object; can't get key");
       }
       innerObj = deltas.peekLast().getRight();


### PR DESCRIPTION
Non functional change to improve the code quality. See https://rules.sonarsource.com/java/RSPEC-1155

This is the result of running the recipe `org.openrewrite.java.cleanup.IsEmptyCallOnCollections` from the OpenRewrite project

Read more : https://docs.openrewrite.org/reference/recipes/java/cleanup/isemptycalloncollections

Created with: [Moderne](https://app.moderne.io)