### PR TITLE
Flake: Fixes rate-limit queue flakiness

### DIFF
--- a/extended/src/test/java/io/kubernetes/client/extended/workqueue/DefaultRateLimitQueueTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/workqueue/DefaultRateLimitQueueTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.assertTrue;
 import io.kubernetes.client.extended.workqueue.ratelimiter.RateLimiter;
 import java.time.Duration;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 public class DefaultRateLimitQueueTest {
@@ -26,9 +25,11 @@ public class DefaultRateLimitQueueTest {
 
     private int count;
 
+    private static Duration mockConstantBackoff = Duration.ofMillis(500);
+
     @Override
     public Duration when(Object item) {
-      return Duration.ofMillis(500);
+      return mockConstantBackoff;
     }
 
     @Override
@@ -53,6 +54,6 @@ public class DefaultRateLimitQueueTest {
     rlq.addRateLimited("foo");
     rlq.get();
     long t2 = System.nanoTime();
-    assertTrue(t2 - t1 > TimeUnit.MILLISECONDS.toNanos(500));
+    assertTrue(t2 - t1 > MockRateLimiter.mockConstantBackoff.toNanos());
   }
 }


### PR DESCRIPTION
Fixes flakiness in https://github.com/kubernetes-client/java/runs/6603599991?check_suite_focus=true