### PR TITLE
Fix: GCPAuthenticator throws null exception in some cases

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/authenticators/GCPAuthenticator.java
+++ b/util/src/main/java/io/kubernetes/client/util/authenticators/GCPAuthenticator.java
@@ -99,6 +99,7 @@ public class GCPAuthenticator implements Authenticator {
     String[] scopes = parseScopes(config);
     try {
       if (this.gc == null) this.gc = GoogleCredentials.getApplicationDefault().createScoped(scopes);
+      gc.refreshIfExpired();
       AccessToken accessToken = gc.getAccessToken();
       config.put(ACCESS_TOKEN, accessToken.getTokenValue());
       config.put(EXPIRY, accessToken.getExpirationTime());


### PR DESCRIPTION
Hi, currently GCPAuthenticator support for environment without `gcloud` is broken. The code will throw `NullPointerException` when being executed:
```
Exception in thread "main" java.lang.NullPointerException
	at io.kubernetes.client.util.authenticators.GCPAuthenticator.refresh(GCPAuthenticator.java:103)
	at io.kubernetes.client.util.KubeConfig.getCredentials(KubeConfig.java:220)
	at io.kubernetes.client.util.credentials.KubeconfigAuthentication.<init>(KubeconfigAuthentication.java:59)
	at io.kubernetes.client.util.ClientBuilder.kubeconfig(ClientBuilder.java:299)
```
```
// Where exception is thrown
// File: util/src/main/java/io/kubernetes/client/util/authenticators/GCPAuthenticator.java

101:  if (this.gc == null) this.gc = GoogleCredentials.getApplicationDefault().createScoped(scopes);
102:  AccessToken accessToken = gc.getAccessToken();
103:  config.put(ACCESS_TOKEN, accessToken.getTokenValue());
104:  config.put(EXPIRY, accessToken.getExpirationTime());
```
The reason is that `gc.getAccessToken()` just returns the cached access token which is `null` initially. You have to explicitly call `gc.refreshIfExpired()` before to initialize it, as documented [here](https://github.com/googleapis/google-auth-library-java#explicit-credential-loading)

The current test for this functionality is broken too. Since it mocks `getAccessToken()`, it will never get null exception. However, it's quite hard to mock the correct behavior of Google Oauth2 Library, so I think I'll just attempt to fix the bug first. The fix for the test might come in another PR.