### PR TITLE
Add support for v1 exec credentials (and a brief explanation)

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/KubeConfig.java
+++ b/util/src/main/java/io/kubernetes/client/util/KubeConfig.java
@@ -272,7 +272,15 @@ public class KubeConfig {
     Map<String, String> credentials = new HashMap<>();
 
     String apiVersion = (String) execMap.get("apiVersion");
-    if (!"client.authentication.k8s.io/v1beta1".equals(apiVersion)
+    /**
+     * Some history here: v1 was added in kubernetes 1.21
+     * (https://github.com/kubernetes/kubernetes/pull/102890) v1alpha1 was removed in Kubernetes
+     * 1.24 (https://github.com/kubernetes/kubernetes/pull/108616) We need to leave v1alpha1 for now
+     * to support backwards compatability, but we will likely want to remove it eventually after
+     * Kubernetes 1.23 is no longer supported }
+     */
+    if (!"client.authentication.k8s.io/v1".equals(apiVersion)
+        && !"client.authentication.k8s.io/v1beta1".equals(apiVersion)
         && !"client.authentication.k8s.io/v1alpha1".equals(apiVersion)) {
       log.error("Unrecognized user.exec.apiVersion: {}", apiVersion);
       return null;

--- a/util/src/test/java/io/kubernetes/client/util/KubeConfigTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/KubeConfigTest.java
@@ -374,6 +374,17 @@ public class KubeConfigTest {
     assertEquals("abc123", kc.getCredentials().get(KubeConfig.CRED_TOKEN_KEY));
   }
 
+  @Test
+  public void testExecCredentialsV1() throws Exception {
+    // TODO: test exec on Windows
+    if (System.getProperty("os.name").contains("Windows")) {
+      return;
+    }
+    KubeConfig kc =
+        KubeConfig.loadKubeConfig(new StringReader(KUBECONFIG_EXEC.replace("v1beta1", "v1")));
+    assertEquals("abc123", kc.getCredentials().get(KubeConfig.CRED_TOKEN_KEY));
+  }
+
   private static final String KUBECONFIG_EXEC_ENV =
       "apiVersion: v1\n"
           + "current-context: c\n"


### PR DESCRIPTION
Fixes https://github.com/kubernetes-client/java/issues/2290