### PR TITLE
Close ResponseBody in PodLogs on error

### DIFF
--- a/util/src/main/java/io/kubernetes/client/PodLogs.java
+++ b/util/src/main/java/io/kubernetes/client/PodLogs.java
@@ -95,6 +95,9 @@ public class PodLogs {
             null);
     Response response = call.execute();
     if (!response.isSuccessful()) {
+      if (response.body() != null) {
+        response.close();
+      }
       throw new ApiException(response.code(), "Logs request failed: " + response.code());
     }
     return response.body().byteStream();

--- a/util/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/util/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Cherry pick of #2314 for release 12 branch.

Code is the same as the linked PR but it includes the `mock-maker-inline` extension as it is needed for these tests.