### PR TITLE
Add a consumer for unhandled errors to Exec.java

### DIFF
--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlExec.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlExec.java
@@ -21,6 +21,7 @@ import io.kubernetes.client.util.Streams;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 public class KubectlExec extends Kubectl.ResourceAndContainerBuilder<V1Pod, KubectlExec>
@@ -82,7 +83,7 @@ public class KubectlExec extends Kubectl.ResourceAndContainerBuilder<V1Pod, Kube
                 try {
                   Streams.copy(in, out);
                 } catch (IOException ex) {
-                  onUnhandledError.accept(ex);
+                  Optional.ofNullable(onUnhandledError).orElse(Throwable::printStackTrace).accept(ex);
                 }
               }
             });

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlExec.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlExec.java
@@ -75,7 +75,8 @@ public class KubectlExec extends Kubectl.ResourceAndContainerBuilder<V1Pod, Kube
     }
   }
 
-  protected static Thread copyAsync(InputStream in, OutputStream out, Consumer<Throwable> onUnhandledError) {
+  protected static Thread copyAsync(
+      InputStream in, OutputStream out, Consumer<Throwable> onUnhandledError) {
     Thread t =
         new Thread(
             new Runnable() {
@@ -83,7 +84,9 @@ public class KubectlExec extends Kubectl.ResourceAndContainerBuilder<V1Pod, Kube
                 try {
                   Streams.copy(in, out);
                 } catch (IOException ex) {
-                  Optional.ofNullable(onUnhandledError).orElse(Throwable::printStackTrace).accept(ex);
+                  Optional.ofNullable(onUnhandledError)
+                      .orElse(Throwable::printStackTrace)
+                      .accept(ex);
                 }
               }
             });

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlExec.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlExec.java
@@ -21,12 +21,14 @@ import io.kubernetes.client.util.Streams;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.function.Consumer;
 
 public class KubectlExec extends Kubectl.ResourceAndContainerBuilder<V1Pod, KubectlExec>
     implements Kubectl.Executable<Integer> {
   private String[] command;
   private boolean stdin;
   private boolean tty;
+  private Consumer<Throwable> onUnhandledError = Throwable::printStackTrace;
 
   KubectlExec() {
     super(V1Pod.class);
@@ -47,17 +49,24 @@ public class KubectlExec extends Kubectl.ResourceAndContainerBuilder<V1Pod, Kube
     return this;
   }
 
+  public KubectlExec onUnhandledError(Consumer<Throwable> onUnhandledError) {
+    this.onUnhandledError = onUnhandledError;
+    return this;
+  }
+
   @Override
   public Integer execute() throws KubectlException {
     V1Pod pod = new V1Pod().metadata(new V1ObjectMeta().name(name).namespace(namespace));
 
     Exec exec = new Exec(apiClient);
+    exec.setOnUnhandledError(onUnhandledError);
+
     try {
       Process proc = exec.exec(pod, command, container, stdin, tty);
-      copyAsync(proc.getInputStream(), System.out);
-      copyAsync(proc.getErrorStream(), System.err);
+      copyAsync(proc.getInputStream(), System.out, onUnhandledError);
+      copyAsync(proc.getErrorStream(), System.err, onUnhandledError);
       if (stdin) {
-        copyAsync(System.in, proc.getOutputStream());
+        copyAsync(System.in, proc.getOutputStream(), onUnhandledError);
       }
       return proc.waitFor();
     } catch (InterruptedException | ApiException | IOException ex) {
@@ -65,7 +74,7 @@ public class KubectlExec extends Kubectl.ResourceAndContainerBuilder<V1Pod, Kube
     }
   }
 
-  protected static Thread copyAsync(InputStream in, OutputStream out) {
+  protected static Thread copyAsync(InputStream in, OutputStream out, Consumer<Throwable> onUnhandledError) {
     Thread t =
         new Thread(
             new Runnable() {
@@ -73,7 +82,7 @@ public class KubectlExec extends Kubectl.ResourceAndContainerBuilder<V1Pod, Kube
                 try {
                   Streams.copy(in, out);
                 } catch (IOException ex) {
-                  ex.printStackTrace();
+                  onUnhandledError.accept(ex);
                 }
               }
             });

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlPortForward.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlPortForward.java
@@ -25,6 +25,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 public class KubectlPortForward
@@ -111,7 +112,7 @@ public class KubectlPortForward
                     t1.join();
                     t2.join();
                   } catch (InterruptedException | IOException ex) {
-                    onUnhandledError.accept(ex);
+                    Optional.ofNullable(onUnhandledError).orElse(Throwable::printStackTrace).accept(ex);
                   }
                 }
               }

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlPortForward.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlPortForward.java
@@ -112,7 +112,9 @@ public class KubectlPortForward
                     t1.join();
                     t2.join();
                   } catch (InterruptedException | IOException ex) {
-                    Optional.ofNullable(onUnhandledError).orElse(Throwable::printStackTrace).accept(ex);
+                    Optional.ofNullable(onUnhandledError)
+                        .orElse(Throwable::printStackTrace)
+                        .accept(ex);
                   }
                 }
               }

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlPortForward.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlPortForward.java
@@ -25,6 +25,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 public class KubectlPortForward
     extends Kubectl.ResourceAndContainerBuilder<V1Pod, KubectlPortForward>
@@ -32,6 +33,7 @@ public class KubectlPortForward
   List<Integer> localPorts;
   List<Integer> targetPorts;
   boolean running;
+  Consumer<Throwable> onUnhandledError = Throwable::printStackTrace;
 
   KubectlPortForward() {
     super(V1Pod.class);
@@ -49,6 +51,11 @@ public class KubectlPortForward
   public KubectlPortForward ports(int localPort, int targetPort) {
     localPorts.add(localPort);
     targetPorts.add(targetPort);
+    return this;
+  }
+
+  public KubectlPortForward onUnhandledError(Consumer<Throwable> onUnhandledError) {
+    this.onUnhandledError = onUnhandledError;
     return this;
   }
 
@@ -98,13 +105,13 @@ public class KubectlPortForward
                 while (running) {
                   try {
                     Socket sock = server.accept();
-                    Thread t1 = copyAsync(sock.getInputStream(), out);
-                    Thread t2 = copyAsync(in, sock.getOutputStream());
+                    Thread t1 = copyAsync(sock.getInputStream(), out, onUnhandledError);
+                    Thread t2 = copyAsync(in, sock.getOutputStream(), onUnhandledError);
 
                     t1.join();
                     t2.join();
                   } catch (InterruptedException | IOException ex) {
-                    ex.printStackTrace();
+                    onUnhandledError.accept(ex);
                   }
                 }
               }


### PR DESCRIPTION
Signed-off-by: Daniel Arteaga Barba <darteaga@vmware.com>

This PR will try to implement an acceptable approach for the following proposal #2361

See an example of use.

```java
  @Override
  public Process exec(String[] args, boolean stdin, boolean tty) {
    try {
      Exec kubeExec = new Exec(client);
      kubeExec.setOnUnhandledError(this::logUnhandledExceptions);

      return kubeExec.exec(namespace, host, args, null, stdin, tty);
    } catch (ApiException | IOException e) {
      throw Errors.internal("Error executing command on the remote host", e).get();
    }
  }

  private void logUnhandledExceptions(final Throwable throwable) {
    log.debug(throwable.getMessage(), throwable);
  }
``` 