### PR TITLE
fix: WebSocketOutputStream wait to write until WebSocket queue is released

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/WebSocketStreamHandler.java
+++ b/util/src/main/java/io/kubernetes/client/util/WebSocketStreamHandler.java
@@ -210,11 +210,11 @@ public class WebSocketStreamHandler implements WebSockets.SocketListener, Closea
 
   private class WebSocketOutputStream extends OutputStream {
 
-    private static final long WEB_SOCKET_MAX_QUEUE_SIZE = 16L * 1024 * 1024;
+    private static final long MAX_QUEUE_SIZE = 16L * 1024 * 1024;
 
-    private static final int WEB_SOCKET_MAX_QUEUE_SIZE_MAX_ATTEMPTS = 15;
+    private static final int MAX_QUEUE_SIZE_MAX_ATTEMPTS = 15;
 
-    private static final int WEB_SOCKET_MAX_QUEUE_SIZE_WAIT_MILLISECONDS = 1000;
+    private static final int MAX_QUEUE_SIZE_WAIT_MILLISECONDS = 1000;
 
     private final byte stream;
 
@@ -277,11 +277,11 @@ public class WebSocketStreamHandler implements WebSockets.SocketListener, Closea
         ByteString byteString = ByteString.of(buffer);
 
         int attempts = 0;
-        while (WebSocketStreamHandler.this.socket.queueSize() + byteString.size() > WEB_SOCKET_MAX_QUEUE_SIZE
-            && attempts < WEB_SOCKET_MAX_QUEUE_SIZE_MAX_ATTEMPTS) {
+        while (WebSocketStreamHandler.this.socket.queueSize() + byteString.size() > MAX_QUEUE_SIZE
+            && attempts < MAX_QUEUE_SIZE_MAX_ATTEMPTS) {
           try {
-            Thread.sleep(WEB_SOCKET_MAX_QUEUE_SIZE_WAIT_MILLISECONDS);
-            attempts ++;
+            Thread.sleep(MAX_QUEUE_SIZE_WAIT_MILLISECONDS);
+            attempts++;
           } catch (InterruptedException e) {
             throw new IOException("Error waiting web socket queue", e);
           }


### PR DESCRIPTION
Signed-off-by: Daniel Arteaga Barba <darteaga@vmware.com>

This PR is a proposal for the following issue:https://github.com/kubernetes-client/java/issues/2309 based in this comment: https://github.com/kubernetes-client/java/issues/2309#issuecomment-1255038176