### PR TITLE
add support for Spring Framework 6 AOT engine 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
     <maven-plugin-version>1.0.0</maven-plugin-version>
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
     <javax.annotation.version>1.3.2</javax.annotation.version>
     <snakeyaml.version>1.33</snakeyaml.version>
     <slf4j.version>2.0.3</slf4j.version>
@@ -329,7 +330,16 @@
       <layout>default</layout>
     </repository>
   </distributionManagement>
-
+  <repositories>
+    <repository>
+      <id>spring-milestones</id>
+      <name>Spring Milestones</name>
+      <url>https://repo.spring.io/milestone</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
   <build>
     <pluginManagement>
       <plugins>
@@ -530,7 +540,6 @@
       </plugin>
     </plugins>
   </build>
-
   <profiles>
     <profile>
       <id>release-sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <maven-plugin-version>1.0.0</maven-plugin-version>
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
+    <reflections.version>0.10.2</reflections.version>
     <javax.annotation.version>1.3.2</javax.annotation.version>
     <snakeyaml.version>1.33</snakeyaml.version>
     <slf4j.version>2.0.3</slf4j.version>
@@ -89,6 +89,11 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.reflections</groupId>
+        <artifactId>reflections</artifactId>
+        <version>${reflections.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
@@ -482,49 +487,49 @@
               <include>src/test/groovy/**/*.groovy</include>
             </includes>
 
-            <importOrder>  <!-- or a custom ordering -->
-              <order>java,javax,org,com,com.diffplug,
-              </order>  <!-- or use <file>${basedir}/eclipse.importorder</file> -->
-            </importOrder>
-            <greclipse />          <!-- has its own section below -->
-            <licenseHeader>
-              <content>
-/*
-Copyright $YEAR The Kubernetes Authors.
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-              </content>
-            </licenseHeader>
-          </groovy>
-          <licenseHeader>
-            <content>
-/*
-Copyright $YEAR The Kubernetes Authors.
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-            </content>
-            <delimiter>package </delimiter>
-          </licenseHeader>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+                        <importOrder>  <!-- or a custom ordering -->
+                            <order>java,javax,org,com,com.diffplug,
+                            </order>  <!-- or use <file>${basedir}/eclipse.importorder</file> -->
+                        </importOrder>
+                        <greclipse/>          <!-- has its own section below -->
+                        <licenseHeader>
+                            <content>
+                                /*
+                                Copyright $YEAR The Kubernetes Authors.
+                                Licensed under the Apache License, Version 2.0 (the "License");
+                                you may not use this file except in compliance with the License.
+                                You may obtain a copy of the License at
+                                http://www.apache.org/licenses/LICENSE-2.0
+                                Unless required by applicable law or agreed to in writing, software
+                                distributed under the License is distributed on an "AS IS" BASIS,
+                                WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                See the License for the specific language governing permissions and
+                                limitations under the License.
+                                */
+                            </content>
+                        </licenseHeader>
+                    </groovy>
+                    <licenseHeader>
+                        <content>
+                            /*
+                            Copyright $YEAR The Kubernetes Authors.
+                            Licensed under the Apache License, Version 2.0 (the "License");
+                            you may not use this file except in compliance with the License.
+                            You may obtain a copy of the License at
+                            http://www.apache.org/licenses/LICENSE-2.0
+                            Unless required by applicable law or agreed to in writing, software
+                            distributed under the License is distributed on an "AS IS" BASIS,
+                            WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                            See the License for the specific language governing permissions and
+                            limitations under the License.
+                            */
+                        </content>
+                        <delimiter>package</delimiter>
+                    </licenseHeader>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
   <profiles>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -329,16 +329,7 @@
       <layout>default</layout>
     </repository>
   </distributionManagement>
-  <repositories>
-    <repository>
-      <id>spring-milestones</id>
-      <name>Spring Milestones</name>
-      <url>https://repo.spring.io/milestone</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
+
   <build>
     <pluginManagement>
       <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
     <maven-plugin-version>1.0.0</maven-plugin-version>
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <reflections.version>0.10.2</reflections.version>
     <javax.annotation.version>1.3.2</javax.annotation.version>
     <snakeyaml.version>1.33</snakeyaml.version>
     <slf4j.version>2.0.3</slf4j.version>
@@ -60,9 +59,10 @@
     <apache.commons.compress>1.21</apache.commons.compress>
     <apache.commons.io>2.11.0</apache.commons.io>
     <common.codec.version>1.15</common.codec.version>
-    <spring.boot.version>2.7.4</spring.boot.version>
+    <spring.boot.version>3.0.0-M5</spring.boot.version>
     <spring.version>5.3.23</spring.version>
     <prometheus.client.version>0.15.0</prometheus.client.version>
+    <reflections.version>0.10.2</reflections.version>
 
     <e2e.skip>true</e2e.skip>
 
@@ -329,7 +329,16 @@
       <layout>default</layout>
     </repository>
   </distributionManagement>
-
+  <repositories>
+    <repository>
+      <id>spring-milestones</id>
+      <name>Spring Milestones</name>
+      <url>https://repo.spring.io/milestone</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
   <build>
     <pluginManagement>
       <plugins>
@@ -398,21 +407,21 @@
       </plugins>
     </pluginManagement>
     <plugins>
-    <!-- Sources jar -->
-    <plugin>
+      <!-- Sources jar -->
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>3.2.1</version>
         <executions>
-            <execution>
-                <id>attach-sources</id>
-                <goals>
-                    <goal>jar-no-fork</goal>
-                </goals>
-            </execution>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
         </executions>
-    </plugin>
-    <plugin>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <version>3.4.2</version>
@@ -487,49 +496,49 @@
               <include>src/test/groovy/**/*.groovy</include>
             </includes>
 
-                        <importOrder>  <!-- or a custom ordering -->
-                            <order>java,javax,org,com,com.diffplug,
-                            </order>  <!-- or use <file>${basedir}/eclipse.importorder</file> -->
-                        </importOrder>
-                        <greclipse/>          <!-- has its own section below -->
-                        <licenseHeader>
-                            <content>
-                                /*
-                                Copyright $YEAR The Kubernetes Authors.
-                                Licensed under the Apache License, Version 2.0 (the "License");
-                                you may not use this file except in compliance with the License.
-                                You may obtain a copy of the License at
-                                http://www.apache.org/licenses/LICENSE-2.0
-                                Unless required by applicable law or agreed to in writing, software
-                                distributed under the License is distributed on an "AS IS" BASIS,
-                                WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                See the License for the specific language governing permissions and
-                                limitations under the License.
-                                */
-                            </content>
-                        </licenseHeader>
-                    </groovy>
-                    <licenseHeader>
-                        <content>
-                            /*
-                            Copyright $YEAR The Kubernetes Authors.
-                            Licensed under the Apache License, Version 2.0 (the "License");
-                            you may not use this file except in compliance with the License.
-                            You may obtain a copy of the License at
-                            http://www.apache.org/licenses/LICENSE-2.0
-                            Unless required by applicable law or agreed to in writing, software
-                            distributed under the License is distributed on an "AS IS" BASIS,
-                            WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                            See the License for the specific language governing permissions and
-                            limitations under the License.
-                            */
-                        </content>
-                        <delimiter>package</delimiter>
-                    </licenseHeader>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+            <importOrder>  <!-- or a custom ordering -->
+              <order>java,javax,org,com,com.diffplug,
+              </order>  <!-- or use <file>${basedir}/eclipse.importorder</file> -->
+            </importOrder>
+            <greclipse />          <!-- has its own section below -->
+            <licenseHeader>
+              <content>
+                /*
+                Copyright $YEAR The Kubernetes Authors.
+                Licensed under the Apache License, Version 2.0 (the "License");
+                you may not use this file except in compliance with the License.
+                You may obtain a copy of the License at
+                http://www.apache.org/licenses/LICENSE-2.0
+                Unless required by applicable law or agreed to in writing, software
+                distributed under the License is distributed on an "AS IS" BASIS,
+                WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                See the License for the specific language governing permissions and
+                limitations under the License.
+                */
+              </content>
+            </licenseHeader>
+          </groovy>
+          <licenseHeader>
+            <content>
+              /*
+              Copyright $YEAR The Kubernetes Authors.
+              Licensed under the Apache License, Version 2.0 (the "License");
+              you may not use this file except in compliance with the License.
+              You may obtain a copy of the License at
+              http://www.apache.org/licenses/LICENSE-2.0
+              Unless required by applicable law or agreed to in writing, software
+              distributed under the License is distributed on an "AS IS" BASIS,
+              WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+              See the License for the specific language governing permissions and
+              limitations under the License.
+              */
+            </content>
+            <delimiter>package </delimiter>
+          </licenseHeader>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <profiles>
     <profile>
@@ -546,8 +555,8 @@
                 <phase>verify</phase>
                 <goals>
                   <goal>sign</goal>
-	        </goals>
-		<configuration>
+                </goals>
+                <configuration>
                   <!-- This is necessary for gpg to not try to use the pinentry programs -->
                   <gpgArguments>
                     <arg>--pinentry-mode</arg>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -14,8 +14,11 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-
   <dependencies>
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.kubernetes</groupId>
       <artifactId>client-java-api</artifactId>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -29,7 +29,6 @@
       <artifactId>client-java-extended</artifactId>
       <version>${project.version}</version>
     </dependency>
-
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>

--- a/spring/src/main/java/io/kubernetes/client/spring/extended/controller/config/KubernetesReconcilerAutoConfiguration.java
+++ b/spring/src/main/java/io/kubernetes/client/spring/extended/controller/config/KubernetesReconcilerAutoConfiguration.java
@@ -17,7 +17,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-@Configuration(proxyBeanMethods = false)
+@Configuration
 @ConditionalOnKubernetesReconcilerEnabled
 public class KubernetesReconcilerAutoConfiguration {
 

--- a/spring/src/main/java/io/kubernetes/client/spring/extended/controller/config/aot/KubernetesBeanFactoryInitializationAotProcessor.java
+++ b/spring/src/main/java/io/kubernetes/client/spring/extended/controller/config/aot/KubernetesBeanFactoryInitializationAotProcessor.java
@@ -1,0 +1,81 @@
+package io.kubernetes.client.spring.extended.controller.config.aot;
+
+
+import com.google.gson.annotations.JsonAdapter;
+import io.swagger.annotations.ApiModel;
+import org.jetbrains.annotations.NotNull;
+import org.reflections.Reflections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.TypeReference;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationAotContribution;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
+
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Registers hints to support Spring Framework 6 and Spring Boot 3 AOT
+ */
+public class KubernetesBeanFactoryInitializationAotProcessor implements BeanFactoryInitializationAotProcessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KubernetesBeanFactoryInitializationAotProcessor.class);
+
+    private final MemberCategory[] allMemberCategories = MemberCategory.values();
+
+    @Override
+    public BeanFactoryInitializationAotContribution processAheadOfTime(
+            @NotNull ConfigurableListableBeanFactory beanFactory) {
+        return (generationContext, beanFactoryInitializationCode) -> {
+            RuntimeHints hints = generationContext.getRuntimeHints();
+            String[] classNames = new String[]{
+                    "com.google.gson.JsonElement",//
+                    "io.kubernetes.client.informer.cache.ProcessorListener", //
+                    "io.kubernetes.client.extended.controller.Controller", //
+                    "io.kubernetes.client.util.generic.GenericKubernetesApi$StatusPatch", //
+                    "io.kubernetes.client.util.Watch$Response" //
+            };
+            for (String className : classNames) {
+                LOGGER.info("registering " + className + " for reflection");
+                hints.reflection().registerType(TypeReference.of(className), allMemberCategories);
+            }
+            registerForPackage("io.kubernetes", hints);
+            Collection<String> packages = AutoConfigurationPackages.get(beanFactory);
+            for (String packageName : packages) {
+                registerForPackage(packageName, hints);
+            }
+        };
+    }
+
+    private void registerForPackage(String packageName, RuntimeHints hints) {
+        Reflections reflections = new Reflections(packageName);
+        Set<Class<?>> apiModels = reflections.getTypesAnnotatedWith(ApiModel.class);
+        Set<Class<?>> jsonAdapters = findJsonAdapters(reflections);
+        Set<Class<?>> all = new HashSet<>();
+        all.addAll(jsonAdapters);
+        all.addAll(apiModels);
+        for (Class<?> clazz : all) {
+            LOGGER.info("registering " + clazz.getName() + " for reflection");
+            hints.reflection().registerType(clazz, allMemberCategories);
+        }
+    }
+
+    private <R extends Annotation> Set<Class<?>> findJsonAdapters(Reflections reflections) {
+        Class<JsonAdapter> jsonAdapterClass = JsonAdapter.class;
+        Set<Class<?>> classes = new HashSet<>();
+        for (Class<?> clazz : reflections.getTypesAnnotatedWith(jsonAdapterClass)) {
+            JsonAdapter annotation = clazz.getAnnotation(jsonAdapterClass);
+            if (null != annotation) {
+                classes.add(annotation.value());
+            }
+            classes.add(clazz);
+        }
+        return classes;
+    }
+}

--- a/spring/src/main/resources/META-INF/spring/aot.factories
+++ b/spring/src/main/resources/META-INF/spring/aot.factories
@@ -1,0 +1,1 @@
+org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor=io.kubernetes.client.spring.extended.controller.config.aot.KubernetesBeanFactoryInitializationAotProcessor

--- a/spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,3 @@
+io.kubernetes.client.spring.extended.controller.config.KubernetesInformerAutoConfiguration
+io.kubernetes.client.spring.extended.controller.config.KubernetesReconcilerAutoConfiguration
+io.kubernetes.client.spring.extended.manifests.config.KubernetesManifestsAutoConfiguration


### PR DESCRIPTION
Hi 

Please find a proof-of-concept introduction of AOT support in Spring Boot 3, per #2398 .

I've tested the proposed changes and they work with both Spring Boot 3 and Spring Boot 2. 

Spring Boot 3 is not yet GA, however. So, i've had to add `snapshot` and `milestone` repositories. Obviously, this won't do in a library like the Kubernetes Java client which needs to be releasable all the time. I'm not sure how you want to handle this. Maybe we create a separate module that doesn't get released and that has the appropriate repositories? Maybe we just stash this PR until [November 24th](https://github.com/spring-projects/spring-boot/milestone/240), when Spring Boot 3 is due to go GA? (maybe a little later than that, who knows...) 
 
Also, for my contribution to work, I need to add a dependency on an external [library called Reflections](https://www.baeldung.com/reflections-library). This is used to capture all the code-generated types for CRDs, for example, in the Kubernetes API _and_ in the user's auto-configured packages in a Spring Boot application. This library is _only_ used at compile time, and _only_ when the user is using Spring Boot 3 AOT compilation. that's not the default. I don't know how to handle that, either. I suppose you could make the package `optional` and then make sure that the interested developer who wnats to use AOT processing gets a warning or something when they try it without that class on the classpath? I don't like that approach very much. It'd be nice if the library was just there and it worked for anybody who wants to build an AOT/ GraalVM native image, out-of-the-box.  

Is there a Maven `scope` i don't know about that limits the lifetime of the binary _explicitly_ to the time the AOT engine runs? 

I tried this new support out on [a sample Kubernetes CRD+Controller demo](https://github.com/kubernetes-native-java/controllers-101) and it works just fine, better than what I was able to do before with Spring Native, actually. From ac consumer's perspective, I didn't have to do anything to make code from the Kubernetes Java client do its magic. I was able to delete code, even. 

thanks for your time and consideration 
