### PR TITLE
Cherrypick(release-15): Bump OkHttp From 4.9.2 To 4.10.0 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <bouncycastle.version>1.70</bouncycastle.version>
     <gson.version>2.9.0</gson.version>
     <jsr305.version>3.0.2</jsr305.version>
-    <okhttp3.version>4.9.2</okhttp3.version>
+    <okhttp3.version>4.10.0</okhttp3.version>
     <swagger-core.version>1.6.5</swagger-core.version>
     <sundrio.version>0.90.0</sundrio.version>
     <gsonfire.version>1.8.5</gsonfire.version>


### PR DESCRIPTION
Picking https://github.com/kubernetes-client/java/pull/2362 to release-15 branch