### PR TITLE
Cherrypick(release-15): Bump protobuf-java from 3.21.9 to 3.21.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <snakeyaml.version>1.30</snakeyaml.version>
     <slf4j.version>1.7.36</slf4j.version>
     <caffeine.version>2.9.3</caffeine.version>
-    <protobuf.version>3.19.4</protobuf.version>
+    <protobuf.version>3.21.8</protobuf.version>
     <junit.version>4.13</junit.version>
     <bucket4j.version>7.3.0</bucket4j.version>
     <bouncycastle.version>1.70</bouncycastle.version>


### PR DESCRIPTION
Picking https://github.com/kubernetes-client/java/pull/2474 to release-15