### PR TITLE
Cherrypick(release-16): Bump okhttp from 4.9.2 to 4.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <bouncycastle.version>1.71</bouncycastle.version>
     <gson.version>2.9.0</gson.version>
     <jsr305.version>3.0.2</jsr305.version>
-    <okhttp3.version>4.9.2</okhttp3.version>
+    <okhttp3.version>4.10.0</okhttp3.version>
     <swagger-core.version>1.6.6</swagger-core.version>
     <sundrio.version>0.91.1</sundrio.version>
     <gsonfire.version>1.8.5</gsonfire.version>


### PR DESCRIPTION
Picking https://github.com/kubernetes-client/java/pull/2362 tot release-16