### PR TITLE
fix  client's timeout  when vip failover

### DIFF
--- a/util/src/main/java/io/kubernetes/client/informer/SharedInformerFactory.java
+++ b/util/src/main/java/io/kubernetes/client/informer/SharedInformerFactory.java
@@ -76,9 +76,6 @@ public class SharedInformerFactory {
    * @param threadPool specified thread pool
    */
   public SharedInformerFactory(ApiClient client, ExecutorService threadPool) {
-    if (client.getReadTimeout() != 0) {
-      throw new IllegalArgumentException("read timeout of ApiClient must be zero");
-    }
 
     apiClient = client;
     informerExecutor = threadPool;


### PR DESCRIPTION
fix when vip failover(base on keepalived+haproxy)，the informer watch data is not updated.