### PR TITLE
Add asynchronous methods to GenericKubernetesApi

### DIFF
--- a/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlAnnotateTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlAnnotateTest.java
@@ -13,6 +13,7 @@ limitations under the License.
 package io.kubernetes.client.extended.kubectl;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
@@ -32,13 +33,13 @@ public class KubectlAnnotateTest {
 
   private ApiClient apiClient;
 
-  @Rule public WireMockRule wireMockRule = new WireMockRule(8384);
+  @Rule public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
   @Before
   public void setup() throws IOException {
     ModelMapper.addModelMap("", "v1", "Pod", "pods", true, V1Pod.class);
     ModelMapper.addModelMap("", "v1", "Node", "nodes", false, V1Node.class);
-    apiClient = new ClientBuilder().setBasePath("http://localhost:" + 8384).build();
+    apiClient = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
   }
 
   @Test

--- a/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlApplyTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlApplyTest.java
@@ -17,6 +17,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.patch;
 import static com.github.tomakehurst.wiremock.client.WireMock.patchRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.Assert.assertNotNull;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
@@ -59,11 +60,11 @@ public class KubectlApplyTest {
 
   private ApiClient apiClient;
 
-  @Rule public WireMockRule wireMockRule = new WireMockRule(8384);
+  @Rule public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
   @Before
   public void setup() throws IOException {
-    apiClient = new ClientBuilder().setBasePath("http://localhost:" + 8384).build();
+    apiClient = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
   }
 
   @Test

--- a/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlCreateTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlCreateTest.java
@@ -13,6 +13,7 @@ limitations under the License.
 package io.kubernetes.client.extended.kubectl;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.Assert.assertNotNull;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
@@ -51,11 +52,11 @@ public class KubectlCreateTest {
 
   private ApiClient apiClient;
 
-  @Rule public WireMockRule wireMockRule = new WireMockRule(8384);
+  @Rule public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
   @Before
   public void setup() throws IOException {
-    apiClient = new ClientBuilder().setBasePath("http://localhost:" + 8384).build();
+    apiClient = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
   }
 
   @Test

--- a/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlLabelTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlLabelTest.java
@@ -20,6 +20,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
 import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
@@ -39,13 +40,13 @@ public class KubectlLabelTest {
 
   private ApiClient apiClient;
 
-  @Rule public WireMockRule wireMockRule = new WireMockRule(8384);
+  @Rule public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
   @Before
   public void setup() throws IOException {
     ModelMapper.addModelMap("", "v1", "Pod", "pods", true, V1Pod.class);
     ModelMapper.addModelMap("", "v1", "Node", "nodes", false, V1Node.class);
-    apiClient = new ClientBuilder().setBasePath("http://localhost:" + 8384).build();
+    apiClient = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
   }
 
   @Test

--- a/util/src/main/java/io/kubernetes/client/util/generic/GenericKubernetesApi.java
+++ b/util/src/main/java/io/kubernetes/client/util/generic/GenericKubernetesApi.java
@@ -198,7 +198,7 @@ public class GenericKubernetesApi<
    * @return future for the kubernetes api response
    */
   public Future<KubernetesApiResponse<ApiType>> getAsync(String name,
-                                                         Consumer<KubernetesApiResponse<ApiType>> callback) {
+                                                         @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     return getAsync(name, new GetOptions(), callback);
   }
 
@@ -211,7 +211,7 @@ public class GenericKubernetesApi<
    * @return future for the kubernetes api response
    */
   public Future<KubernetesApiResponse<ApiType>> getAsync(String namespace, String name,
-                                                         Consumer<KubernetesApiResponse<ApiType>> callback) {
+                                                         @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     return getAsync(namespace, name, new GetOptions(), callback);
   }
 
@@ -240,7 +240,8 @@ public class GenericKubernetesApi<
    * @param callback the callback
    * @return future for the kubernetes api response
    */
-  public Future<KubernetesApiResponse<ApiListType>> listAsync(Consumer<KubernetesApiResponse<ApiListType>> callback) {
+  public Future<KubernetesApiResponse<ApiListType>> listAsync(
+      @Nonnull Consumer<KubernetesApiResponse<ApiListType>> callback) {
     return listAsync(new ListOptions(), callback);
   }
 
@@ -251,8 +252,8 @@ public class GenericKubernetesApi<
    * @param callback the callback
    * @return future for the kubernetes api response
    */
-  public Future<KubernetesApiResponse<ApiListType>> listAsync(String namespace,
-                                                              Consumer<KubernetesApiResponse<ApiListType>> callback) {
+  public Future<KubernetesApiResponse<ApiListType>> listAsync(
+      String namespace, @Nonnull Consumer<KubernetesApiResponse<ApiListType>> callback) {
     return listAsync(namespace, new ListOptions(), callback);
   }
 
@@ -275,8 +276,8 @@ public class GenericKubernetesApi<
    * @param callback the callback
    * @return future for the kubernetes api response
    */
-  public Future<KubernetesApiResponse<ApiType>> createAsync(ApiType object,
-                                                            Consumer<KubernetesApiResponse<ApiType>> callback) {
+  public Future<KubernetesApiResponse<ApiType>> createAsync(
+      ApiType object, @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     return createAsync(object, new CreateOptions(), callback);
   }
 
@@ -299,8 +300,8 @@ public class GenericKubernetesApi<
    * @param callback the callback
    * @return future for the kubernetes api response
    */
-  public Future<KubernetesApiResponse<ApiType>> updateAsync(ApiType object,
-                                                            Consumer<KubernetesApiResponse<ApiType>> callback) {
+  public Future<KubernetesApiResponse<ApiType>> updateAsync(
+      ApiType object, @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     return updateAsync(object, new UpdateOptions(), callback);
   }
 
@@ -340,7 +341,7 @@ public class GenericKubernetesApi<
    * @return future for the kubernetes api response
    */
   public Future<KubernetesApiResponse<ApiType>> patchAsync(String name, String patchType, V1Patch patch,
-                                                           Consumer<KubernetesApiResponse<ApiType>> callback) {
+                                                           @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     return patchAsync(name, patchType, patch, new PatchOptions(), callback);
   }
 
@@ -355,7 +356,7 @@ public class GenericKubernetesApi<
    */
   public Future<KubernetesApiResponse<ApiType>> patchAsync(
       String namespace, String name, String patchType, V1Patch patch,
-      Consumer<KubernetesApiResponse<ApiType>> callback) {
+      @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     return patchAsync(namespace, name, patchType, patch, new PatchOptions(), callback);
   }
 
@@ -387,8 +388,8 @@ public class GenericKubernetesApi<
    * @param callback the callback
    * @return future for the kubernetes api response
    */
-  public Future<KubernetesApiResponse<ApiType>> deleteAsync(String name,
-                                                            Consumer<KubernetesApiResponse<ApiType>> callback) {
+  public Future<KubernetesApiResponse<ApiType>> deleteAsync(
+      String name, @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     return deleteAsync(name, new DeleteOptions(), callback);
   }
 
@@ -400,8 +401,8 @@ public class GenericKubernetesApi<
    * @param callback the callback
    * @return future for the kubernetes api response
    */
-  public Future<KubernetesApiResponse<ApiType>> deleteAsync(String namespace, String name,
-                                                            Consumer<KubernetesApiResponse<ApiType>> callback) {
+  public Future<KubernetesApiResponse<ApiType>> deleteAsync(
+      String namespace, String name, @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     return deleteAsync(namespace, name, new DeleteOptions(), callback);
   }
 
@@ -445,7 +446,7 @@ public class GenericKubernetesApi<
         makeClusterGetCallBuilder(name, getOptions));
   }
 
-  private CallBuilder makeClusterGetCallBuilder(String name, GetOptions getOptions) {
+  private CallBuilder makeClusterGetCallBuilder(String name, final GetOptions getOptions) {
     return () ->
         customObjectsApi.getClusterCustomObjectCall(
             this.apiGroup, this.apiVersion, this.resourcePlural, name, null);
@@ -460,7 +461,7 @@ public class GenericKubernetesApi<
    * @return future for the kubernetes api response
    */
   public Future<KubernetesApiResponse<ApiType>> getAsync(String name, final GetOptions getOptions,
-                                                         Consumer<KubernetesApiResponse<ApiType>> callback) {
+                                                         @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     if (Strings.isNullOrEmpty(name)) {
       throw new IllegalArgumentException("invalid name");
     }
@@ -508,7 +509,8 @@ public class GenericKubernetesApi<
    * @return future for the kubernetes api response
    */
   public Future<KubernetesApiResponse<ApiType>> getAsync(
-      String namespace, String name, final GetOptions getOptions, Consumer<KubernetesApiResponse<ApiType>> callback) {
+      String namespace, String name, final GetOptions getOptions,
+      @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     if (Strings.isNullOrEmpty(name)) {
       throw new IllegalArgumentException("invalid name");
     }
@@ -596,8 +598,8 @@ public class GenericKubernetesApi<
    * @param callback the callback
    * @return future for the kubernetes api response
    */
-  public Future<KubernetesApiResponse<ApiListType>> listAsync(final ListOptions listOptions,
-                                                              Consumer<KubernetesApiResponse<ApiListType>> callback) {
+  public Future<KubernetesApiResponse<ApiListType>> listAsync(
+      final ListOptions listOptions, @Nonnull Consumer<KubernetesApiResponse<ApiListType>> callback) {
     return executeCallAsync(
         customObjectsApi.getApiClient(),
         apiListTypeClass,
@@ -613,8 +615,8 @@ public class GenericKubernetesApi<
    * @param callback the callback
    * @return future for the kubernetes api response
    */
-  public Future<KubernetesApiResponse<ApiListType>> listAsync(String namespace, final ListOptions listOptions,
-                                                              Consumer<KubernetesApiResponse<ApiListType>> callback) {
+  public Future<KubernetesApiResponse<ApiListType>> listAsync(
+      String namespace, final ListOptions listOptions, @Nonnull Consumer<KubernetesApiResponse<ApiListType>> callback) {
     if (Strings.isNullOrEmpty(namespace)) {
       throw new IllegalArgumentException("invalid namespace");
     }
@@ -674,8 +676,8 @@ public class GenericKubernetesApi<
         makeNamespacedCreateCallBuilder(namespace, object, createOptions));
   }
 
-  private CallBuilder makeNamespacedCreateCallBuilder(String namespace, ApiType object, final
-  CreateOptions createOptions) {
+  private CallBuilder makeNamespacedCreateCallBuilder(
+      String namespace, ApiType object, final CreateOptions createOptions) {
     // TODO(yue9944882): judge namespaced object via api discovery
     return () -> customObjectsApi.createNamespacedCustomObjectCall(
         this.apiGroup,
@@ -697,8 +699,8 @@ public class GenericKubernetesApi<
    * @param callback the callback
    * @return future for the kubernetes api response
    */
-  public Future<KubernetesApiResponse<ApiType>> createAsync(ApiType object, final CreateOptions createOptions,
-                                                            Consumer<KubernetesApiResponse<ApiType>> callback) {
+  public Future<KubernetesApiResponse<ApiType>> createAsync(
+      ApiType object, final CreateOptions createOptions, @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     V1ObjectMeta objectMeta = object.getMetadata();
 
     boolean isNamespaced = !Strings.isNullOrEmpty(objectMeta.getNamespace());
@@ -721,9 +723,9 @@ public class GenericKubernetesApi<
    * @param callback the callback
    * @return future for the kubernetes api response
    */
-  public Future<KubernetesApiResponse<ApiType>> createAsync(String namespace, ApiType object,
-                                                            final CreateOptions createOptions,
-                                                            Consumer<KubernetesApiResponse<ApiType>> callback) {
+  public Future<KubernetesApiResponse<ApiType>> createAsync(
+      String namespace, ApiType object, final CreateOptions createOptions,
+      @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     return executeCallAsync(
         customObjectsApi.getApiClient(),
         apiTypeClass,
@@ -780,8 +782,8 @@ public class GenericKubernetesApi<
    * @param callback the callback
    * @return future for the kubernetes api response
    */
-  public Future<KubernetesApiResponse<ApiType>> updateAsync(ApiType object, final UpdateOptions updateOptions,
-                                                            Consumer<KubernetesApiResponse<ApiType>> callback) {
+  public Future<KubernetesApiResponse<ApiType>> updateAsync(
+      ApiType object, final UpdateOptions updateOptions, @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     return executeCallAsync(
         customObjectsApi.getApiClient(),
         apiTypeClass,
@@ -858,7 +860,7 @@ public class GenericKubernetesApi<
    * @return future for the kubernetes api response
    */
   public Future<KubernetesApiResponse<ApiType>> updateStatusAsync(
-      ApiType object, Function<ApiType, Object> status, Consumer<KubernetesApiResponse<ApiType>> callback) {
+      ApiType object, Function<ApiType, Object> status, @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     return updateStatusAsync(object, status, new UpdateOptions(), callback);
   }
 
@@ -873,7 +875,7 @@ public class GenericKubernetesApi<
    */
   public Future<KubernetesApiResponse<ApiType>> updateStatusAsync(
       ApiType object, Function<ApiType, Object> status, final UpdateOptions updateOptions,
-      Consumer<KubernetesApiResponse<ApiType>> callback) {
+      @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     return executeCallAsync(
         customObjectsApi.getApiClient(),
         apiTypeClass,
@@ -980,7 +982,7 @@ public class GenericKubernetesApi<
    */
   public Future<KubernetesApiResponse<ApiType>> patchAsync(
       String name, String patchType, V1Patch patch, final PatchOptions patchOptions,
-      Consumer<KubernetesApiResponse<ApiType>> callback) {
+      @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     if (Strings.isNullOrEmpty(name)) {
       throw new IllegalArgumentException("invalid name");
     }
@@ -1009,7 +1011,7 @@ public class GenericKubernetesApi<
       String patchType,
       V1Patch patch,
       final PatchOptions patchOptions,
-      Consumer<KubernetesApiResponse<ApiType>> callback) {
+      @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     if (Strings.isNullOrEmpty(namespace)) {
       throw new IllegalArgumentException("invalid namespace");
     }
@@ -1040,7 +1042,7 @@ public class GenericKubernetesApi<
         makeClusterDeleteCallBuilder(name, deleteOptions));
   }
 
-  private CallBuilder makeClusterDeleteCallBuilder(String name, DeleteOptions deleteOptions) {
+  private CallBuilder makeClusterDeleteCallBuilder(String name, final DeleteOptions deleteOptions) {
     return () -> customObjectsApi.deleteClusterCustomObjectCall(
         this.apiGroup,
         this.apiVersion,
@@ -1100,8 +1102,8 @@ public class GenericKubernetesApi<
    * @param callback the callback
    * @return future for the kubernetes api response
    */
-  public Future<KubernetesApiResponse<ApiType>> deleteAsync(String name, final DeleteOptions deleteOptions,
-                                                            Consumer<KubernetesApiResponse<ApiType>> callback) {
+  public Future<KubernetesApiResponse<ApiType>> deleteAsync(
+      String name, final DeleteOptions deleteOptions, @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     if (Strings.isNullOrEmpty(name)) {
       throw new IllegalArgumentException("invalid name");
     }
@@ -1123,7 +1125,7 @@ public class GenericKubernetesApi<
    */
   public Future<KubernetesApiResponse<ApiType>> deleteAsync(
       String namespace, String name, final DeleteOptions deleteOptions,
-      Consumer<KubernetesApiResponse<ApiType>> callback) {
+      @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     if (Strings.isNullOrEmpty(namespace)) {
       throw new IllegalArgumentException("invalid namespace");
     }
@@ -1269,8 +1271,8 @@ public class GenericKubernetesApi<
 
   }
 
-  private <DataType extends KubernetesType> Call prepareCall(CallBuilder callBuilder,
-                                                             Consumer<KubernetesApiResponse<DataType>> callback)
+  private <DataType extends KubernetesType> Call prepareCall(
+      CallBuilder callBuilder, @Nonnull Consumer<KubernetesApiResponse<DataType>> callback)
       throws ApiException {
     Call call = prepareCall(callBuilder);
 
@@ -1284,7 +1286,7 @@ public class GenericKubernetesApi<
 
   private <DataType extends KubernetesType> Future<KubernetesApiResponse<DataType>> executeCallAsync(
       ApiClient apiClient, Class<DataType> dataClass, CallBuilder callBuilder,
-      Consumer<KubernetesApiResponse<DataType>> callback) {
+      @Nonnull Consumer<KubernetesApiResponse<DataType>> callback) {
     try {
       Call call = prepareCall(callBuilder, callback);
       CountDownLatch latch = new CountDownLatch(1);
@@ -1293,19 +1295,23 @@ public class GenericKubernetesApi<
       apiClient.executeAsync(call, JsonElement.class, new ApiCallback<JsonElement>() {
         @Override
         public void onFailure(ApiException e, int statusCode, Map<String, List<String>> responseHeaders) {
-          KubernetesApiResponse<DataType> r = responseFromApiException(apiClient, e);
-          result.set(r);
-          latch.countDown();
-          callback.accept(r);
+          if (latch.getCount() > 0) {
+            KubernetesApiResponse<DataType> r = responseFromApiException(apiClient, e);
+            result.set(r);
+            latch.countDown();
+            callback.accept(r);
+          }
         }
 
         @Override
         public void onSuccess(JsonElement element, int statusCode, Map<String, List<String>> responseHeaders) {
           KubernetesApiResponse<DataType> r = getKubernetesApiResponse(
               dataClass, element, apiClient.getJSON().getGson());
-          result.set(r);
-          latch.countDown();
-          callback.accept(r);
+          if (latch.getCount() > 0) {
+            result.set(r);
+            latch.countDown();
+            callback.accept(r);
+          }
         }
 
         @Override

--- a/util/src/main/java/io/kubernetes/client/util/generic/GenericKubernetesApi.java
+++ b/util/src/main/java/io/kubernetes/client/util/generic/GenericKubernetesApi.java
@@ -20,13 +20,14 @@ import io.kubernetes.client.common.KubernetesListObject;
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.common.KubernetesType;
 import io.kubernetes.client.custom.V1Patch;
+import io.kubernetes.client.openapi.ApiCallback;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.Configuration;
 import io.kubernetes.client.openapi.apis.CustomObjectsApi;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Status;
-import io.kubernetes.client.util.PatchUtils;
+import io.kubernetes.client.util.ProxyContentTypeRequestBody;
 import io.kubernetes.client.util.Strings;
 import io.kubernetes.client.util.Watch;
 import io.kubernetes.client.util.Watchable;
@@ -38,9 +39,20 @@ import io.kubernetes.client.util.generic.options.PatchOptions;
 import io.kubernetes.client.util.generic.options.UpdateOptions;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Function;
+import javax.annotation.Nonnull;
 import okhttp3.Call;
 import okhttp3.HttpUrl;
+import okhttp3.Request;
 
 /**
  * The Generic kubernetes api provides a unified client interface for not only the non-core-group
@@ -69,12 +81,12 @@ public class GenericKubernetesApi<
   // TODO(yue9944882): supports generic sub-resource operations..
   // TODO(yue9944882): supports delete-collections..
 
-  private Class<ApiType> apiTypeClass;
-  private Class<ApiListType> apiListTypeClass;
-  private String apiGroup;
-  private String apiVersion;
-  private String resourcePlural;
-  private CustomObjectsApi customObjectsApi;
+  private final Class<ApiType> apiTypeClass;
+  private final Class<ApiListType> apiListTypeClass;
+  private final String apiGroup;
+  private final String apiVersion;
+  private final String resourcePlural;
+  private final CustomObjectsApi customObjectsApi;
 
   /**
    * Instantiates a new Generic kubernetes api.
@@ -104,7 +116,7 @@ public class GenericKubernetesApi<
    * Instantiates a new Generic kubernetes api.
    *
    * @param apiTypeClass the api type class, e.g. V1Job.class
-   * @param apiListTypeClass the api list type class e.g V1JobList.class
+   * @param apiListTypeClass the api list type class e.g. V1JobList.class
    * @param apiGroup the api group
    * @param apiVersion the api version
    * @param resourcePlural the resource plural, e.g. "jobs"
@@ -130,7 +142,7 @@ public class GenericKubernetesApi<
    * Instantiates a new Generic kubernetes api with the ApiClient specified.
    *
    * @param apiTypeClass the api type class, e.g. V1Job.class
-   * @param apiListTypeClass the api list type class e.g V1JobList.class
+   * @param apiListTypeClass the api list type class e.g. V1JobList.class
    * @param apiGroup the api group
    * @param apiVersion the api version
    * @param resourcePlural the resource plural, e.g. "jobs"
@@ -173,6 +185,31 @@ public class GenericKubernetesApi<
   }
 
   /**
+   * Get kubernetes api response.
+   *
+   * @param name the name
+   * @param callback the callback
+   * @return future for the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiType>> getAsync(String name,
+                                                         Consumer<KubernetesApiResponse<ApiType>> callback) {
+    return getAsync(name, new GetOptions(), callback);
+  }
+
+  /**
+   * Get kubernetes api response under the namespace.
+   *
+   * @param namespace the namespace
+   * @param name the name
+   * @param callback the callback
+   * @return future for the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiType>> getAsync(String namespace, String name,
+                                                         Consumer<KubernetesApiResponse<ApiType>> callback) {
+    return getAsync(namespace, name, new GetOptions(), callback);
+  }
+
+  /**
    * List kubernetes api response cluster-scoped.
    *
    * @return the kubernetes api response
@@ -192,6 +229,28 @@ public class GenericKubernetesApi<
   }
 
   /**
+   * List kubernetes api response cluster-scoped.
+   *
+   * @param callback the callback
+   * @return future for the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiListType>> listAsync(Consumer<KubernetesApiResponse<ApiListType>> callback) {
+    return listAsync(new ListOptions(), callback);
+  }
+
+  /**
+   * List kubernetes api response under the namespace.
+   *
+   * @param namespace the namespace
+   * @param callback the callback
+   * @return future for the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiListType>> listAsync(String namespace,
+                                                              Consumer<KubernetesApiResponse<ApiListType>> callback) {
+    return listAsync(namespace, new ListOptions(), callback);
+  }
+
+  /**
    * Create kubernetes api response, if the namespace in the object is present, it will send a
    * namespace-scoped requests, vice versa.
    *
@@ -207,10 +266,36 @@ public class GenericKubernetesApi<
    * namespace-scoped requests, vice versa.
    *
    * @param object the object
+   * @param callback the callback
+   * @return future for the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiType>> createAsync(ApiType object,
+                                                            Consumer<KubernetesApiResponse<ApiType>> callback) {
+    return createAsync(object, new CreateOptions(), callback);
+  }
+
+  /**
+   * Create kubernetes api response, if the namespace in the object is present, it will send a
+   * namespace-scoped requests, vice versa.
+   *
+   * @param object the object
    * @return the kubernetes api response
    */
   public KubernetesApiResponse<ApiType> update(ApiType object) {
     return update(object, new UpdateOptions());
+  }
+
+  /**
+   * Create kubernetes api response, if the namespace in the object is present, it will send a
+   * namespace-scoped requests, vice versa.
+   *
+   * @param object the object
+   * @param callback the callback
+   * @return future for the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiType>> updateAsync(ApiType object,
+                                                            Consumer<KubernetesApiResponse<ApiType>> callback) {
+    return updateAsync(object, new UpdateOptions(), callback);
   }
 
   /**
@@ -240,6 +325,35 @@ public class GenericKubernetesApi<
   }
 
   /**
+   * Patch kubernetes api response.
+   *
+   * @param name the name
+   * @param patchType the patch type, supported values defined in V1Patch
+   * @param patch the string patch content
+   * @param callback the callback
+   * @return future for the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiType>> patchAsync(String name, String patchType, V1Patch patch,
+                                                           Consumer<KubernetesApiResponse<ApiType>> callback) {
+    return patchAsync(name, patchType, patch, new PatchOptions(), callback);
+  }
+
+  /**
+   * Patch kubernetes api response under the namespace.
+   *
+   * @param namespace the namespace
+   * @param name the name
+   * @param patchType the patch type, supported values defined in V1Patch
+   * @param patch the string patch content
+   * @return the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiType>> patchAsync(
+      String namespace, String name, String patchType, V1Patch patch,
+      Consumer<KubernetesApiResponse<ApiType>> callback) {
+    return patchAsync(namespace, name, patchType, patch, new PatchOptions(), callback);
+  }
+
+  /**
    * Delete kubernetes api response.
    *
    * @param name the name
@@ -258,6 +372,31 @@ public class GenericKubernetesApi<
    */
   public KubernetesApiResponse<ApiType> delete(String namespace, String name) {
     return delete(namespace, name, new DeleteOptions());
+  }
+
+  /**
+   * Delete kubernetes api response.
+   *
+   * @param name the name
+   * @param callback the callback
+   * @return future for the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiType>> deleteAsync(String name,
+                                                            Consumer<KubernetesApiResponse<ApiType>> callback) {
+    return deleteAsync(name, new DeleteOptions(), callback);
+  }
+
+  /**
+   * Delete kubernetes api response under the namespace.
+   *
+   * @param namespace the namespace
+   * @param name the name
+   * @param callback the callback
+   * @return future for the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiType>> deleteAsync(String namespace, String name,
+                                                            Consumer<KubernetesApiResponse<ApiType>> callback) {
+    return deleteAsync(namespace, name, new DeleteOptions(), callback);
   }
 
   /**
@@ -292,14 +431,38 @@ public class GenericKubernetesApi<
    */
   public KubernetesApiResponse<ApiType> get(String name, final GetOptions getOptions) {
     if (Strings.isNullOrEmpty(name)) {
-      throw new IllegalArgumentException("invalid namespace");
+      throw new IllegalArgumentException("invalid name");
     }
     return executeCall(
         customObjectsApi.getApiClient(),
         apiTypeClass,
-        () ->
-            customObjectsApi.getClusterCustomObjectCall(
-                this.apiGroup, this.apiVersion, this.resourcePlural, name, null));
+        makeClusterGetCallBuilder(name, getOptions));
+  }
+
+  private CallBuilder makeClusterGetCallBuilder(String name, GetOptions getOptions) {
+    return () ->
+        customObjectsApi.getClusterCustomObjectCall(
+            this.apiGroup, this.apiVersion, this.resourcePlural, name, null);
+  }
+
+  /**
+   * Get kubernetes api response.
+   *
+   * @param name the name
+   * @param getOptions the get options
+   * @param callback the callback
+   * @return future for the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiType>> getAsync(String name, final GetOptions getOptions,
+                                                         Consumer<KubernetesApiResponse<ApiType>> callback) {
+    if (Strings.isNullOrEmpty(name)) {
+      throw new IllegalArgumentException("invalid name");
+    }
+    return executeCallAsync(
+        customObjectsApi.getApiClient(),
+        apiTypeClass,
+        makeClusterGetCallBuilder(name, getOptions),
+        callback);
   }
 
   /**
@@ -321,10 +484,36 @@ public class GenericKubernetesApi<
     return executeCall(
         customObjectsApi.getApiClient(),
         apiTypeClass,
-        () -> {
-          return customObjectsApi.getNamespacedCustomObjectCall(
-              this.apiGroup, this.apiVersion, namespace, this.resourcePlural, name, null);
-        });
+        makeNamespacedGetCallBuilder(namespace, name, getOptions));
+  }
+
+  private CallBuilder makeNamespacedGetCallBuilder(String namespace, String name, final GetOptions getOptions) {
+    return () -> customObjectsApi.getNamespacedCustomObjectCall(
+        this.apiGroup, this.apiVersion, namespace, this.resourcePlural, name, null);
+  }
+
+  /**
+   * Get kubernetes api response.
+   *
+   * @param namespace the namespace
+   * @param name the name
+   * @param getOptions the get options
+   * @param callback the callback
+   * @return future for the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiType>> getAsync(
+      String namespace, String name, final GetOptions getOptions, Consumer<KubernetesApiResponse<ApiType>> callback) {
+    if (Strings.isNullOrEmpty(name)) {
+      throw new IllegalArgumentException("invalid name");
+    }
+    if (Strings.isNullOrEmpty(namespace)) {
+      throw new IllegalArgumentException("invalid namespace");
+    }
+    return executeCallAsync(
+        customObjectsApi.getApiClient(),
+        apiTypeClass,
+        makeNamespacedGetCallBuilder(namespace, name, getOptions),
+        callback);
   }
 
   /**
@@ -337,23 +526,25 @@ public class GenericKubernetesApi<
     return executeCall(
         customObjectsApi.getApiClient(),
         apiListTypeClass,
-        () -> {
-          return customObjectsApi.listClusterCustomObjectCall(
-              this.apiGroup,
-              this.apiVersion,
-              this.resourcePlural,
-              null,
-              false,
-              listOptions.getContinue(),
-              listOptions.getFieldSelector(),
-              listOptions.getLabelSelector(),
-              listOptions.getLimit(),
-              listOptions.getResourceVersion(),
-              null,
-              listOptions.getTimeoutSeconds(),
-              false,
-              null);
-        });
+        makeClusterListCallBuilder(listOptions));
+  }
+
+  private CallBuilder makeClusterListCallBuilder(final ListOptions listOptions) {
+    return () -> customObjectsApi.listClusterCustomObjectCall(
+        this.apiGroup,
+        this.apiVersion,
+        this.resourcePlural,
+        null,
+        false,
+        listOptions.getContinue(),
+        listOptions.getFieldSelector(),
+        listOptions.getLabelSelector(),
+        listOptions.getLimit(),
+        listOptions.getResourceVersion(),
+        null,
+        listOptions.getTimeoutSeconds(),
+        false,
+        null);
   }
 
   /**
@@ -370,24 +561,62 @@ public class GenericKubernetesApi<
     return executeCall(
         customObjectsApi.getApiClient(),
         apiListTypeClass,
-        () -> {
-          return customObjectsApi.listNamespacedCustomObjectCall(
-              this.apiGroup,
-              this.apiVersion,
-              namespace,
-              this.resourcePlural,
-              null,
-              null,
-              listOptions.getContinue(),
-              listOptions.getFieldSelector(),
-              listOptions.getLabelSelector(),
-              listOptions.getLimit(),
-              listOptions.getResourceVersion(),
-              null,
-              listOptions.getTimeoutSeconds(),
-              false,
-              null);
-        });
+        makeNamespacedListCallBuilder(namespace, listOptions));
+  }
+
+  private CallBuilder makeNamespacedListCallBuilder(String namespace, final ListOptions listOptions) {
+    return () -> customObjectsApi.listNamespacedCustomObjectCall(
+        this.apiGroup,
+        this.apiVersion,
+        namespace,
+        this.resourcePlural,
+        null,
+        null,
+        listOptions.getContinue(),
+        listOptions.getFieldSelector(),
+        listOptions.getLabelSelector(),
+        listOptions.getLimit(),
+        listOptions.getResourceVersion(),
+        null,
+        listOptions.getTimeoutSeconds(),
+        false,
+        null);
+  }
+
+  /**
+   * List kubernetes api response.
+   *
+   * @param listOptions the list options
+   * @param callback the callback
+   * @return future for the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiListType>> listAsync(final ListOptions listOptions,
+                                                              Consumer<KubernetesApiResponse<ApiListType>> callback) {
+    return executeCallAsync(
+        customObjectsApi.getApiClient(),
+        apiListTypeClass,
+        makeClusterListCallBuilder(listOptions),
+        callback);
+  }
+
+  /**
+   * List kubernetes api response.
+   *
+   * @param namespace the namespace
+   * @param listOptions the list options
+   * @param callback the callback
+   * @return future for the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiListType>> listAsync(String namespace, final ListOptions listOptions,
+                                                              Consumer<KubernetesApiResponse<ApiListType>> callback) {
+    if (Strings.isNullOrEmpty(namespace)) {
+      throw new IllegalArgumentException("invalid namespace");
+    }
+    return executeCallAsync(
+        customObjectsApi.getApiClient(),
+        apiListTypeClass,
+        makeNamespacedListCallBuilder(namespace, listOptions),
+        callback);
   }
 
   /**
@@ -408,38 +637,92 @@ public class GenericKubernetesApi<
     return executeCall(
         customObjectsApi.getApiClient(),
         apiTypeClass,
-        () -> {
-          // TODO(yue9944882): judge namespaced object via api discovery
-          return customObjectsApi.createClusterCustomObjectCall(
-              this.apiGroup,
-              this.apiVersion,
-              this.resourcePlural,
-              object,
-              null,
-              createOptions.getDryRun(),
-              createOptions.getFieldManager(),
-              null);
-        });
+        makeClusterCreateCallBuilder(object, createOptions));
   }
 
-  public KubernetesApiResponse<ApiType> create(
-      String namespace, ApiType object, final CreateOptions createOptions) {
+  private CallBuilder makeClusterCreateCallBuilder(ApiType object, final CreateOptions createOptions) {
+    // TODO(yue9944882): judge namespaced object via api discovery
+    return () -> customObjectsApi.createClusterCustomObjectCall(
+        this.apiGroup,
+        this.apiVersion,
+        this.resourcePlural,
+        object,
+        null,
+        createOptions.getDryRun(),
+        createOptions.getFieldManager(),
+        null);
+  }
+
+  /**
+   * Create kubernetes api response.
+   *
+   * @param namespace the namespace
+   * @param object the object
+   * @param createOptions the create options
+   * @return the kubernetes api response
+   */
+  public KubernetesApiResponse<ApiType> create(String namespace, ApiType object, final CreateOptions createOptions) {
     return executeCall(
         customObjectsApi.getApiClient(),
         apiTypeClass,
-        () -> {
-          // TODO(yue9944882): judge namespaced object via api discovery
-          return customObjectsApi.createNamespacedCustomObjectCall(
-              this.apiGroup,
-              this.apiVersion,
-              namespace,
-              this.resourcePlural,
-              object,
-              null,
-              createOptions.getDryRun(),
-              createOptions.getFieldManager(),
-              null);
-        });
+        makeNamespacedCreateCallBuilder(namespace, object, createOptions));
+  }
+
+  private CallBuilder makeNamespacedCreateCallBuilder(String namespace, ApiType object, final
+  CreateOptions createOptions) {
+    // TODO(yue9944882): judge namespaced object via api discovery
+    return () -> customObjectsApi.createNamespacedCustomObjectCall(
+        this.apiGroup,
+        this.apiVersion,
+        namespace,
+        this.resourcePlural,
+        object,
+        null,
+        createOptions.getDryRun(),
+        createOptions.getFieldManager(),
+        null);
+  }
+
+  /**
+   * Create kubernetes api response.
+   *
+   * @param object the object
+   * @param createOptions the create options
+   * @param callback the callback
+   * @return future for the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiType>> createAsync(ApiType object, final CreateOptions createOptions,
+                                                            Consumer<KubernetesApiResponse<ApiType>> callback) {
+    V1ObjectMeta objectMeta = object.getMetadata();
+
+    boolean isNamespaced = !Strings.isNullOrEmpty(objectMeta.getNamespace());
+    if (isNamespaced) {
+      return createAsync(objectMeta.getNamespace(), object, createOptions, callback);
+    }
+    return executeCallAsync(
+        customObjectsApi.getApiClient(),
+        apiTypeClass,
+        makeClusterCreateCallBuilder(object, createOptions),
+        callback);
+  }
+
+  /**
+   * Create kubernetes api response.
+   *
+   * @param namespace the namespace
+   * @param object the object
+   * @param createOptions the create options
+   * @param callback the callback
+   * @return future for the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiType>> createAsync(String namespace, ApiType object,
+                                                            final CreateOptions createOptions,
+                                                            Consumer<KubernetesApiResponse<ApiType>> callback) {
+    return executeCallAsync(
+        customObjectsApi.getApiClient(),
+        apiTypeClass,
+        makeNamespacedCreateCallBuilder(namespace, object, createOptions),
+        callback);
   }
 
   /**
@@ -450,15 +733,19 @@ public class GenericKubernetesApi<
    * @return the kubernetes api response
    */
   public KubernetesApiResponse<ApiType> update(ApiType object, final UpdateOptions updateOptions) {
-    V1ObjectMeta objectMeta = object.getMetadata();
     return executeCall(
         customObjectsApi.getApiClient(),
         apiTypeClass,
-        () -> {
-          //// TODO(yue9944882): judge namespaced object via api discovery
-          boolean isNamespaced = !Strings.isNullOrEmpty(objectMeta.getNamespace());
-          if (isNamespaced) {
-            return customObjectsApi.replaceNamespacedCustomObjectCall(
+        makeUpdateCallBuilder(object, updateOptions));
+  }
+
+  private CallBuilder makeUpdateCallBuilder(ApiType object, final UpdateOptions updateOptions) {
+    V1ObjectMeta objectMeta = object.getMetadata();
+    boolean isNamespaced = !Strings.isNullOrEmpty(objectMeta.getNamespace());
+    return () ->
+        //// TODO(yue9944882): judge namespaced object via api discovery
+        isNamespaced ?
+            customObjectsApi.replaceNamespacedCustomObjectCall(
                 this.apiGroup,
                 this.apiVersion,
                 objectMeta.getNamespace(),
@@ -467,9 +754,8 @@ public class GenericKubernetesApi<
                 object,
                 updateOptions.getDryRun(),
                 updateOptions.getFieldManager(),
-                null);
-          } else {
-            return customObjectsApi.replaceClusterCustomObjectCall(
+                null) :
+            customObjectsApi.replaceClusterCustomObjectCall(
                 this.apiGroup,
                 this.apiVersion,
                 this.resourcePlural,
@@ -478,8 +764,23 @@ public class GenericKubernetesApi<
                 updateOptions.getDryRun(),
                 updateOptions.getFieldManager(),
                 null);
-          }
-        });
+  }
+
+  /**
+   * Update kubernetes api response.
+   *
+   * @param object the object
+   * @param updateOptions the update options
+   * @param callback the callback
+   * @return future for the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiType>> updateAsync(ApiType object, final UpdateOptions updateOptions,
+                                                            Consumer<KubernetesApiResponse<ApiType>> callback) {
+    return executeCallAsync(
+        customObjectsApi.getApiClient(),
+        apiTypeClass,
+        makeUpdateCallBuilder(object, updateOptions),
+        callback);
   }
 
   /**
@@ -505,15 +806,20 @@ public class GenericKubernetesApi<
    */
   public KubernetesApiResponse<ApiType> updateStatus(
       ApiType object, Function<ApiType, Object> status, final UpdateOptions updateOptions) {
-    V1ObjectMeta objectMeta = object.getMetadata();
     return executeCall(
         customObjectsApi.getApiClient(),
         apiTypeClass,
-        () -> {
-          //// TODO(yue9944882): judge namespaced object via api discovery
-          boolean isNamespaced = !Strings.isNullOrEmpty(objectMeta.getNamespace());
-          if (isNamespaced) {
-            return customObjectsApi.patchNamespacedCustomObjectStatusCall(
+        makeUpdateStatusCallBuilder(object, status, updateOptions));
+  }
+
+  private CallBuilder makeUpdateStatusCallBuilder(ApiType object, Function<ApiType, Object> status,
+                                                  final UpdateOptions updateOptions) {
+    V1ObjectMeta objectMeta = object.getMetadata();
+    boolean isNamespaced = !Strings.isNullOrEmpty(objectMeta.getNamespace());
+    return () ->
+        //// TODO(yue9944882): judge namespaced object via api discovery
+        isNamespaced ?
+            customObjectsApi.patchNamespacedCustomObjectStatusCall(
                 this.apiGroup,
                 this.apiVersion,
                 objectMeta.getNamespace(),
@@ -523,9 +829,8 @@ public class GenericKubernetesApi<
                 updateOptions.getDryRun(),
                 updateOptions.getFieldManager(),
                 null,
-                null);
-          } else {
-            return customObjectsApi.patchClusterCustomObjectStatusCall(
+                null) :
+            customObjectsApi.patchClusterCustomObjectStatusCall(
                 this.apiGroup,
                 this.apiVersion,
                 this.resourcePlural,
@@ -535,8 +840,48 @@ public class GenericKubernetesApi<
                 updateOptions.getFieldManager(),
                 null,
                 null);
-          }
-        });
+  }
+
+  /**
+   * Create kubernetes api response, if the namespace in the object is present, it will send a
+   * namespace-scoped requests, vice versa.
+   *
+   * @param object the object
+   * @param status function to extract the status from the object
+   * @param callback the callback
+   * @return future for the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiType>> updateStatusAsync(
+      ApiType object, Function<ApiType, Object> status, Consumer<KubernetesApiResponse<ApiType>> callback) {
+    return updateStatusAsync(object, status, new UpdateOptions(), callback);
+  }
+
+  /**
+   * Update status of kubernetes api response.
+   *
+   * @param object the object
+   * @param status function to extract the status from the object
+   * @param updateOptions the update options
+   * @param callback the callback
+   * @return future for the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiType>> updateStatusAsync(
+      ApiType object, Function<ApiType, Object> status, final UpdateOptions updateOptions,
+      Consumer<KubernetesApiResponse<ApiType>> callback) {
+    return executeCallAsync(
+        customObjectsApi.getApiClient(),
+        apiTypeClass,
+        makeUpdateStatusCallBuilder(object, status, updateOptions),
+        callback);
+  }
+
+  private Call adaptPatchCall(ApiClient apiClient, Call call, String patchType) {
+    Request request = call.request();
+    return apiClient
+        .getHttpClient()
+        .newCall(request.newBuilder()
+            .patch(new ProxyContentTypeRequestBody(request.body(), patchType))
+            .build());
   }
 
   /**
@@ -553,35 +898,25 @@ public class GenericKubernetesApi<
     if (Strings.isNullOrEmpty(name)) {
       throw new IllegalArgumentException("invalid name");
     }
-    try {
-      ApiType object =
-          PatchUtils.patch(
-              apiTypeClass,
-              () -> {
-                Call call =
-                    customObjectsApi.patchClusterCustomObjectCall(
-                        this.apiGroup,
-                        this.apiVersion,
-                        this.resourcePlural,
-                        name,
-                        patch,
-                        patchOptions.getDryRun(),
-                        patchOptions.getFieldManager(),
-                        patchOptions.getForce(),
-                        null);
-                return tweakCallForCoreV1Group(call);
-              },
-              patchType,
-              this.customObjectsApi.getApiClient());
-      return new KubernetesApiResponse<ApiType>(object);
-    } catch (ApiException e) {
-      V1Status status =
-          customObjectsApi
-              .getApiClient()
-              .getJSON()
-              .deserialize(e.getResponseBody(), V1Status.class);
-      return new KubernetesApiResponse<>(status, e.getCode());
-    }
+
+    return executeCall(
+        customObjectsApi.getApiClient(),
+        apiTypeClass,
+        makeClusterPatchCallBuilder(name, patchType, patch, patchOptions));
+  }
+
+  private CallBuilder makeClusterPatchCallBuilder(String name, String patchType,
+                                                  V1Patch patch, final PatchOptions patchOptions) {
+    return () -> adaptPatchCall(customObjectsApi.getApiClient(), customObjectsApi.patchClusterCustomObjectCall(
+        this.apiGroup,
+        this.apiVersion,
+        this.resourcePlural,
+        name,
+        patch,
+        patchOptions.getDryRun(),
+        patchOptions.getFieldManager(),
+        patchOptions.getForce(),
+        null), patchType);
   }
 
   /**
@@ -606,36 +941,80 @@ public class GenericKubernetesApi<
     if (Strings.isNullOrEmpty(name)) {
       throw new IllegalArgumentException("invalid name");
     }
-    try {
-      ApiType object =
-          PatchUtils.patch(
-              apiTypeClass,
-              () -> {
-                Call call =
-                    customObjectsApi.patchNamespacedCustomObjectCall(
-                        this.apiGroup,
-                        this.apiVersion,
-                        namespace,
-                        this.resourcePlural,
-                        name,
-                        patch,
-                        patchOptions.getDryRun(),
-                        patchOptions.getFieldManager(),
-                        patchOptions.getForce(),
-                        null);
-                return tweakCallForCoreV1Group(call);
-              },
-              patchType,
-              this.customObjectsApi.getApiClient());
-      return new KubernetesApiResponse<ApiType>(object);
-    } catch (ApiException e) {
-      V1Status status =
-          customObjectsApi
-              .getApiClient()
-              .getJSON()
-              .deserialize(e.getResponseBody(), V1Status.class);
-      return new KubernetesApiResponse<>(status, e.getCode());
+    return executeCall(
+        customObjectsApi.getApiClient(),
+        apiTypeClass,
+        makeNamespacedPatchCallBuilder(namespace, name, patchType, patch, patchOptions));
+  }
+
+  private CallBuilder makeNamespacedPatchCallBuilder(String namespace, String name, String patchType,
+                                                     V1Patch patch, final PatchOptions patchOptions) {
+    return () -> adaptPatchCall(customObjectsApi.getApiClient(), customObjectsApi.patchNamespacedCustomObjectCall(
+        this.apiGroup,
+        this.apiVersion,
+        namespace,
+        this.resourcePlural,
+        name,
+        patch,
+        patchOptions.getDryRun(),
+        patchOptions.getFieldManager(),
+        patchOptions.getForce(),
+        null), patchType);
+  }
+
+  /**
+   * Patch kubernetes api response.
+   *
+   * @param name the name
+   * @param patchType the patch type
+   * @param patch the patch
+   * @param patchOptions the patch options
+   * @param callback the callback
+   * @return future for the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiType>> patchAsync(
+      String name, String patchType, V1Patch patch, final PatchOptions patchOptions,
+      Consumer<KubernetesApiResponse<ApiType>> callback) {
+    if (Strings.isNullOrEmpty(name)) {
+      throw new IllegalArgumentException("invalid name");
     }
+
+    return executeCallAsync(
+        customObjectsApi.getApiClient(),
+        apiTypeClass,
+        makeClusterPatchCallBuilder(name, patchType, patch, patchOptions),
+        callback);
+  }
+
+  /**
+   * Patch kubernetes api response.
+   *
+   * @param namespace the namespace
+   * @param name the name
+   * @param patchType the patch type
+   * @param patch the patch
+   * @param patchOptions the patch options
+   * @param callback the callback
+   * @return future for the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiType>> patchAsync(
+      String namespace,
+      String name,
+      String patchType,
+      V1Patch patch,
+      final PatchOptions patchOptions,
+      Consumer<KubernetesApiResponse<ApiType>> callback) {
+    if (Strings.isNullOrEmpty(namespace)) {
+      throw new IllegalArgumentException("invalid namespace");
+    }
+    if (Strings.isNullOrEmpty(name)) {
+      throw new IllegalArgumentException("invalid name");
+    }
+    return executeCallAsync(
+        customObjectsApi.getApiClient(),
+        apiTypeClass,
+        makeNamespacedPatchCallBuilder(namespace, name, patchType, patch, patchOptions),
+        callback);
   }
 
   /**
@@ -652,19 +1031,21 @@ public class GenericKubernetesApi<
     return executeCall(
         customObjectsApi.getApiClient(),
         apiTypeClass,
-        () -> {
-          return customObjectsApi.deleteClusterCustomObjectCall(
-              this.apiGroup,
-              this.apiVersion,
-              this.resourcePlural,
-              name,
-              null,
-              null,
-              null,
-              null,
-              deleteOptions, // TODO: fill/convert the option
-              null);
-        });
+        makeClusterDeleteCallBuilder(name, deleteOptions));
+  }
+
+  private CallBuilder makeClusterDeleteCallBuilder(String name, DeleteOptions deleteOptions) {
+    return () -> customObjectsApi.deleteClusterCustomObjectCall(
+        this.apiGroup,
+        this.apiVersion,
+        this.resourcePlural,
+        name,
+        null,
+        null,
+        null,
+        null,
+        deleteOptions, // TODO: fill/convert the option
+        null);
   }
 
   /**
@@ -686,20 +1067,68 @@ public class GenericKubernetesApi<
     return executeCall(
         customObjectsApi.getApiClient(),
         apiTypeClass,
-        () -> {
-          return customObjectsApi.deleteNamespacedCustomObjectCall(
-              this.apiGroup,
-              this.apiVersion,
-              namespace,
-              this.resourcePlural,
-              name,
-              null,
-              null,
-              null,
-              null,
-              deleteOptions, // TODO: fill/convert the option
-              null);
-        });
+        makeNamespacedDeleteCallBuilder(namespace, name, deleteOptions));
+  }
+
+  private CallBuilder makeNamespacedDeleteCallBuilder(String namespace, String name,
+                                                      final DeleteOptions deleteOptions) {
+    return () -> customObjectsApi.deleteNamespacedCustomObjectCall(
+        this.apiGroup,
+        this.apiVersion,
+        namespace,
+        this.resourcePlural,
+        name,
+        null,
+        null,
+        null,
+        null,
+        deleteOptions, // TODO: fill/convert the option
+        null);
+  }
+
+  /**
+   * Delete kubernetes api response.
+   *
+   * @param name the name
+   * @param deleteOptions the delete options
+   * @param callback the callback
+   * @return future for the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiType>> deleteAsync(String name, final DeleteOptions deleteOptions,
+                                                            Consumer<KubernetesApiResponse<ApiType>> callback) {
+    if (Strings.isNullOrEmpty(name)) {
+      throw new IllegalArgumentException("invalid name");
+    }
+    return executeCallAsync(
+        customObjectsApi.getApiClient(),
+        apiTypeClass,
+        makeClusterDeleteCallBuilder(name, deleteOptions),
+        callback);
+  }
+
+  /**
+   * Delete kubernetes api response.
+   *
+   * @param namespace the namespace
+   * @param name the name
+   * @param deleteOptions the delete options
+   * @param callback the callback
+   * @return future for the kubernetes api response
+   */
+  public Future<KubernetesApiResponse<ApiType>> deleteAsync(
+      String namespace, String name, final DeleteOptions deleteOptions,
+      Consumer<KubernetesApiResponse<ApiType>> callback) {
+    if (Strings.isNullOrEmpty(namespace)) {
+      throw new IllegalArgumentException("invalid namespace");
+    }
+    if (Strings.isNullOrEmpty(name)) {
+      throw new IllegalArgumentException("invalid name");
+    }
+    return executeCallAsync(
+        customObjectsApi.getApiClient(),
+        apiTypeClass,
+        makeNamespacedDeleteCallBuilder(namespace, name, deleteOptions),
+        callback);
   }
 
   /**
@@ -773,14 +1202,14 @@ public class GenericKubernetesApi<
   }
 
   private static <DataType extends KubernetesType>
-      KubernetesApiResponse<DataType> getKubernetesApiResponse(
-          Class<DataType> dataClass, JsonElement element, Gson gson) {
+  KubernetesApiResponse<DataType> getKubernetesApiResponse(
+      Class<DataType> dataClass, JsonElement element, Gson gson) {
     return getKubernetesApiResponse(dataClass, element, gson, 200);
   }
 
   private static <DataType extends KubernetesType>
-      KubernetesApiResponse<DataType> getKubernetesApiResponse(
-          Class<DataType> dataClass, JsonElement element, Gson gson, int httpStatusCode) {
+  KubernetesApiResponse<DataType> getKubernetesApiResponse(
+      Class<DataType> dataClass, JsonElement element, Gson gson, int httpStatusCode) {
     JsonElement kindElement = element.getAsJsonObject().get("kind");
     boolean isStatus = kindElement != null && "Status".equals(kindElement.getAsString());
     if (isStatus) {
@@ -789,30 +1218,131 @@ public class GenericKubernetesApi<
     return new KubernetesApiResponse<>(gson.fromJson(element, dataClass));
   }
 
+  private Call prepareCall(CallBuilder callBuilder) throws ApiException {
+    Call call = callBuilder.build();
+    return tweakCallForCoreV1Group(call);
+  }
+
+  private void checkForIOException(ApiException e) {
+    if (e.getCause() instanceof IOException) {
+      throw new IllegalStateException(e.getCause()); // make this a checked exception?
+    }
+  }
+
+  private <DataType extends KubernetesType> KubernetesApiResponse<DataType> responseFromApiException(
+      ApiClient apiClient, ApiException e) {
+    checkForIOException(e);
+    final V1Status status;
+    try {
+      status = apiClient.getJSON().deserialize(e.getResponseBody(), V1Status.class);
+    } catch (JsonSyntaxException jsonEx) {
+      // craft a status object
+      return new KubernetesApiResponse<>(
+          new V1Status().code(e.getCode()).message(e.getResponseBody()), e.getCode());
+    }
+    if (null == status) { // the response body can be something unexpected sometimes...
+      // this line should never reach?
+      throw new RuntimeException(e);
+    }
+    return new KubernetesApiResponse<>(status, e.getCode());
+  }
+
   private <DataType extends KubernetesType> KubernetesApiResponse<DataType> executeCall(
       ApiClient apiClient, Class<DataType> dataClass, CallBuilder callBuilder) {
     try {
-      Call call = callBuilder.build();
-      call = tweakCallForCoreV1Group(call);
+      Call call = prepareCall(callBuilder);
       JsonElement element = apiClient.<JsonElement>execute(call, JsonElement.class).getData();
       return getKubernetesApiResponse(dataClass, element, apiClient.getJSON().getGson());
     } catch (ApiException e) {
-      if (e.getCause() instanceof IOException) {
-        throw new IllegalStateException(e.getCause()); // make this a checked exception?
-      }
-      final V1Status status;
-      try {
-        status = apiClient.getJSON().deserialize(e.getResponseBody(), V1Status.class);
-      } catch (JsonSyntaxException jsonEx) {
-        // craft a status object
-        return new KubernetesApiResponse<>(
-            new V1Status().code(e.getCode()).message(e.getResponseBody()), e.getCode());
-      }
-      if (null == status) { // the response body can be something unexpected sometimes..
-        // this line should never reach?
-        throw new RuntimeException(e);
-      }
-      return new KubernetesApiResponse<>(status, e.getCode());
+      return responseFromApiException(apiClient, e);
+    }
+  }
+
+  private <DataType extends KubernetesType> Future<KubernetesApiResponse<DataType>> executeCallAsync(
+      ApiClient apiClient, Class<DataType> dataClass, CallBuilder callBuilder,
+      Consumer<KubernetesApiResponse<DataType>> callback) {
+    try {
+      Call call = prepareCall(callBuilder);
+      CountDownLatch latch = new CountDownLatch(1);
+      AtomicReference<KubernetesApiResponse<DataType>> result = new AtomicReference<>();
+      apiClient.executeAsync(call, JsonElement.class, new ApiCallback<JsonElement>() {
+        @Override
+        public void onFailure(ApiException e, int statusCode, Map<String, List<String>> responseHeaders) {
+          KubernetesApiResponse<DataType> r = responseFromApiException(apiClient, e);
+          result.set(r);
+          latch.countDown();
+          callback.accept(r);
+        }
+
+        @Override
+        public void onSuccess(JsonElement element, int statusCode, Map<String, List<String>> responseHeaders) {
+          KubernetesApiResponse<DataType> r = getKubernetesApiResponse(
+              dataClass, element, apiClient.getJSON().getGson());
+          result.set(r);
+          latch.countDown();
+          callback.accept(r);
+        }
+
+        @Override
+        public void onUploadProgress(long bytesWritten, long contentLength, boolean done) {
+          // no-op
+        }
+
+        @Override
+        public void onDownloadProgress(long bytesRead, long contentLength, boolean done) {
+          // no-op
+        }
+      });
+
+      return new Future<KubernetesApiResponse<DataType>>() {
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+          if (isDone()) {
+            return false;
+          }
+          call.cancel();
+          boolean isCanceled = call.isCanceled();
+          if (isCanceled) {
+            latch.countDown();
+          }
+          return isCanceled;
+        }
+
+        @Override
+        public boolean isCancelled() {
+          return call.isCanceled();
+        }
+
+        @Override
+        public boolean isDone() {
+          return latch.getCount() == 0;
+        }
+
+        @Override
+        public KubernetesApiResponse<DataType> get() throws InterruptedException {
+          latch.await();
+          if (isCancelled()) {
+            throw new CancellationException();
+          }
+          return result.get();
+        }
+
+        @Override
+        public KubernetesApiResponse<DataType> get(long timeout, @Nonnull TimeUnit unit)
+            throws InterruptedException, TimeoutException {
+          if (latch.await(timeout, unit)) {
+            if (isCancelled()) {
+              throw new CancellationException();
+            }
+            return result.get();
+          } else {
+            throw new TimeoutException();
+          }
+        }
+      };
+    } catch (ApiException e) {
+      checkForIOException(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/util/src/main/java/io/kubernetes/client/util/generic/GenericKubernetesApi.java
+++ b/util/src/main/java/io/kubernetes/client/util/generic/GenericKubernetesApi.java
@@ -197,8 +197,8 @@ public class GenericKubernetesApi<
    * @param callback the callback
    * @return future for the kubernetes api response
    */
-  public Future<KubernetesApiResponse<ApiType>> getAsync(String name,
-                                                         @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
+  public Future<KubernetesApiResponse<ApiType>> getAsync(
+      String name, @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     return getAsync(name, new GetOptions(), callback);
   }
 
@@ -210,8 +210,8 @@ public class GenericKubernetesApi<
    * @param callback the callback
    * @return future for the kubernetes api response
    */
-  public Future<KubernetesApiResponse<ApiType>> getAsync(String namespace, String name,
-                                                         @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
+  public Future<KubernetesApiResponse<ApiType>> getAsync(
+      String namespace, String name, @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     return getAsync(namespace, name, new GetOptions(), callback);
   }
 
@@ -340,8 +340,11 @@ public class GenericKubernetesApi<
    * @param callback the callback
    * @return future for the kubernetes api response
    */
-  public Future<KubernetesApiResponse<ApiType>> patchAsync(String name, String patchType, V1Patch patch,
-                                                           @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
+  public Future<KubernetesApiResponse<ApiType>> patchAsync(
+      String name,
+      String patchType,
+      V1Patch patch,
+      @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     return patchAsync(name, patchType, patch, new PatchOptions(), callback);
   }
 
@@ -355,7 +358,10 @@ public class GenericKubernetesApi<
    * @return the kubernetes api response
    */
   public Future<KubernetesApiResponse<ApiType>> patchAsync(
-      String namespace, String name, String patchType, V1Patch patch,
+      String namespace,
+      String name,
+      String patchType,
+      V1Patch patch,
       @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     return patchAsync(namespace, name, patchType, patch, new PatchOptions(), callback);
   }
@@ -441,9 +447,7 @@ public class GenericKubernetesApi<
       throw new IllegalArgumentException("invalid name");
     }
     return executeCall(
-        customObjectsApi.getApiClient(),
-        apiTypeClass,
-        makeClusterGetCallBuilder(name, getOptions));
+        customObjectsApi.getApiClient(), apiTypeClass, makeClusterGetCallBuilder(name, getOptions));
   }
 
   private CallBuilder makeClusterGetCallBuilder(String name, final GetOptions getOptions) {
@@ -460,8 +464,10 @@ public class GenericKubernetesApi<
    * @param callback the callback
    * @return future for the kubernetes api response
    */
-  public Future<KubernetesApiResponse<ApiType>> getAsync(String name, final GetOptions getOptions,
-                                                         @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
+  public Future<KubernetesApiResponse<ApiType>> getAsync(
+      String name,
+      final GetOptions getOptions,
+      @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     if (Strings.isNullOrEmpty(name)) {
       throw new IllegalArgumentException("invalid name");
     }
@@ -494,9 +500,11 @@ public class GenericKubernetesApi<
         makeNamespacedGetCallBuilder(namespace, name, getOptions));
   }
 
-  private CallBuilder makeNamespacedGetCallBuilder(String namespace, String name, final GetOptions getOptions) {
-    return () -> customObjectsApi.getNamespacedCustomObjectCall(
-        this.apiGroup, this.apiVersion, namespace, this.resourcePlural, name, null);
+  private CallBuilder makeNamespacedGetCallBuilder(
+      String namespace, String name, final GetOptions getOptions) {
+    return () ->
+        customObjectsApi.getNamespacedCustomObjectCall(
+            this.apiGroup, this.apiVersion, namespace, this.resourcePlural, name, null);
   }
 
   /**
@@ -509,7 +517,9 @@ public class GenericKubernetesApi<
    * @return future for the kubernetes api response
    */
   public Future<KubernetesApiResponse<ApiType>> getAsync(
-      String namespace, String name, final GetOptions getOptions,
+      String namespace,
+      String name,
+      final GetOptions getOptions,
       @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     if (Strings.isNullOrEmpty(name)) {
       throw new IllegalArgumentException("invalid name");
@@ -532,27 +542,26 @@ public class GenericKubernetesApi<
    */
   public KubernetesApiResponse<ApiListType> list(final ListOptions listOptions) {
     return executeCall(
-        customObjectsApi.getApiClient(),
-        apiListTypeClass,
-        makeClusterListCallBuilder(listOptions));
+        customObjectsApi.getApiClient(), apiListTypeClass, makeClusterListCallBuilder(listOptions));
   }
 
   private CallBuilder makeClusterListCallBuilder(final ListOptions listOptions) {
-    return () -> customObjectsApi.listClusterCustomObjectCall(
-        this.apiGroup,
-        this.apiVersion,
-        this.resourcePlural,
-        null,
-        false,
-        listOptions.getContinue(),
-        listOptions.getFieldSelector(),
-        listOptions.getLabelSelector(),
-        listOptions.getLimit(),
-        listOptions.getResourceVersion(),
-        null,
-        listOptions.getTimeoutSeconds(),
-        false,
-        null);
+    return () ->
+        customObjectsApi.listClusterCustomObjectCall(
+            this.apiGroup,
+            this.apiVersion,
+            this.resourcePlural,
+            null,
+            false,
+            listOptions.getContinue(),
+            listOptions.getFieldSelector(),
+            listOptions.getLabelSelector(),
+            listOptions.getLimit(),
+            listOptions.getResourceVersion(),
+            null,
+            listOptions.getTimeoutSeconds(),
+            false,
+            null);
   }
 
   /**
@@ -572,23 +581,25 @@ public class GenericKubernetesApi<
         makeNamespacedListCallBuilder(namespace, listOptions));
   }
 
-  private CallBuilder makeNamespacedListCallBuilder(String namespace, final ListOptions listOptions) {
-    return () -> customObjectsApi.listNamespacedCustomObjectCall(
-        this.apiGroup,
-        this.apiVersion,
-        namespace,
-        this.resourcePlural,
-        null,
-        null,
-        listOptions.getContinue(),
-        listOptions.getFieldSelector(),
-        listOptions.getLabelSelector(),
-        listOptions.getLimit(),
-        listOptions.getResourceVersion(),
-        null,
-        listOptions.getTimeoutSeconds(),
-        false,
-        null);
+  private CallBuilder makeNamespacedListCallBuilder(
+      String namespace, final ListOptions listOptions) {
+    return () ->
+        customObjectsApi.listNamespacedCustomObjectCall(
+            this.apiGroup,
+            this.apiVersion,
+            namespace,
+            this.resourcePlural,
+            null,
+            null,
+            listOptions.getContinue(),
+            listOptions.getFieldSelector(),
+            listOptions.getLabelSelector(),
+            listOptions.getLimit(),
+            listOptions.getResourceVersion(),
+            null,
+            listOptions.getTimeoutSeconds(),
+            false,
+            null);
   }
 
   /**
@@ -599,7 +610,8 @@ public class GenericKubernetesApi<
    * @return future for the kubernetes api response
    */
   public Future<KubernetesApiResponse<ApiListType>> listAsync(
-      final ListOptions listOptions, @Nonnull Consumer<KubernetesApiResponse<ApiListType>> callback) {
+      final ListOptions listOptions,
+      @Nonnull Consumer<KubernetesApiResponse<ApiListType>> callback) {
     return executeCallAsync(
         customObjectsApi.getApiClient(),
         apiListTypeClass,
@@ -616,7 +628,9 @@ public class GenericKubernetesApi<
    * @return future for the kubernetes api response
    */
   public Future<KubernetesApiResponse<ApiListType>> listAsync(
-      String namespace, final ListOptions listOptions, @Nonnull Consumer<KubernetesApiResponse<ApiListType>> callback) {
+      String namespace,
+      final ListOptions listOptions,
+      @Nonnull Consumer<KubernetesApiResponse<ApiListType>> callback) {
     if (Strings.isNullOrEmpty(namespace)) {
       throw new IllegalArgumentException("invalid namespace");
     }
@@ -648,17 +662,19 @@ public class GenericKubernetesApi<
         makeClusterCreateCallBuilder(object, createOptions));
   }
 
-  private CallBuilder makeClusterCreateCallBuilder(ApiType object, final CreateOptions createOptions) {
+  private CallBuilder makeClusterCreateCallBuilder(
+      ApiType object, final CreateOptions createOptions) {
     // TODO(yue9944882): judge namespaced object via api discovery
-    return () -> customObjectsApi.createClusterCustomObjectCall(
-        this.apiGroup,
-        this.apiVersion,
-        this.resourcePlural,
-        object,
-        null,
-        createOptions.getDryRun(),
-        createOptions.getFieldManager(),
-        null);
+    return () ->
+        customObjectsApi.createClusterCustomObjectCall(
+            this.apiGroup,
+            this.apiVersion,
+            this.resourcePlural,
+            object,
+            null,
+            createOptions.getDryRun(),
+            createOptions.getFieldManager(),
+            null);
   }
 
   /**
@@ -669,7 +685,8 @@ public class GenericKubernetesApi<
    * @param createOptions the create options
    * @return the kubernetes api response
    */
-  public KubernetesApiResponse<ApiType> create(String namespace, ApiType object, final CreateOptions createOptions) {
+  public KubernetesApiResponse<ApiType> create(
+      String namespace, ApiType object, final CreateOptions createOptions) {
     return executeCall(
         customObjectsApi.getApiClient(),
         apiTypeClass,
@@ -679,16 +696,17 @@ public class GenericKubernetesApi<
   private CallBuilder makeNamespacedCreateCallBuilder(
       String namespace, ApiType object, final CreateOptions createOptions) {
     // TODO(yue9944882): judge namespaced object via api discovery
-    return () -> customObjectsApi.createNamespacedCustomObjectCall(
-        this.apiGroup,
-        this.apiVersion,
-        namespace,
-        this.resourcePlural,
-        object,
-        null,
-        createOptions.getDryRun(),
-        createOptions.getFieldManager(),
-        null);
+    return () ->
+        customObjectsApi.createNamespacedCustomObjectCall(
+            this.apiGroup,
+            this.apiVersion,
+            namespace,
+            this.resourcePlural,
+            object,
+            null,
+            createOptions.getDryRun(),
+            createOptions.getFieldManager(),
+            null);
   }
 
   /**
@@ -700,7 +718,9 @@ public class GenericKubernetesApi<
    * @return future for the kubernetes api response
    */
   public Future<KubernetesApiResponse<ApiType>> createAsync(
-      ApiType object, final CreateOptions createOptions, @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
+      ApiType object,
+      final CreateOptions createOptions,
+      @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     V1ObjectMeta objectMeta = object.getMetadata();
 
     boolean isNamespaced = !Strings.isNullOrEmpty(objectMeta.getNamespace());
@@ -724,7 +744,9 @@ public class GenericKubernetesApi<
    * @return future for the kubernetes api response
    */
   public Future<KubernetesApiResponse<ApiType>> createAsync(
-      String namespace, ApiType object, final CreateOptions createOptions,
+      String namespace,
+      ApiType object,
+      final CreateOptions createOptions,
       @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     return executeCallAsync(
         customObjectsApi.getApiClient(),
@@ -752,8 +774,8 @@ public class GenericKubernetesApi<
     boolean isNamespaced = !Strings.isNullOrEmpty(objectMeta.getNamespace());
     return () ->
         //// TODO(yue9944882): judge namespaced object via api discovery
-        isNamespaced ?
-            customObjectsApi.replaceNamespacedCustomObjectCall(
+        isNamespaced
+            ? customObjectsApi.replaceNamespacedCustomObjectCall(
                 this.apiGroup,
                 this.apiVersion,
                 objectMeta.getNamespace(),
@@ -762,8 +784,8 @@ public class GenericKubernetesApi<
                 object,
                 updateOptions.getDryRun(),
                 updateOptions.getFieldManager(),
-                null) :
-            customObjectsApi.replaceClusterCustomObjectCall(
+                null)
+            : customObjectsApi.replaceClusterCustomObjectCall(
                 this.apiGroup,
                 this.apiVersion,
                 this.resourcePlural,
@@ -783,7 +805,9 @@ public class GenericKubernetesApi<
    * @return future for the kubernetes api response
    */
   public Future<KubernetesApiResponse<ApiType>> updateAsync(
-      ApiType object, final UpdateOptions updateOptions, @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
+      ApiType object,
+      final UpdateOptions updateOptions,
+      @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     return executeCallAsync(
         customObjectsApi.getApiClient(),
         apiTypeClass,
@@ -820,14 +844,14 @@ public class GenericKubernetesApi<
         makeUpdateStatusCallBuilder(object, status, updateOptions));
   }
 
-  private CallBuilder makeUpdateStatusCallBuilder(ApiType object, Function<ApiType, Object> status,
-                                                  final UpdateOptions updateOptions) {
+  private CallBuilder makeUpdateStatusCallBuilder(
+      ApiType object, Function<ApiType, Object> status, final UpdateOptions updateOptions) {
     V1ObjectMeta objectMeta = object.getMetadata();
     boolean isNamespaced = !Strings.isNullOrEmpty(objectMeta.getNamespace());
     return () ->
         //// TODO(yue9944882): judge namespaced object via api discovery
-        isNamespaced ?
-            customObjectsApi.patchNamespacedCustomObjectStatusCall(
+        isNamespaced
+            ? customObjectsApi.patchNamespacedCustomObjectStatusCall(
                 this.apiGroup,
                 this.apiVersion,
                 objectMeta.getNamespace(),
@@ -837,8 +861,8 @@ public class GenericKubernetesApi<
                 updateOptions.getDryRun(),
                 updateOptions.getFieldManager(),
                 null,
-                null) :
-            customObjectsApi.patchClusterCustomObjectStatusCall(
+                null)
+            : customObjectsApi.patchClusterCustomObjectStatusCall(
                 this.apiGroup,
                 this.apiVersion,
                 this.resourcePlural,
@@ -860,7 +884,9 @@ public class GenericKubernetesApi<
    * @return future for the kubernetes api response
    */
   public Future<KubernetesApiResponse<ApiType>> updateStatusAsync(
-      ApiType object, Function<ApiType, Object> status, @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
+      ApiType object,
+      Function<ApiType, Object> status,
+      @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     return updateStatusAsync(object, status, new UpdateOptions(), callback);
   }
 
@@ -874,7 +900,9 @@ public class GenericKubernetesApi<
    * @return future for the kubernetes api response
    */
   public Future<KubernetesApiResponse<ApiType>> updateStatusAsync(
-      ApiType object, Function<ApiType, Object> status, final UpdateOptions updateOptions,
+      ApiType object,
+      Function<ApiType, Object> status,
+      final UpdateOptions updateOptions,
       @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     return executeCallAsync(
         customObjectsApi.getApiClient(),
@@ -887,9 +915,11 @@ public class GenericKubernetesApi<
     Request request = call.request();
     return apiClient
         .getHttpClient()
-        .newCall(request.newBuilder()
-            .patch(new ProxyContentTypeRequestBody(request.body(), patchType))
-            .build());
+        .newCall(
+            request
+                .newBuilder()
+                .patch(new ProxyContentTypeRequestBody(request.body(), patchType))
+                .build());
   }
 
   /**
@@ -913,18 +943,22 @@ public class GenericKubernetesApi<
         makeClusterPatchCallBuilder(name, patchType, patch, patchOptions));
   }
 
-  private CallBuilder makeClusterPatchCallBuilder(String name, String patchType,
-                                                  V1Patch patch, final PatchOptions patchOptions) {
-    return () -> adaptPatchCall(customObjectsApi.getApiClient(), customObjectsApi.patchClusterCustomObjectCall(
-        this.apiGroup,
-        this.apiVersion,
-        this.resourcePlural,
-        name,
-        patch,
-        patchOptions.getDryRun(),
-        patchOptions.getFieldManager(),
-        patchOptions.getForce(),
-        null), patchType);
+  private CallBuilder makeClusterPatchCallBuilder(
+      String name, String patchType, V1Patch patch, final PatchOptions patchOptions) {
+    return () ->
+        adaptPatchCall(
+            customObjectsApi.getApiClient(),
+            customObjectsApi.patchClusterCustomObjectCall(
+                this.apiGroup,
+                this.apiVersion,
+                this.resourcePlural,
+                name,
+                patch,
+                patchOptions.getDryRun(),
+                patchOptions.getFieldManager(),
+                patchOptions.getForce(),
+                null),
+            patchType);
   }
 
   /**
@@ -955,19 +989,27 @@ public class GenericKubernetesApi<
         makeNamespacedPatchCallBuilder(namespace, name, patchType, patch, patchOptions));
   }
 
-  private CallBuilder makeNamespacedPatchCallBuilder(String namespace, String name, String patchType,
-                                                     V1Patch patch, final PatchOptions patchOptions) {
-    return () -> adaptPatchCall(customObjectsApi.getApiClient(), customObjectsApi.patchNamespacedCustomObjectCall(
-        this.apiGroup,
-        this.apiVersion,
-        namespace,
-        this.resourcePlural,
-        name,
-        patch,
-        patchOptions.getDryRun(),
-        patchOptions.getFieldManager(),
-        patchOptions.getForce(),
-        null), patchType);
+  private CallBuilder makeNamespacedPatchCallBuilder(
+      String namespace,
+      String name,
+      String patchType,
+      V1Patch patch,
+      final PatchOptions patchOptions) {
+    return () ->
+        adaptPatchCall(
+            customObjectsApi.getApiClient(),
+            customObjectsApi.patchNamespacedCustomObjectCall(
+                this.apiGroup,
+                this.apiVersion,
+                namespace,
+                this.resourcePlural,
+                name,
+                patch,
+                patchOptions.getDryRun(),
+                patchOptions.getFieldManager(),
+                patchOptions.getForce(),
+                null),
+            patchType);
   }
 
   /**
@@ -981,7 +1023,10 @@ public class GenericKubernetesApi<
    * @return future for the kubernetes api response
    */
   public Future<KubernetesApiResponse<ApiType>> patchAsync(
-      String name, String patchType, V1Patch patch, final PatchOptions patchOptions,
+      String name,
+      String patchType,
+      V1Patch patch,
+      final PatchOptions patchOptions,
       @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     if (Strings.isNullOrEmpty(name)) {
       throw new IllegalArgumentException("invalid name");
@@ -1043,17 +1088,18 @@ public class GenericKubernetesApi<
   }
 
   private CallBuilder makeClusterDeleteCallBuilder(String name, final DeleteOptions deleteOptions) {
-    return () -> customObjectsApi.deleteClusterCustomObjectCall(
-        this.apiGroup,
-        this.apiVersion,
-        this.resourcePlural,
-        name,
-        null,
-        null,
-        null,
-        null,
-        deleteOptions, // TODO: fill/convert the option
-        null);
+    return () ->
+        customObjectsApi.deleteClusterCustomObjectCall(
+            this.apiGroup,
+            this.apiVersion,
+            this.resourcePlural,
+            name,
+            null,
+            null,
+            null,
+            null,
+            deleteOptions, // TODO: fill/convert the option
+            null);
   }
 
   /**
@@ -1078,20 +1124,21 @@ public class GenericKubernetesApi<
         makeNamespacedDeleteCallBuilder(namespace, name, deleteOptions));
   }
 
-  private CallBuilder makeNamespacedDeleteCallBuilder(String namespace, String name,
-                                                      final DeleteOptions deleteOptions) {
-    return () -> customObjectsApi.deleteNamespacedCustomObjectCall(
-        this.apiGroup,
-        this.apiVersion,
-        namespace,
-        this.resourcePlural,
-        name,
-        null,
-        null,
-        null,
-        null,
-        deleteOptions, // TODO: fill/convert the option
-        null);
+  private CallBuilder makeNamespacedDeleteCallBuilder(
+      String namespace, String name, final DeleteOptions deleteOptions) {
+    return () ->
+        customObjectsApi.deleteNamespacedCustomObjectCall(
+            this.apiGroup,
+            this.apiVersion,
+            namespace,
+            this.resourcePlural,
+            name,
+            null,
+            null,
+            null,
+            null,
+            deleteOptions, // TODO: fill/convert the option
+            null);
   }
 
   /**
@@ -1103,7 +1150,9 @@ public class GenericKubernetesApi<
    * @return future for the kubernetes api response
    */
   public Future<KubernetesApiResponse<ApiType>> deleteAsync(
-      String name, final DeleteOptions deleteOptions, @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
+      String name,
+      final DeleteOptions deleteOptions,
+      @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     if (Strings.isNullOrEmpty(name)) {
       throw new IllegalArgumentException("invalid name");
     }
@@ -1124,7 +1173,9 @@ public class GenericKubernetesApi<
    * @return future for the kubernetes api response
    */
   public Future<KubernetesApiResponse<ApiType>> deleteAsync(
-      String namespace, String name, final DeleteOptions deleteOptions,
+      String namespace,
+      String name,
+      final DeleteOptions deleteOptions,
       @Nonnull Consumer<KubernetesApiResponse<ApiType>> callback) {
     if (Strings.isNullOrEmpty(namespace)) {
       throw new IllegalArgumentException("invalid namespace");
@@ -1210,14 +1261,14 @@ public class GenericKubernetesApi<
   }
 
   private static <DataType extends KubernetesType>
-  KubernetesApiResponse<DataType> getKubernetesApiResponse(
-      Class<DataType> dataClass, JsonElement element, Gson gson) {
+      KubernetesApiResponse<DataType> getKubernetesApiResponse(
+          Class<DataType> dataClass, JsonElement element, Gson gson) {
     return getKubernetesApiResponse(dataClass, element, gson, 200);
   }
 
   private static <DataType extends KubernetesType>
-  KubernetesApiResponse<DataType> getKubernetesApiResponse(
-      Class<DataType> dataClass, JsonElement element, Gson gson, int httpStatusCode) {
+      KubernetesApiResponse<DataType> getKubernetesApiResponse(
+          Class<DataType> dataClass, JsonElement element, Gson gson, int httpStatusCode) {
     JsonElement kindElement = element.getAsJsonObject().get("kind");
     boolean isStatus = kindElement != null && "Status".equals(kindElement.getAsString());
     if (isStatus) {
@@ -1237,8 +1288,9 @@ public class GenericKubernetesApi<
     }
   }
 
-  private <DataType extends KubernetesType> KubernetesApiResponse<DataType> responseFromApiException(
-      ApiClient apiClient, ApiException e) {
+  private <DataType extends KubernetesType>
+      KubernetesApiResponse<DataType> responseFromApiException(
+          ApiClient apiClient, ApiException e) {
     checkForIOException(e);
     final V1Status status;
     try {
@@ -1267,9 +1319,7 @@ public class GenericKubernetesApi<
   }
 
   // For unit-test
-  interface CallAdapter extends UnaryOperator<Call> {
-
-  }
+  interface CallAdapter extends UnaryOperator<Call> {}
 
   private <DataType extends KubernetesType> Call prepareCall(
       CallBuilder callBuilder, @Nonnull Consumer<KubernetesApiResponse<DataType>> callback)
@@ -1284,46 +1334,54 @@ public class GenericKubernetesApi<
     return call;
   }
 
-  private <DataType extends KubernetesType> Future<KubernetesApiResponse<DataType>> executeCallAsync(
-      ApiClient apiClient, Class<DataType> dataClass, CallBuilder callBuilder,
-      @Nonnull Consumer<KubernetesApiResponse<DataType>> callback) {
+  private <DataType extends KubernetesType>
+      Future<KubernetesApiResponse<DataType>> executeCallAsync(
+          ApiClient apiClient,
+          Class<DataType> dataClass,
+          CallBuilder callBuilder,
+          @Nonnull Consumer<KubernetesApiResponse<DataType>> callback) {
     try {
       Call call = prepareCall(callBuilder, callback);
       CountDownLatch latch = new CountDownLatch(1);
       AtomicReference<KubernetesApiResponse<DataType>> result = new AtomicReference<>();
 
-      apiClient.executeAsync(call, JsonElement.class, new ApiCallback<JsonElement>() {
-        @Override
-        public void onFailure(ApiException e, int statusCode, Map<String, List<String>> responseHeaders) {
-          if (latch.getCount() > 0) {
-            KubernetesApiResponse<DataType> r = responseFromApiException(apiClient, e);
-            result.set(r);
-            latch.countDown();
-            callback.accept(r);
-          }
-        }
+      apiClient.executeAsync(
+          call,
+          JsonElement.class,
+          new ApiCallback<JsonElement>() {
+            @Override
+            public void onFailure(
+                ApiException e, int statusCode, Map<String, List<String>> responseHeaders) {
+              if (latch.getCount() > 0) {
+                KubernetesApiResponse<DataType> r = responseFromApiException(apiClient, e);
+                result.set(r);
+                latch.countDown();
+                callback.accept(r);
+              }
+            }
 
-        @Override
-        public void onSuccess(JsonElement element, int statusCode, Map<String, List<String>> responseHeaders) {
-          KubernetesApiResponse<DataType> r = getKubernetesApiResponse(
-              dataClass, element, apiClient.getJSON().getGson());
-          if (latch.getCount() > 0) {
-            result.set(r);
-            latch.countDown();
-            callback.accept(r);
-          }
-        }
+            @Override
+            public void onSuccess(
+                JsonElement element, int statusCode, Map<String, List<String>> responseHeaders) {
+              KubernetesApiResponse<DataType> r =
+                  getKubernetesApiResponse(dataClass, element, apiClient.getJSON().getGson());
+              if (latch.getCount() > 0) {
+                result.set(r);
+                latch.countDown();
+                callback.accept(r);
+              }
+            }
 
-        @Override
-        public void onUploadProgress(long bytesWritten, long contentLength, boolean done) {
-          // no-op
-        }
+            @Override
+            public void onUploadProgress(long bytesWritten, long contentLength, boolean done) {
+              // no-op
+            }
 
-        @Override
-        public void onDownloadProgress(long bytesRead, long contentLength, boolean done) {
-          // no-op
-        }
-      });
+            @Override
+            public void onDownloadProgress(long bytesRead, long contentLength, boolean done) {
+              // no-op
+            }
+          });
 
       return new Future<KubernetesApiResponse<DataType>>() {
         @Override

--- a/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesApiForCoreApiTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesApiForCoreApiTest.java
@@ -12,37 +12,6 @@ limitations under the License.
 */
 package io.kubernetes.client.util.generic;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import io.kubernetes.client.common.KubernetesType;
-import io.kubernetes.client.custom.V1Patch;
-import io.kubernetes.client.openapi.ApiClient;
-import io.kubernetes.client.openapi.JSON;
-import io.kubernetes.client.openapi.models.V1ListMeta;
-import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import io.kubernetes.client.openapi.models.V1Pod;
-import io.kubernetes.client.openapi.models.V1PodList;
-import io.kubernetes.client.openapi.models.V1Status;
-import io.kubernetes.client.util.ClientBuilder;
-import okhttp3.Call;
-import okhttp3.Interceptor;
-import okhttp3.Request;
-import okhttp3.Response;
-import org.jetbrains.annotations.NotNull;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
-import java.io.IOException;
-import java.net.SocketTimeoutException;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.delete;
@@ -69,6 +38,36 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.kubernetes.client.common.KubernetesType;
+import io.kubernetes.client.custom.V1Patch;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.JSON;
+import io.kubernetes.client.openapi.models.V1ListMeta;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodList;
+import io.kubernetes.client.openapi.models.V1Status;
+import io.kubernetes.client.util.ClientBuilder;
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import okhttp3.Call;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
 public class GenericKubernetesApiForCoreApiTest {
 
   @Rule public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
@@ -78,8 +77,10 @@ public class GenericKubernetesApiForCoreApiTest {
 
   @Before
   public void setup() throws IOException {
-    ApiClient apiClient = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
-    apiClient.setHttpClient(apiClient.getHttpClient().newBuilder().addInterceptor(new TestInterceptor()).build());
+    ApiClient apiClient =
+        new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
+    apiClient.setHttpClient(
+        apiClient.getHttpClient().newBuilder().addInterceptor(new TestInterceptor()).build());
     podClient =
         new GenericKubernetesApi<>(V1Pod.class, V1PodList.class, "", "v1", "pods", apiClient);
   }
@@ -107,7 +108,8 @@ public class GenericKubernetesApiForCoreApiTest {
             .willReturn(aResponse().withStatus(200).withBody(json.serialize(status))));
     TestCallback<V1Pod> callback = new TestCallback<>(podClient.getApiClient());
 
-    Future<KubernetesApiResponse<V1Pod>> deletePodFuture = podClient.deleteAsync("default", "foo1", null, callback);
+    Future<KubernetesApiResponse<V1Pod>> deletePodFuture =
+        podClient.deleteAsync("default", "foo1", null, callback);
     KubernetesApiResponse<V1Pod> deletePodResp = callback.waitForAndGetResponse();
     assertTrue(deletePodResp.isSuccess());
     assertEquals(status, deletePodResp.getStatus());
@@ -144,7 +146,8 @@ public class GenericKubernetesApiForCoreApiTest {
             .willReturn(aResponse().withStatus(200).withBody(json.serialize(foo1))));
     TestCallback<V1Pod> callback = new TestCallback<>(podClient.getApiClient());
 
-    Future<KubernetesApiResponse<V1Pod>> deletePodFuture = podClient.deleteAsync("default", "foo1", callback);
+    Future<KubernetesApiResponse<V1Pod>> deletePodFuture =
+        podClient.deleteAsync("default", "foo1", callback);
     KubernetesApiResponse<V1Pod> deletePodResp = callback.waitForAndGetResponse();
     assertTrue(deletePodResp.isSuccess());
     assertEquals(foo1, deletePodResp.getObject());
@@ -178,7 +181,8 @@ public class GenericKubernetesApiForCoreApiTest {
             .willReturn(aResponse().withStatus(403).withBody(json.serialize(status))));
     TestCallback<V1Pod> callback = new TestCallback<>(podClient.getApiClient());
 
-    Future<KubernetesApiResponse<V1Pod>> deletePodFuture = podClient.deleteAsync("default", "foo1", callback);
+    Future<KubernetesApiResponse<V1Pod>> deletePodFuture =
+        podClient.deleteAsync("default", "foo1", callback);
     KubernetesApiResponse<V1Pod> deletePodResp = callback.waitForAndGetResponse();
     assertFalse(deletePodResp.isSuccess());
     assertEquals(status, deletePodResp.getStatus());
@@ -211,7 +215,8 @@ public class GenericKubernetesApiForCoreApiTest {
             .willReturn(aResponse().withStatus(200).withBody(json.serialize(podList))));
     TestCallback<V1PodList> callback = new TestCallback<>(podClient.getApiClient());
 
-    Future<KubernetesApiResponse<V1PodList>> podListFuture = podClient.listAsync("default", callback);
+    Future<KubernetesApiResponse<V1PodList>> podListFuture =
+        podClient.listAsync("default", callback);
     KubernetesApiResponse<V1PodList> podListResp = callback.waitForAndGetResponse();
     assertTrue(podListResp.isSuccess());
     assertEquals(podList, podListResp.getObject());
@@ -406,7 +411,8 @@ public class GenericKubernetesApiForCoreApiTest {
     TestCallback<V1Pod> callback = new TestCallback<>(podClient.getApiClient());
 
     Future<KubernetesApiResponse<V1Pod>> podPatchFuture =
-        podClient.patchAsync("default", "foo1", V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH, v1Patch, callback);
+        podClient.patchAsync(
+            "default", "foo1", V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH, v1Patch, callback);
     KubernetesApiResponse<V1Pod> podPatchResp = callback.waitForAndGetResponse();
 
     assertTrue(podPatchResp.isSuccess());
@@ -436,7 +442,9 @@ public class GenericKubernetesApiForCoreApiTest {
             "",
             "v1",
             "pods",
-            new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port() + prefix).build());
+            new ClientBuilder()
+                .setBasePath("http://localhost:" + wireMockRule.port() + prefix)
+                .build());
     KubernetesApiResponse<V1Pod> podPatchResp =
         rancherPodClient.patch(
             "default", "foo1", V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH, v1Patch);
@@ -467,7 +475,9 @@ public class GenericKubernetesApiForCoreApiTest {
             "",
             "v1",
             "pods",
-            new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port() + prefix).build());
+            new ClientBuilder()
+                .setBasePath("http://localhost:" + wireMockRule.port() + prefix)
+                .build());
     Future<KubernetesApiResponse<V1Pod>> podPatchFuture =
         rancherPodClient.patchAsync(
             "default", "foo1", V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH, v1Patch, callback);
@@ -483,7 +493,8 @@ public class GenericKubernetesApiForCoreApiTest {
 
   @Test
   public void testReadTimeoutShouldThrowException() {
-    ApiClient apiClient = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
+    ApiClient apiClient =
+        new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
     apiClient.setHttpClient(
         apiClient
             .getHttpClient()
@@ -540,8 +551,11 @@ public class GenericKubernetesApiForCoreApiTest {
     @Override
     public Call apply(Call call) {
       if (waitForRequest != null) {
-        call = apiClient.getHttpClient().newCall(
-            call.request().newBuilder().tag(WaitForRequest.class, waitForRequest).build());
+        call =
+            apiClient
+                .getHttpClient()
+                .newCall(
+                    call.request().newBuilder().tag(WaitForRequest.class, waitForRequest).build());
       }
       return call;
     }

--- a/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesApiTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesApiTest.java
@@ -46,7 +46,8 @@ public class GenericKubernetesApiTest {
 
   @Before
   public void setup() throws IOException {
-    ApiClient apiClient = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
+    ApiClient apiClient =
+        new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
     jobClient =
         new GenericKubernetesApi<>(V1Job.class, V1JobList.class, "batch", "v1", "jobs", apiClient);
   }
@@ -206,7 +207,8 @@ public class GenericKubernetesApiTest {
 
   @Test
   public void testReadTimeoutShouldThrowException() {
-    ApiClient apiClient = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
+    ApiClient apiClient =
+        new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
     apiClient.setHttpClient(
         apiClient
             .getHttpClient()

--- a/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesApiTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesApiTest.java
@@ -13,6 +13,7 @@ limitations under the License.
 package io.kubernetes.client.util.generic;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.Assert.*;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
@@ -38,14 +39,14 @@ import org.junit.Test;
 
 public class GenericKubernetesApiTest {
 
-  @Rule public WireMockRule wireMockRule = new WireMockRule(8181);
+  @Rule public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
   private JSON json = new JSON();
   private GenericKubernetesApi<V1Job, V1JobList> jobClient;
 
   @Before
   public void setup() throws IOException {
-    ApiClient apiClient = new ClientBuilder().setBasePath("http://localhost:" + 8181).build();
+    ApiClient apiClient = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
     jobClient =
         new GenericKubernetesApi<>(V1Job.class, V1JobList.class, "batch", "v1", "jobs", apiClient);
   }
@@ -205,7 +206,7 @@ public class GenericKubernetesApiTest {
 
   @Test
   public void testReadTimeoutShouldThrowException() {
-    ApiClient apiClient = new ClientBuilder().setBasePath("http://localhost:" + 8181).build();
+    ApiClient apiClient = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
     apiClient.setHttpClient(
         apiClient
             .getHttpClient()

--- a/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesGetApiTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesGetApiTest.java
@@ -13,6 +13,7 @@ limitations under the License.
 package io.kubernetes.client.util.generic;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -29,7 +30,7 @@ import org.junit.Test;
 
 public class GenericKubernetesGetApiTest {
 
-  @Rule public WireMockRule wireMockRule = new WireMockRule(8181);
+  @Rule public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
   private JSON json = new JSON();
   private GenericKubernetesApi<V1Job, V1JobList> jobClient; // non-core built-in resource
@@ -38,7 +39,7 @@ public class GenericKubernetesGetApiTest {
 
   @Before
   public void setup() {
-    ApiClient apiClient = new ClientBuilder().setBasePath("http://localhost:" + 8181).build();
+    ApiClient apiClient = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
     jobClient =
         new GenericKubernetesApi<>(V1Job.class, V1JobList.class, "batch", "v1", "jobs", apiClient);
     fooClient =

--- a/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesGetApiTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesGetApiTest.java
@@ -39,7 +39,8 @@ public class GenericKubernetesGetApiTest {
 
   @Before
   public void setup() {
-    ApiClient apiClient = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
+    ApiClient apiClient =
+        new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
     jobClient =
         new GenericKubernetesApi<>(V1Job.class, V1JobList.class, "batch", "v1", "jobs", apiClient);
     fooClient =

--- a/util/src/test/java/io/kubernetes/client/util/generic/KubernetesApiResponseTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/generic/KubernetesApiResponseTest.java
@@ -40,7 +40,8 @@ public class KubernetesApiResponseTest {
 
   @Before
   public void setup() throws IOException {
-    ApiClient apiClient = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
+    ApiClient apiClient =
+        new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
     podClient =
         new GenericKubernetesApi<>(V1Pod.class, V1PodList.class, "", "v1", "pods", apiClient);
   }

--- a/util/src/test/java/io/kubernetes/client/util/generic/KubernetesApiResponseTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/generic/KubernetesApiResponseTest.java
@@ -16,6 +16,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.delete;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.Assert.*;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
@@ -33,13 +34,13 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class KubernetesApiResponseTest {
-  @Rule public WireMockRule wireMockRule = new WireMockRule(8485);
+  @Rule public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
   private GenericKubernetesApi<V1Pod, V1PodList> podClient;
 
   @Before
   public void setup() throws IOException {
-    ApiClient apiClient = new ClientBuilder().setBasePath("http://localhost:" + 8485).build();
+    ApiClient apiClient = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
     podClient =
         new GenericKubernetesApi<>(V1Pod.class, V1PodList.class, "", "v1", "pods", apiClient);
   }


### PR DESCRIPTION
This change updates GenericKuberentesApi to have asynchronous methods similar to each of the existing synchronous methods. I've chosen to have the callback be an implementation of Consumer<KubernetesApiResonse<ApiType>> and have each method return Future<KubernetesApiResponse<ApiType>> to continue the pattern of not exposing symbols from OkHttp.

Second, and much more minor, I was having a lot of trouble building locally because of "port already in use" messages from WireMock. I saw that the wireMockConfig().dynamicPort() pattern was already in use elsewhere in the code base so I've updated more test classes.