### PR TITLE
Fix `DynamicKubernetesTypeAdaptorFactory` when it does not apply.

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/generic/dynamic/DynamicKubernetesTypeAdaptorFactory.java
+++ b/util/src/main/java/io/kubernetes/client/util/generic/dynamic/DynamicKubernetesTypeAdaptorFactory.java
@@ -34,7 +34,7 @@ public class DynamicKubernetesTypeAdaptorFactory implements TypeAdapterFactory {
     if (shouldHandleAsListObject(typeToken)) {
       return (TypeAdapter<T>) (new GenericListObjectCreator(gson));
     }
-    return gson.getDelegateAdapter(this, typeToken);
+    return null;
   }
 
   private boolean shouldHandleAsSingleObject(TypeToken typeToken) {

--- a/util/src/test/java/io/kubernetes/client/util/generic/dynamic/DynamicKubernetesTypeAdaptorFactoryTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/generic/dynamic/DynamicKubernetesTypeAdaptorFactoryTest.java
@@ -44,11 +44,7 @@ public class DynamicKubernetesTypeAdaptorFactoryTest {
 
   @Before
   public void setup() {
-    gson =
-        new Gson()
-            .newBuilder()
-            .registerTypeAdapterFactory(factory)
-            .create();
+    gson = new Gson().newBuilder().registerTypeAdapterFactory(factory).create();
   }
 
   @Test


### PR DESCRIPTION
When a `TypeAdapterFactory` does not handle the type in its `create` method, the protocol is for it to return `null`. Calling `gson.getDelegateAdapter` is only appropriate for factories that wrap the results of other factories.

See https://github.com/google/gson/issues/2312.