### PR TITLE
WebSockets: handle onClosing

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/WebSockets.java
+++ b/util/src/main/java/io/kubernetes/client/util/WebSockets.java
@@ -145,6 +145,12 @@ public class WebSockets {
     @Override
     public void onClosing(WebSocket webSocket, int code, String reason) {
       super.onClosing(webSocket, code, reason);
+      if (code == 1000) {
+        webSocket.close(1000, "Normal close");
+      } else {
+        log.warn("Unexpected WebSocket ({}) closure: {} {}", webSocket, code, reason);
+        webSocket.close(1002, "Abnormal close");
+      }
     }
 
     @Override


### PR DESCRIPTION
We are trying to use the `PortForward` class to communicate with our kubernetes pods for testing purposes. We've been having trouble with tunneled connections timing out or receiving unexpected EOFs. There is little documentation about how this api server proxy works, which makes diagnosing any problems a struggle.
I added voluminous debug logs and discovered that the server seems to be sending an `onClosing` event with a code of 1000, indicating that it will not communicate with us further in this session.
I don't understand why the api server proxy is closing our session which we intend to use further. But, if it does, it does no good to keep it open clientside: you will wait as long as you like but the server won't send any more data.

Shutting down the client side in this case seems to allow the higher levels to re-establish the connection and continue. We still have some stability problems with the PortForward, but this seems to make it significantly better.