### PR TITLE
Update spotless testing to use JDK 11

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 8.0.x
+          java-version: 11
       - name: Verify Format and License
         run: mvn spotless:check
   build:


### PR DESCRIPTION
Spotless has moved to only support JDK 11+, see #2579 