### PR TITLE
Controllers and LeaderElector uses non-daemon threads by default #2509

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/Threads.java
+++ b/util/src/main/java/io/kubernetes/client/util/Threads.java
@@ -29,6 +29,7 @@ public class Threads {
       Thread thread = defaultFactory.newThread(r);
       // Daemon status inherited from default
       thread.setName(String.format(format, threadNumber.getAndIncrement()));
+      thread.setDaemon(false); // Explicitly set daemon status to false
       return thread;
     };
   }


### PR DESCRIPTION
I tried to solve this issue "Controllers and LeaderElector uses non-daemon threads by default #2509". Explicitly set daemon status to false.