### PR TITLE
Refactor findHomeDir() function to reduce cyclomatic complexity

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/ClientBuilder.java
+++ b/util/src/main/java/io/kubernetes/client/util/ClientBuilder.java
@@ -175,26 +175,39 @@ public class ClientBuilder {
         return config;
       }
     }
-    if (System.getProperty("os.name").toLowerCase().startsWith("windows")) {
-      String homeDrive = System.getenv("HOMEDRIVE");
-      String homePath = System.getenv("HOMEPATH");
-      if (homeDrive != null
-          && homeDrive.length() > 0
-          && homePath != null
-          && homePath.length() > 0) {
-        File homeDir = new File(new File(homeDrive), homePath);
-        if (homeDir.exists()) {
-          return homeDir;
-        }
-      }
-      String userProfile = System.getenv("USERPROFILE");
-      if (userProfile != null && userProfile.length() > 0) {
-        File profileDir = new File(userProfile);
-        if (profileDir.exists()) {
-          return profileDir;
-        }
+
+    if (isWindows()) {
+      File homeDir = getWindowsHomeDir();
+      if (homeDir != null && homeDir.exists()) {
+        return homeDir;
       }
     }
+
+    return null;
+  }
+
+  private static boolean isWindows() {
+    return System.getProperty("os.name").toLowerCase().startsWith("windows");
+  }
+
+  private static File getWindowsHomeDir() {
+    String homeDrive = System.getenv("HOMEDRIVE");
+    String homePath = System.getenv("HOMEPATH");
+    if (homeDrive != null && homeDrive.length() > 0 && homePath != null && homePath.length() > 0) {
+      File homeDir = new File(new File(homeDrive), homePath);
+      if (homeDir.exists()) {
+        return homeDir;
+      }
+    }
+
+    String userProfile = System.getenv("USERPROFILE");
+    if (userProfile != null && userProfile.length() > 0) {
+      File profileDir = new File(userProfile);
+      if (profileDir.exists()) {
+        return profileDir;
+      }
+    }
+
     return null;
   }
 


### PR DESCRIPTION
This some changes to the findHomeDir() function in ClientBuilder class to make it easier to read and work with. The code has been split into smaller methods which are easier to understand and maintain. This is super important because when code gets too complex it can be really hard to test and fix when things go wrong. By making the findHomeDir() function less complicated, we can improve the overall quality of the code and make it more reliable in the long run.

And refactored code in KubeConfig class in the getCredentials() method to improve its readability, maintainability and reduce its complexity. Replaced nested if-statements with early returns and used guard clauses to simplify the code flow. Also extracted the nested credentialsViaExecCredential method for better readability and maintainability

