### PR TITLE
Revert "build(deps): bump jacoco-maven-plugin from 0.8.8 to 0.8.9"

### DIFF
--- a/extended/pom.xml
+++ b/extended/pom.xml
@@ -83,7 +83,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.9</version>
+                <version>0.8.8</version>
                 <executions>
                     <execution>
                         <id>jacoco-initialize</id>

--- a/pom.xml
+++ b/pom.xml
@@ -568,7 +568,7 @@ limitations under the License.
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.9</version>
+            <version>0.8.8</version>
             <executions>
               <execution>
                 <id>jacoco-initialize</id>


### PR DESCRIPTION
Reverts kubernetes-client/java#2618

the new build 0.8.9 of jacoco was reverted from maven central, which leaving the test pipelines in this repo constantly failing. downgrading the version to fix it.