### PR TITLE
Fixed bug: label being set as null instead of deleted

### DIFF
--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlLabel.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlLabel.java
@@ -38,11 +38,7 @@ public class KubectlLabel<ApiType extends KubernetesObject>
   }
 
   public KubectlLabel<ApiType> deleteLabel(String key) {
-    if (this.addingLabels.containsKey(key)) {
-      // Remove the label from the map
-      this.addingLabels.remove(key);
-    }
-
+    this.addingLabels.remove(key);
     return this;
   }
 

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlLabel.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlLabel.java
@@ -38,7 +38,7 @@ public class KubectlLabel<ApiType extends KubernetesObject>
   }
 
   public KubectlLabel<ApiType> deleteLabel(String key) {
-    this.addingLabels.put(key, "null");
+    this.addingLabels.remove(key);
     return this;
   }
 

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlLabel.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlLabel.java
@@ -38,7 +38,11 @@ public class KubectlLabel<ApiType extends KubernetesObject>
   }
 
   public KubectlLabel<ApiType> deleteLabel(String key) {
-    this.addingLabels.remove(key);
+    if (this.addingLabels.containsKey(key)) {
+      // Remove the label from the map
+      this.addingLabels.remove(key);
+    }
+
     return this;
   }
 

--- a/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlLabelTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlLabelTest.java
@@ -91,7 +91,7 @@ public class KubectlLabelTest {
     wireMockRule.stubFor(
         put(urlPathEqualTo("/api/v1/namespaces/default/pods/foo"))
             .withRequestBody(
-                matchingJsonPath("$.metadata.labels", equalToJson("{ \"k1\": \"null\" }")))
+                matchingJsonPath("$.metadata.labels", equalToJson("{}")))
             .willReturn(
                 aResponse()
                     .withStatus(200)
@@ -174,7 +174,7 @@ public class KubectlLabelTest {
     wireMockRule.stubFor(
         put(urlPathEqualTo("/api/v1/nodes/foo"))
             .withRequestBody(
-                matchingJsonPath("$.metadata.labels", equalToJson("{ \"k1\": \"null\" }")))
+                matchingJsonPath("$.metadata.labels", equalToJson("{}")))
             .willReturn(aResponse().withStatus(200).withBody("{\"metadata\":{\"name\":\"foo\"}}")));
 
     V1Node unlabelledNode =


### PR DESCRIPTION
Updated KubectlLabel class to fix bug #2638 where the label was not deleted properly. The deleteLabel() method now removes the label key from the addingLabels map, and the resulting JSON object in the PUT request correctly omits the label key instead of setting it to null. Also updated the corresponding unit test to reflect the changes.