### PR TITLE
use dl.k8s.io, not kubernetes-release bucket

### DIFF
--- a/client-java-contrib/Dockerfile
+++ b/client-java-contrib/Dockerfile
@@ -4,7 +4,7 @@ FROM docker:stable
 RUN apk add --no-cache git bash && \
     wget -O /usr/bin/kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64 && \
     chmod +x /usr/bin/kind && \
-    wget -O /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.20.2/bin/linux/amd64/kubectl && \
+    wget -O /usr/bin/kubectl https://dl.k8s.io/release/v1.26.4/bin/linux/amd64/kubectl && \
     chmod +x /usr/bin/kubectl && \
     git clone https://github.com/kubernetes-client/gen.git && \
     cd gen && \


### PR DESCRIPTION
This commit updates the Dockerfile in the client-java-contrib directory. It modifies the installation of kubectl to use the updated URL: https://dl.k8s.io/release/v1.20.2/bin/linux/amd64/kubectl.

The previous URL (https://storage.googleapis.com/kubernetes-release/release/v1.20.2/bin/linux/amd64/kubectl) is no longer valid.

#### What type of PR is this?
/kind cleanup
/kind deprecation

#### What this PR does / why we need it:
There are still references to https://storage.googleapis.com/kubernetes-release instead of https://dl.k8s.io/

dl.k8s.io is the correct advertised download host and will eventually move to be fastly shielding a fully community-owned bucket

ref: https://github.com/kubernetes/k8s.io/issues/2396
