### PR TITLE
Fixed field names for explicit substitution

### DIFF
--- a/util/src/test/resources/crd-validations.yaml
+++ b/util/src/test/resources/crd-validations.yaml
@@ -1,0 +1,45 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: crontabs.stable.example.com
+spec:
+  group: stable.example.com
+  names:
+    kind: CronTab
+    plural: crontabs
+    shortNames:
+    - ct
+    singular: crontab
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          foo:
+            anyOf:
+            - type: integer
+            - type: string
+            pattern: ^.*
+            x-kubernetes-int-or-string: true
+          spec:
+            type: object
+            properties:
+              cronSpec:
+                type: string
+              image:
+                type: string
+              minReplicas:
+                type: integer
+              replicas:
+                type: integer
+              maxReplicas:
+                type: integer
+            x-kubernetes-validations:
+            - rule: self.minReplicas <= self.replicas
+              message: replicas should be greater than or equal to minReplicas.
+            - rule: self.replicas <= self.maxReplicas
+              message: replicas should be smaller than or equal to maxReplicas.
+    served: true
+    storage: true


### PR DESCRIPTION
For substitution we have to use field names, for example `xKubernetesEmbeddedResource` instead of `x-kubernetes-embedded-resource`.