### PR TITLE
Update generate.sh

### DIFF
--- a/client-java-contrib/generate.sh
+++ b/client-java-contrib/generate.sh
@@ -49,7 +49,7 @@ kind create cluster
 # install CRDs to the KinD cluster and dump the swagger spec
 for url in "${CRD_URLS[@]}"; do
   if [[ ! -z $url ]]; then
-    kubectl apply -f "$url"
+    kubectl create -f "$url"
   fi
 done
 


### PR DESCRIPTION
Java Model Generation Failed due to error message "The CustomResourceDefinition "xxx" is invalid: metadata.annotations: Too long: must have at most 262144 bytes" #2619