### PR TITLE
Fix Maven build warnings and minor doc issues

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,5 +1,5 @@
 # This workflow will build a Java project with Maven
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+# For more information see: https://docs.github.com/actions/automating-builds-and-tests/building-and-testing-java-with-maven
 
 name: build
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ If you have any problem with the package or any suggestions, please file an [iss
 1. Submit an issue describing your proposed change to the repo.
 2. Fork this repo, develop and test your code changes.
 3. Submit a pull request.
-4. The bot will automatically assigns someone to review your PR. Check the full list of bot commands [here](https://prow.k8s.io/command-help).
+4. The bot will automatically assign someone to review your PR. Check the full list of bot commands [here](https://prow.k8s.io/command-help).
 
 ### Contact
 You can reach the maintainers of this project at [SIG API Machinery](https://github.com/kubernetes/community/tree/master/sig-api-machinery) or on the [#kubernetes-client](https://kubernetes.slack.com/messages/kubernetes-client) channel on the Kubernetes slack.

--- a/examples/examples-release-14/README.md
+++ b/examples/examples-release-14/README.md
@@ -6,7 +6,7 @@ export REPO_ROOT=/path/to/client-java/repo
 cd ${REPO_ROOT}/
 mvn install
 
-cd ${REPO_ROOT}/examples/examples-13
+cd ${REPO_ROOT}/examples/examples-14
 mvn compile
 mvn exec:java -Dexec.mainClass="io.kubernetes.client.examples.Example"
 ```

--- a/examples/examples-release-15/README.md
+++ b/examples/examples-release-15/README.md
@@ -6,7 +6,7 @@ export REPO_ROOT=/path/to/client-java/repo
 cd ${REPO_ROOT}/
 mvn install
 
-cd ${REPO_ROOT}/examples/examples-13
+cd ${REPO_ROOT}/examples/examples-15
 mvn compile
 mvn exec:java -Dexec.mainClass="io.kubernetes.client.examples.Example"
 ```

--- a/fluent-gen/pom.xml
+++ b/fluent-gen/pom.xml
@@ -6,9 +6,6 @@
   <name>client-java-fluent-gen</name>
   <url>https://github.com/kubernetes-client/java</url>
   <description>Client Java Fluent Generator</description>
-  <prerequisites>
-    <maven>2.2.0</maven>
-  </prerequisites>
 
   <parent>
     <groupId>io.kubernetes</groupId>

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -6,9 +6,6 @@
   <name>client-java-api</name>
   <url>https://github.com/kubernetes-client/java</url>
   <description>Swagger Java</description>
-  <prerequisites>
-    <maven>2.2.0</maven>
-  </prerequisites>
 
   <parent>
     <groupId>io.kubernetes</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,6 @@
     <tag>HEAD</tag>
   </scm>
 
-  <prerequisites>
-    <maven>2.2.0</maven>
-  </prerequisites>
-
   <properties>
     <java.version>1.8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -392,6 +388,16 @@
           <artifactId>gmavenplus-plugin</artifactId>
           <version>2.1.0</version>
         </plugin>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.10</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.3.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -536,6 +542,25 @@ limitations under the License.
           </licenseHeader>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>2.2.0</version>
+                </requireMavenVersion>
+              </rules>    
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
@@ -568,7 +593,6 @@ limitations under the License.
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.10</version>
             <executions>
               <execution>
                 <id>jacoco-initialize</id>


### PR DESCRIPTION
- Fix Maven build warnings
    - Invalid use of `prerequisites` tag (replaced by `maven-enforcer-plugin`)
    - Missing version for `jacoco-maven-plugin` (introduced by https://github.com/kubernetes-client/java/pull/2493)
- Fix minor doc issues (typos and broken link)