### PR TITLE
fix: when api machine down, client which use SharedInformerFactory to watch keep the invalid connection and receive nothing unless restart process.

### DIFF
--- a/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiClient.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiClient.java
@@ -457,6 +457,13 @@ public class ApiClient {
     return this;
   }
 
+  /**
+   * Sets the call timeout (in milliseconds). A value of 0 means no timeout, otherwise values
+   * must be between 1 and {@link Integer#MAX_VALUE}.
+   *
+   * @param callTimeout connection timeout in milliseconds
+   * @return Api client
+   */
   public ApiClient setCallTimeout(int callTimeout) {
     httpClient =
         httpClient.newBuilder().callTimeout(callTimeout, TimeUnit.MILLISECONDS).build();

--- a/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiClient.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiClient.java
@@ -457,6 +457,12 @@ public class ApiClient {
     return this;
   }
 
+  public ApiClient setCallTimeout(int callTimeout) {
+    httpClient =
+        httpClient.newBuilder().callTimeout(callTimeout, TimeUnit.MILLISECONDS).build();
+    return this;
+  }
+
   /**
    * Get read timeout (in milliseconds).
    *

--- a/util/src/main/java/io/kubernetes/client/informer/SharedInformerFactory.java
+++ b/util/src/main/java/io/kubernetes/client/informer/SharedInformerFactory.java
@@ -16,6 +16,7 @@ import com.google.gson.reflect.TypeToken;
 import io.kubernetes.client.common.KubernetesListObject;
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.informer.cache.Cache;
+import io.kubernetes.client.informer.cache.ReflectorRunnable;
 import io.kubernetes.client.informer.impl.DefaultSharedIndexInformer;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
@@ -276,7 +277,7 @@ public class SharedInformerFactory {
         Call call = callGenerator.generate(params);
 
         //set call timeout to make sure the api machine down still work well
-        apiClient.setCallTimeout(apiClient.getConnectTimeout() + params.getTimeoutSeconds() * 1000);
+        apiClient.setCallTimeout(ReflectorRunnable.REFLECTOR_WATCH_CLIENTSIDE_MAX_TIMEOUT.toMillis());
 
         // bind call with private http client to make sure read timeout is zero.
         call = apiClient.getHttpClient().newCall(call.request());
@@ -326,7 +327,7 @@ public class SharedInformerFactory {
 
       public Watchable<ApiType> watch(CallGeneratorParams params) throws ApiException {
         //set call timeout to make sure the api machine down still work well
-        apiClient.setCallTimeout(apiClient.getConnectTimeout() + params.getTimeoutSeconds() * 1000);
+        apiClient.setCallTimeout(apiClient.getConnectTimeout() + ReflectorRunnable.REFLECTOR_WATCH_CLIENTSIDE_MAX_TIMEOUT.toMillis());
         
         if (Namespaces.NAMESPACE_ALL.equals(namespace)) {
           return genericKubernetesApi.watch(

--- a/util/src/main/java/io/kubernetes/client/informer/SharedInformerFactory.java
+++ b/util/src/main/java/io/kubernetes/client/informer/SharedInformerFactory.java
@@ -274,6 +274,11 @@ public class SharedInformerFactory {
       @Override
       public Watch<ApiType> watch(CallGeneratorParams params) throws ApiException {
         Call call = callGenerator.generate(params);
+
+        //set call timeout to make sure the machine down still work well
+        int callTimeout = apiClient.getConnectTimeout() + params.getTimeoutSeconds() * 1000;
+        apiClient.setHttpClient(apiClient.getHttpClient().newBuilder().callTimeout(Duration.ofMillis(callTimeout)).build());
+        
         // bind call with private http client to make sure read timeout is zero.
         call = apiClient.getHttpClient().newCall(call.request());
         return Watch.createWatch(

--- a/util/src/main/java/io/kubernetes/client/informer/SharedInformerFactory.java
+++ b/util/src/main/java/io/kubernetes/client/informer/SharedInformerFactory.java
@@ -327,7 +327,7 @@ public class SharedInformerFactory {
 
       public Watchable<ApiType> watch(CallGeneratorParams params) throws ApiException {
         //set call timeout to make sure the api machine down still work well
-        apiClient.setCallTimeout(apiClient.getConnectTimeout() + ReflectorRunnable.REFLECTOR_WATCH_CLIENTSIDE_MAX_TIMEOUT.toMillis());
+        apiClient.setCallTimeout(ReflectorRunnable.REFLECTOR_WATCH_CLIENTSIDE_MAX_TIMEOUT.toMillis());
         
         if (Namespaces.NAMESPACE_ALL.equals(namespace)) {
           return genericKubernetesApi.watch(

--- a/util/src/main/java/io/kubernetes/client/informer/SharedInformerFactory.java
+++ b/util/src/main/java/io/kubernetes/client/informer/SharedInformerFactory.java
@@ -276,9 +276,8 @@ public class SharedInformerFactory {
         Call call = callGenerator.generate(params);
 
         //set call timeout to make sure the machine down still work well
-        int callTimeout = apiClient.getConnectTimeout() + params.getTimeoutSeconds() * 1000;
-        apiClient.setHttpClient(apiClient.getHttpClient().newBuilder().callTimeout(Duration.ofMillis(callTimeout)).build());
-        
+        apiClient.setCallTimeout(apiClient.getConnectTimeout() + params.getTimeoutSeconds() * 1000);
+
         // bind call with private http client to make sure read timeout is zero.
         call = apiClient.getHttpClient().newCall(call.request());
         return Watch.createWatch(

--- a/util/src/main/java/io/kubernetes/client/informer/SharedInformerFactory.java
+++ b/util/src/main/java/io/kubernetes/client/informer/SharedInformerFactory.java
@@ -275,7 +275,7 @@ public class SharedInformerFactory {
       public Watch<ApiType> watch(CallGeneratorParams params) throws ApiException {
         Call call = callGenerator.generate(params);
 
-        //set call timeout to make sure the machine down still work well
+        //set call timeout to make sure the api machine down still work well
         apiClient.setCallTimeout(apiClient.getConnectTimeout() + params.getTimeoutSeconds() * 1000);
 
         // bind call with private http client to make sure read timeout is zero.
@@ -325,6 +325,9 @@ public class SharedInformerFactory {
       }
 
       public Watchable<ApiType> watch(CallGeneratorParams params) throws ApiException {
+        //set call timeout to make sure the api machine down still work well
+        apiClient.setCallTimeout(apiClient.getConnectTimeout() + params.getTimeoutSeconds() * 1000);
+        
         if (Namespaces.NAMESPACE_ALL.equals(namespace)) {
           return genericKubernetesApi.watch(
               new ListOptions() {


### PR DESCRIPTION
see issue #2678 https://github.com/kubernetes-client/java/issues/2678