### PR TITLE
Add automatic module names

### DIFF
--- a/extended/pom.xml
+++ b/extended/pom.xml
@@ -104,6 +104,11 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+                <configuration>
+                  <instructions>
+                    <Automatic-Module-Name>io.kubernetes.client.java.extended</Automatic-Module-Name>
+                  </instructions>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/fluent-gen/pom.xml
+++ b/fluent-gen/pom.xml
@@ -22,7 +22,6 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>5.1.9</version>
       </plugin>
     </plugins>
   </build>

--- a/fluent/pom.xml
+++ b/fluent/pom.xml
@@ -35,7 +35,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>5.1.9</version>
             </plugin>
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -23,6 +23,11 @@
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Automatic-Module-Name>io.kubernetes.client.java.api</Automatic-Module-Name>
+          </instructions>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -25,6 +25,11 @@
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
 				<extensions>true</extensions>
+                <configuration>
+                  <instructions>
+                    <Automatic-Module-Name>io.kubernetes.client.java.proto</Automatic-Module-Name>
+                  </instructions>
+                </configuration>
 			</plugin>
 			<plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/spring-aot/pom.xml
+++ b/spring-aot/pom.xml
@@ -57,6 +57,11 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+                <configuration>
+                  <instructions>
+                    <Automatic-Module-Name>io.kubernetes.client.java.spring.aot.integration</Automatic-Module-Name>
+                  </instructions>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -82,6 +82,11 @@
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Automatic-Module-Name>io.kubernetes.client.java.spring.integration</Automatic-Module-Name>
+          </instructions>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -128,6 +128,11 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+                <configuration>
+                  <instructions>
+                    <Automatic-Module-Name>io.kubernetes.client.java</Automatic-Module-Name>
+                  </instructions>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fix https://github.com/kubernetes-client/java/issues/2656 by adding `Automatic-Module-Name` manifest headers to appropriate jars. Values for the headers are derived from artifact IDs.