### PR TITLE
fix: discovery fail when at least one api is unavailable

### DIFF
--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlApiResources.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlApiResources.java
@@ -15,16 +15,24 @@ package io.kubernetes.client.extended.kubectl;
 import io.kubernetes.client.Discovery;
 import io.kubernetes.client.extended.kubectl.exception.KubectlException;
 import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.util.exception.IncompleteDiscoveryException;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class KubectlApiResources extends Kubectl.ApiClientBuilder<KubectlApiResources>
     implements Kubectl.Executable<Set<Discovery.APIResource>> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(KubectlApiResources.class);
 
   @Override
   public Set<Discovery.APIResource> execute() throws KubectlException {
     Discovery discovery = new Discovery(this.apiClient);
     try {
       return discovery.findAll();
+    } catch (IncompleteDiscoveryException e) {
+      LOGGER.warn("Error while getting all api resources, some resources will be missing", e);
+      return e.getDiscoveredResources();
     } catch (ApiException e) {
       throw new KubectlException(e);
     }

--- a/util/src/main/java/io/kubernetes/client/Discovery.java
+++ b/util/src/main/java/io/kubernetes/client/Discovery.java
@@ -72,7 +72,7 @@ public class Discovery {
       V1APIResourceList resourceList = resourceDiscovery(path);
       return groupResourcesByName(group, versions, preferredVersion, resourceList);
     } catch (ApiException e) {
-      LOGGER.warn("Api {} returns a {} code, all api resources managed by this api cannot be discovered", path, e.getCode(), e);
+      LOGGER.warn("Unable to retrieve the complete list of server APIs: {}/{}: {}", group, preferredVersion, e.getResponseBody());
       return Collections.emptySet();
     }
   }

--- a/util/src/main/java/io/kubernetes/client/Discovery.java
+++ b/util/src/main/java/io/kubernetes/client/Discovery.java
@@ -32,9 +32,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import okhttp3.Call;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Discovery {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(Discovery.class);
   private final ApiClient apiClient;
 
   public Discovery() {
@@ -60,16 +63,18 @@ public class Discovery {
     return allResources;
   }
 
-  public Set<APIResource> findAll(String group, List<String> versions, String preferredVersion)
-      throws ApiException {
+  public Set<APIResource> findAll(String group, List<String> versions, String preferredVersion) {
     return findAll(group, versions, preferredVersion, "/apis/" + group + "/" + preferredVersion);
   }
 
-  public Set<APIResource> findAll(
-      String group, List<String> versions, String preferredVersion, String path)
-      throws ApiException {
-    V1APIResourceList resourceList = resourceDiscovery(path);
-    return groupResourcesByName(group, versions, preferredVersion, resourceList);
+  public Set<APIResource> findAll(String group, List<String> versions, String preferredVersion, String path) {
+    try {
+      V1APIResourceList resourceList = resourceDiscovery(path);
+      return groupResourcesByName(group, versions, preferredVersion, resourceList);
+    } catch (ApiException e) {
+      LOGGER.warn("Api {} returns a {} code, all api resources managed by this api cannot be discovered", path, e.getCode(), e);
+      return Collections.emptySet();
+    }
   }
 
   public Set<APIResource> groupResourcesByName(

--- a/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
+++ b/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
@@ -18,6 +18,7 @@ import io.kubernetes.client.apimachinery.GroupVersionResource;
 import io.kubernetes.client.common.KubernetesListObject;
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.util.exception.IncompleteDiscoveryException;
 import java.io.File;
 
 import java.io.IOException;
@@ -266,7 +267,13 @@ public class ModelMapper {
       return lastAPIDiscovery;
     }
 
-    Set<Discovery.APIResource> apiResources = discovery.findAll();
+    Set<Discovery.APIResource> apiResources = null;
+    try {
+      apiResources = discovery.findAll();
+    } catch (IncompleteDiscoveryException e) {
+      logger.warn("Error while getting all api resources, some api resources will not be refreshed", e);
+      apiResources = e.getDiscoveredResources();
+    }
 
     for (Discovery.APIResource apiResource : apiResources) {
       for (String version : apiResource.getVersions()) {

--- a/util/src/main/java/io/kubernetes/client/util/exception/IncompleteDiscoveryException.java
+++ b/util/src/main/java/io/kubernetes/client/util/exception/IncompleteDiscoveryException.java
@@ -1,3 +1,15 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package io.kubernetes.client.util.exception;
 
 import io.kubernetes.client.Discovery.APIResource;

--- a/util/src/main/java/io/kubernetes/client/util/exception/IncompleteDiscoveryException.java
+++ b/util/src/main/java/io/kubernetes/client/util/exception/IncompleteDiscoveryException.java
@@ -1,0 +1,22 @@
+package io.kubernetes.client.util.exception;
+
+import io.kubernetes.client.Discovery.APIResource;
+import io.kubernetes.client.openapi.ApiException;
+import java.util.Set;
+
+public class IncompleteDiscoveryException extends ApiException {
+
+  private static final long serialVersionUID = 1L;
+
+  private final transient Set<APIResource> discoveredResources;
+
+  public IncompleteDiscoveryException(String message, ApiException cause, Set<APIResource> discoveredResources) {
+    super(message, cause, cause.getCode(), cause.getResponseHeaders(), cause.getResponseBody());
+    this.discoveredResources = discoveredResources;
+  }
+
+  public Set<APIResource> getDiscoveredResources() {
+    return discoveredResources;
+  }
+
+}

--- a/util/src/test/java/io/kubernetes/client/DiscoveryTest.java
+++ b/util/src/test/java/io/kubernetes/client/DiscoveryTest.java
@@ -28,6 +28,7 @@ import io.kubernetes.client.openapi.models.V1APIResourceList;
 import io.kubernetes.client.openapi.models.V1APIVersions;
 import io.kubernetes.client.util.ClientBuilder;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -129,7 +130,9 @@ public class DiscoveryTest {
                                       new V1APIResource()
                                         .name("second")))))));
 
-    Set<APIResource> apiResources = discovery.findAll(group, List.of(version), version);
+    List<String> versions = new ArrayList<>();
+    versions.add(version);
+    Set<APIResource> apiResources = discovery.findAll(group, versions, version);
     wireMockRule.verify(1, getRequestedFor(urlPathEqualTo(path)));
     assertEquals(2, apiResources.size());
   }
@@ -148,7 +151,9 @@ public class DiscoveryTest {
                 aResponse()
                     .withStatus(503)));
 
-    Set<APIResource> apiResources = discovery.findAll(group, List.of(version), version);
+    List<String> versions = new ArrayList<>();
+    versions.add(version);
+    Set<APIResource> apiResources = discovery.findAll(group, versions, version);
     wireMockRule.verify(1, getRequestedFor(urlPathEqualTo(path)));
     assertEquals(0, apiResources.size());
   }


### PR DESCRIPTION
fix #2719

Exceptions raised when calling an API to obtain all the resources it manages are now ignored. So when an API is unavailable, discovery doesn't stop, and all others APIs are processed.

This PR means that when ModelMapper calls Discovery#findAll and at least one api is unavailable, all metadata related to resources managed by unavailable APIs will not be updated in ModelMapper until the next refresh (30 minutes by default).

In addition, this PR allows the KubectlApiResources class (the extended client equivalent of `kubectl api-resources`) to list all resources managed by available API .