### PR TITLE
fix: NPE in GenericKubernetesApi if response body is empty

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/generic/GenericKubernetesApi.java
+++ b/util/src/main/java/io/kubernetes/client/util/generic/GenericKubernetesApi.java
@@ -23,6 +23,7 @@ import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.ApiCallback;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.ApiResponse;
 import io.kubernetes.client.openapi.Configuration;
 import io.kubernetes.client.openapi.apis.CustomObjectsApi;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -1356,7 +1357,11 @@ public class GenericKubernetesApi<
       ApiClient apiClient, Class<DataType> dataClass, CallBuilder callBuilder) {
     try {
       Call call = prepareCall(callBuilder);
-      JsonElement element = apiClient.<JsonElement>execute(call, JsonElement.class).getData();
+      ApiResponse<JsonElement> response = apiClient.execute(call, JsonElement.class);
+      JsonElement element = response.getData();
+      if (element == null) {
+        throw new ApiException(null, response.getStatusCode(), null, "Unexpected response body");
+      }
       return getKubernetesApiResponse(dataClass, element, apiClient.getJSON().getGson());
     } catch (ApiException e) {
       return responseFromApiException(apiClient, e);

--- a/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesApiTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesApiTest.java
@@ -246,6 +246,23 @@ public class GenericKubernetesApiTest {
   }
 
   @Test
+  public void patchNamespacedJobReturningEmpty() {
+    V1Patch v1Patch = new V1Patch("{}");
+    stubFor(
+        patch(urlEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1"))
+            .withHeader("Content-Type", containing(V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH))
+            .willReturn(aResponse().withStatus(200).withBody("")));
+    KubernetesApiResponse<V1Job> jobPatchResp =
+        jobClient.patch("default", "foo1", V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH, v1Patch);
+
+    assertTrue(jobPatchResp.isSuccess());
+    assertNull(jobPatchResp.getObject());
+    assertEquals("Unexpected response body", jobPatchResp.getStatus().getMessage());
+    assertEquals(200, jobPatchResp.getStatus().getCode().intValue());
+    verify(1, patchRequestedFor(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1")));
+  }
+
+  @Test
   public void watchNamespacedJobReturningObject() throws ApiException {
     V1JobList jobList = new V1JobList().kind("JobList").metadata(new V1ListMeta());
 


### PR DESCRIPTION
The PR is based on [Issue 2733](https://github.com/kubernetes-client/java/issues/2733)
Observe the problem description there.