### PR TITLE
Update dependencies except for Spring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.4.11</version>
+        <version>1.3.11</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -41,14 +41,14 @@
     <javax.annotation.version>1.3.2</javax.annotation.version>
     <snakeyaml.version>2.1</snakeyaml.version>
     <slf4j.version>2.0.7</slf4j.version>
-    <caffeine.version>2.9.3</caffeine.version>
-    <protobuf.version>3.24.0</protobuf.version>
+    <caffeine.version>3.1.8</caffeine.version>
+    <protobuf.version>3.24.1</protobuf.version>
     <junit.version>4.13</junit.version>
     <bucket4j.version>7.6.0</bucket4j.version>
     <bouncycastle.version>1.76</bouncycastle.version>
     <gson.version>2.10.1</gson.version>
     <jsr305.version>3.0.2</jsr305.version>
-    <okhttp3.version>4.10.0</okhttp3.version>
+    <okhttp3.version>4.11.0</okhttp3.version>
     <swagger-core.version>1.6.11</swagger-core.version>
     <sundrio.version>0.100.3</sundrio.version>
     <gsonfire.version>1.8.5</gsonfire.version>
@@ -59,7 +59,7 @@
     <common.codec.version>1.16.0</common.codec.version>
     <spring.boot.version>2.7.12</spring.boot.version>
     <spring.version>5.3.23</spring.version>
-    <prometheus.client.version>0.15.0</prometheus.client.version>
+    <prometheus.client.version>0.16.0</prometheus.client.version>
     <reflections.version>0.10.2</reflections.version>
 
     <e2e.skip>true</e2e.skip>
@@ -233,7 +233,7 @@
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.3.11</version>
+        <version>1.4.11</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -245,7 +245,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>4.11.0</version>
+        <version>5.4.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>5.4.0</version>
+        <version>4.11.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
We're seeing OWASP scan reports about okio, which is included by okhttp3. I'm curious about why Dependabot didn't update this dependency? Whatever the answer, here are all of the missing updates except for those from Spring, which seem to require other, compensating changes.