### PR TITLE
Update PortForwardTest.java

### DIFF
--- a/util/src/test/java/io/kubernetes/client/PortForwardTest.java
+++ b/util/src/test/java/io/kubernetes/client/PortForwardTest.java
@@ -184,7 +184,6 @@ public class PortForwardTest {
             });
     synchronized (block) {
       t.start();
-      Thread.sleep(2000);
       handler.close();
       block.wait();
     }


### PR DESCRIPTION
fixed the test to use semaphore class instead of thread.sleep() method.