### PR TITLE
chore: update examples-release-18

### DIFF
--- a/examples/examples-release-18/src/main/java/io/kubernetes/client/examples/Example.java
+++ b/examples/examples-release-18/src/main/java/io/kubernetes/client/examples/Example.java
@@ -36,9 +36,11 @@ public class Example {
 
     CoreV1Api api = new CoreV1Api();
     V1PodList list =
-        api.listPodForAllNamespaces(null, null, null, null, null, null, null, null, null, null, null);
+        api.listPodForAllNamespaces(null, null, null, null, null, null, null, null, null, null);
+    System.out.println("Pods:");
     for (V1Pod item : list.getItems()) {
-      System.out.println(item.getMetadata().getName());
+        assert item.getMetadata() != null;
+        System.out.println(item.getMetadata().getName());
     }
   }
 }

--- a/examples/examples-release-18/src/main/java/io/kubernetes/client/examples/InClusterClientExample.java
+++ b/examples/examples-release-18/src/main/java/io/kubernetes/client/examples/InClusterClientExample.java
@@ -52,7 +52,8 @@ public class InClusterClientExample {
     V1PodList list =
         api.listPodForAllNamespaces(null, null, null, null, null, null, null, null, null, null, null);
     for (V1Pod item : list.getItems()) {
-      System.out.println(item.getMetadata().getName());
+        assert item.getMetadata() != null;
+        System.out.println(item.getMetadata().getName());
     }
   }
 }

--- a/examples/examples-release-18/src/main/java/io/kubernetes/client/examples/KubeConfigFileClientExample.java
+++ b/examples/examples-release-18/src/main/java/io/kubernetes/client/examples/KubeConfigFileClientExample.java
@@ -50,9 +50,10 @@ public class KubeConfigFileClientExample {
 
     // invokes the CoreV1Api client
     V1PodList list =
-        api.listPodForAllNamespaces(null, null, null, null, null, null, null, null, null, null, null);
+        api.listPodForAllNamespaces(null, null, null, null, null, null, null, null, null, null);
     for (V1Pod item : list.getItems()) {
-      System.out.println(item.getMetadata().getName());
+        assert item.getMetadata() != null;
+        System.out.println(item.getMetadata().getName());
     }
   }
 }

--- a/examples/examples-release-18/src/main/java/io/kubernetes/client/examples/LogsExample.java
+++ b/examples/examples-release-18/src/main/java/io/kubernetes/client/examples/LogsExample.java
@@ -41,7 +41,7 @@ public class LogsExample {
     V1Pod pod =
         coreApi
             .listNamespacedPod(
-                "default", "false", null, null, null, null, null, null, null, null, null, null)
+                "default", "false", null, null, null, null, null, null, null, null, null)
             .getItems()
             .get(0);
 

--- a/examples/examples-release-18/src/main/java/io/kubernetes/client/examples/NamespaceList.java
+++ b/examples/examples-release-18/src/main/java/io/kubernetes/client/examples/NamespaceList.java
@@ -1,0 +1,55 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.examples;
+
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.Configuration;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1Namespace;
+import io.kubernetes.client.openapi.models.V1NamespaceList;
+import io.kubernetes.client.util.Config;
+import java.io.IOException;
+
+/**
+ * A simple example of how to use the Java API
+ *
+ * <p>Easiest way to run this: mvn exec:java
+ * -Dexec.mainClass="io.kubernetes.client.examples.NamespaceList"
+ *
+ * <p>From inside $REPO_DIR/examples
+ */
+public class NamespaceList {
+    public static void main(String[] args) throws IOException, ApiException {
+        try{
+            ApiClient client = Config.defaultClient();
+            Configuration.setDefaultApiClient(client);
+        }
+        catch(IOException e){
+            System.out.println(e.getMessage());
+        }
+        CoreV1Api api = new CoreV1Api();
+        try {
+            V1NamespaceList list =
+                    api.listNamespace(null, null, null, null, null, null, null, null, null, null);
+            System.out.println("Namespaces:");
+            for (V1Namespace item : list.getItems()) {
+                assert item.getMetadata() != null;
+                System.out.println(item.getMetadata().getName());
+            }
+        }
+        catch(ApiException e){
+            System.out.println(e.getMessage());
+        }
+    }
+}

--- a/examples/examples-release-18/src/main/java/io/kubernetes/client/examples/ResourceQuotaList.java
+++ b/examples/examples-release-18/src/main/java/io/kubernetes/client/examples/ResourceQuotaList.java
@@ -1,0 +1,56 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.examples;
+
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.Configuration;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1ResourceQuota;
+import io.kubernetes.client.openapi.models.V1ResourceQuotaList;
+import io.kubernetes.client.util.Config;
+import java.io.IOException;
+
+/**
+ * A simple example of how to use the Java API
+ *
+ * <p>Easiest way to run this: mvn exec:java
+ * -Dexec.mainClass="io.kubernetes.client.examples.ResourceQuotaList"
+ *
+ * <p>From inside $REPO_DIR/examples
+ */
+public class ResourceQuotaList {
+    public static void main(String[] args) throws IOException, ApiException {
+        try{
+            ApiClient client = Config.defaultClient();
+            Configuration.setDefaultApiClient(client);
+        }
+        catch(IOException e){
+            System.out.println(e.getMessage());
+        }
+
+        CoreV1Api api = new CoreV1Api();
+        try {
+             V1ResourceQuotaList list =
+                    api.listResourceQuotaForAllNamespaces(null, null, null, null, null, null, null, null, null, null);
+            System.out.println("Namespaces:");
+            for (V1ResourceQuota item : list.getItems()) {
+                assert item.getMetadata() != null;
+                System.out.println(item.getMetadata().getName());
+            }
+        }
+        catch(ApiException e){
+            System.out.println(e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Related to #2786 
Corrected parameter count for few examples for release 18.0.1
Also added 2 more examples:
- NamespaceList
- ResourceQuotaList


**Additional context:**
The client still remains open after executing a function; we can mitigate it by implementing the AutoCloseable interface and using a TWR block.

Also for some methods we are passing the `pretty` parameter as a String which I guess should be a Boolean IMO. Wdyt? We would have to change it everywhere tho... 