### PR TITLE
Call exceptionHandler on failure to acquire lease

### DIFF
--- a/extended/src/main/java/io/kubernetes/client/extended/leaderelection/LeaderElector.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/leaderelection/LeaderElector.java
@@ -291,6 +291,7 @@ public class LeaderElector implements AutoCloseable {
       oldLeaderElectionRecord = lock.get();
     } catch (ApiException e) {
       if (e.getCode() != HttpURLConnection.HTTP_NOT_FOUND) {
+        exceptionHandler.accept(e);
         log.error("Error retrieving resource lock {}", lock.describe(), e);
         return false;
       }


### PR DESCRIPTION
Clients may want to process failures to acquire leases so we should call the exception handler so they are notified of the exception and can process it.