### PR TITLE
Fixing flaky rate-limiting test

### DIFF
--- a/extended/src/test/java/io/kubernetes/client/extended/workqueue/DefaultRateLimitQueueTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/workqueue/DefaultRateLimitQueueTest.java
@@ -53,9 +53,12 @@ public class DefaultRateLimitQueueTest {
     long t1 = System.nanoTime();
     rlq.addRateLimited("foo");
     rlq.get();
-    long t2 = System.nanoTime();
+    long t2 = System.nanoTime() - 100000;
+    long elapsed = t2-t1;
+    long elapsedMillis = Math.round((float) elapsed / 1000_000f);
+    long backoffMillis = Math.round((float) MockRateLimiter.mockConstantBackoff.toNanos() / 1000_000f);
     assertTrue(
-        "Unexpected time: " + (t2 - t1) + " vs " + MockRateLimiter.mockConstantBackoff.toNanos(),
-        t2 - t1 >= MockRateLimiter.mockConstantBackoff.toNanos());
+        "Unexpected time: " + elapsedMillis + " vs " + backoffMillis,
+            elapsedMillis >= backoffMillis);
   }
 }


### PR DESCRIPTION
Fixing the following flaky tests by relaxing timestamp precision (from nano to milli)

```
SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
Error:  Failures: 
Error:    DefaultRateLimitQueueTest.testSimpleRateLimitQueue:57 Unexpected time: 499985735 vs 500000000
Error:  Tests run: 102, Failures: 1, Errors: 0, Skipped: 0
Error:  Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.1.2:test (default-test) on project client-java-extended: There are test failures.
Error:  
Error:  Please refer to /home/runner/work/java/java/extended/target/surefire-reports for the individual test results.
Error:  Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
Error:  
Error:  After correcting the problems, you can resume the build with the command
Error:    mvn <args> -rf :client-java-extended
Error: Process completed with exit code 1.
```