### PR TITLE
Add jakarta rs-api dependency

### DIFF
--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -176,6 +176,10 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>
+    <dependency>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+    </dependency>
 
     <!-- test dependencies -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
 
     <javax.annotation.version>1.3.2</javax.annotation.version>
     <jakarta.annotation.version>2.1.1</jakarta.annotation.version>
+    <jakarta.ws.rs-api-version>3.1.0</jakarta.ws.rs-api-version>
     <snakeyaml.version>2.2</snakeyaml.version>
     <slf4j.version>2.0.9</slf4j.version>
     <caffeine.version>2.9.3</caffeine.version>
@@ -232,6 +233,11 @@
         <groupId>jakarta.annotation</groupId>
         <artifactId>jakarta.annotation-api</artifactId>
         <version>${jakarta.annotation.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.ws.rs</groupId>
+        <artifactId>jakarta.ws.rs-api</artifactId>
+        <version>${jakarta.ws.rs-api-version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
Tried running generation on the master branch but failed with the following message, this PR explicitly adds jakarta rs-api dependency to fix the compile failure.

> https://github.com/kubernetes-client/java/actions/runs/6569477390/job/17845422444

```
Error:  /home/runner/work/java/java/kubernetes/src/main/java/io/kubernetes/client/openapi/apis/ApiregistrationApi.java:[37,26] package jakarta.ws.rs.core does not exist
Error:  /home/runner/work/java/java/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiException.java:[19,26] package jakarta.ws.rs.core does not exist
Error:  /home/runner/work/java/java/kubernetes/src/main/java/io/kubernetes/client/openapi/apis/AdmissionregistrationV1Api.java:[44,26] package jakarta.ws.rs.core does not exist
Error:  /home/runner/work/java/java/kubernetes/src/main/java/io/kubernetes/client/openapi/apis/CoordinationApi.java:[37,26] package jakarta.ws.rs.core does not exist
Error:  /home/runner/work/java/java/kubernetes/src/main/java/io/kubernetes/client/openapi/apis/BatchApi.java:[37,26] package jakarta.ws.rs.core does not exist
Error:  /home/runner/work/java/java/kubernetes/src/main/java/io/kubernetes/client/openapi/apis/StorageApi.java:[37,26] package jakarta.ws.rs.core does not exist
Error:  /home/runner/work/java/java/kubernetes/src/main/java/io/kubernetes/client/openapi/apis/NetworkingV1alpha1Api.java:[44,26] package jakarta.ws.rs.core does not exist
Error:  /home/runner/work/java/java/kubernetes/src/main/java/io/kubernetes/client/openapi/apis/CoreV1Api.java:[76,26] package jakarta.ws.rs.core does not exist
Error:  /home/runner/work/java/java/kubernetes/src/main/java/io/kubernetes/client/openapi/apis/ApiregistrationV1Api.java:[42,26] package jakarta.ws.rs.core does not exist
Error:  /home/runner/work/java/java/kubernetes/src/main/java/io/kubernetes/client/openapi/apis/AutoscalingV2Api.java:[42,26] package jakarta.ws.rs.core does not exist
Error:  /home/runner/work/java/java/kubernetes/src/main/java/io/kubernetes/client/openapi/apis/StorageV1Api.java:[50,26] package jakarta.ws.rs.core does not exist
Error:  /home/runner/work/java/java/kubernetes/src/main/java/io/kubernetes/client/openapi/apis/AdmissionregistrationApi.java:[37,26] package jakarta.ws.rs.core does not exist
Error:  /home/runner/work/java/java/kubernetes/src/main/java/io/kubernetes/client/openapi/apis/AutoscalingV1Api.java:[42,26] package jakarta.ws.rs.core does not exist
Error:  /home/runner/work/java/java/kubernetes/src/main/java/io/kubernetes/client/openapi/apis/OpenidApi.java:[36,26] package jakarta.ws.rs.core does not exist
Error:  /home/runner/work/java/java/kubernetes/src/main/java/io/kubernetes/client/openapi/apis/NetworkingApi.java:[37,26] package jakarta.ws.rs.core does not exist
Error:  /home/runner/work/java/java/kubernetes/src/main/java/io/kubernetes/client/openapi/apis/InternalApiserverApi.java:[37,26] package jakarta.ws.rs.core does not exist
Error:  /home/runner/work/java/java/kubernetes/src/main/java/io/kubernetes/client/openapi/apis/AdmissionregistrationV1alpha1Api.java:[44,26] package jakarta.ws.rs.core does not exist
Error:  /home/runner/work/java/java/kubernetes/src/main/java/io/kubernetes/client/openapi/apis/FlowcontrolApiserverV1beta2Api.java:[44,26] package jakarta.ws.rs.core does not exist
Error:  /home/runner/work/java/java/kubernetes/src/main/java/io/kubernetes/client/openapi/apis/NodeV1Api.java:[42,26] package jakarta.ws.rs.core does not exist
Error:  /home/runner/work/java/java/kubernetes/src/main/java/io/kubernetes/client/openapi/apis/AuthenticationV1alpha1Api.java:[38,26] package jakarta.ws.rs.core does not exist

```