### PR TITLE
Expose resize & connection-error streams for Attach

### DIFF
--- a/util/src/main/java/io/kubernetes/client/Attach.java
+++ b/util/src/main/java/io/kubernetes/client/Attach.java
@@ -258,6 +258,14 @@ public class Attach {
       return handler.getInputStream(2);
     }
 
+    public InputStream getConnectionErrorStream() {
+      return handler.getInputStream(3);
+    }
+
+    public OutputStream getResizeStream() {
+      return handler.getOutputStream(4);
+    }
+
     public void close() {
       handler.close();
     }


### PR DESCRIPTION
In #900, the streams for resizing and connection errors were added for Exec. This PR adds the same streams for Attach.

This makes it possible to resize the terminal when using Attach by getting the stream from the AttachResult.