### PR TITLE
Build with JDK 21

### DIFF
--- a/docs/java-controller-tutorial-rewrite-rs-controller.md
+++ b/docs/java-controller-tutorial-rewrite-rs-controller.md
@@ -32,8 +32,8 @@ plugins are present in the [pom.xml](https://github.com/yue9944882/replicaset-co
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-compiler-plugin</artifactId>
     <configuration>
-        <source>8</source>
-        <target>8</target>
+        <source>21</source>
+        <target>21</target>
     </configuration>
 </plugin>
 ```

--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <spock.version>2.3-groovy-4.0</spock.version>
+        <groovy.version>4.0.15</groovy.version>
     </properties>
     <dependencies>
         <dependency>
@@ -34,7 +35,22 @@
             <artifactId>spock-core</artifactId>
             <version>${spock.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <!-- spock brings apache groovy 4.0.4; but a minimum of 4.0.11 is required to be compatible with JDK 21 -->
+                <exclusion>
+                    <groupId>org.apache.groovy</groupId>
+                    <artifactId>groovy</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>${groovy.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -93,6 +109,7 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
@@ -105,9 +122,10 @@
                 </executions>
                 <dependencies>
                     <dependency>
-                        <groupId>org.codehaus.groovy</groupId>
-                        <artifactId>groovy-all</artifactId>
-                        <version>2.4.21</version>
+                        <groupId>org.apache.groovy</groupId>
+                        <artifactId>groovy</artifactId>
+                        <version>${groovy.version}</version>
+                        <scope>runtime</scope>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/extended/pom.xml
+++ b/extended/pom.xml
@@ -114,8 +114,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
   </scm>
 
   <properties>
-    <java.version>1.8</java.version>
+    <java.version>21</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven-plugin-version>1.0.0</maven-plugin-version>
@@ -73,6 +73,7 @@
 
     <gpg.keyname>48540ECBBF00A28EACCF04E720FD12AFB0C9EBA9</gpg.keyname>
     <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+    <mockito-core.version>5.6.0</mockito-core.version>
   </properties>
 
   <licenses>
@@ -273,7 +274,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>4.11.0</version>
+        <version>${mockito-core.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -35,8 +35,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
 		</plugins>

--- a/spring-aot/pom.xml
+++ b/spring-aot/pom.xml
@@ -67,8 +67,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -92,8 +92,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>8</source>
-          <target>8</target>
+          <source>21</source>
+          <target>21</target>
         </configuration>
       </plugin>
     </plugins>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -141,8 +141,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
As outlined in #2886, here's a change that will build and pass all tests except e2e tests. I've not had time to run e2e tests, but they compile.

Note that this very eagerly changes all locations where a java version is referenced to 21. What level of support is desired for this library is up to the maintainers. I'll argue that at the very least it's gotta be newer than Java 8.