### PR TITLE
Fix order-dependent flakiness in KubernetesReconcilerCreatorTest.java

### DIFF
--- a/spring/src/test/java/io/kubernetes/client/spring/extended/controller/KubernetesReconcilerCreatorTest.java
+++ b/spring/src/test/java/io/kubernetes/client/spring/extended/controller/KubernetesReconcilerCreatorTest.java
@@ -202,5 +202,6 @@ public class KubernetesReconcilerCreatorTest {
       fail();
     }
     assertEquals("foo", workQueue.get().getName());
+    sharedInformerFactory.stopAllRegisteredInformers();
   }
 }


### PR DESCRIPTION
**Describe the bug**
The order dependent flakiness was detected when `KubernetesReconcilerCreatorTest.java` was run before the `KubernetesInformerCreatorTest.java`. The error appeared at line 157 in `KubernetesInformerCreatorTest.java`. It was suppose to get 1 result the calling `getRequestedFor()`for specific `urlPattern`, however, the actual result was 2.

**Fix log**
The reason that the flakiness showed up was due to the object `SharedInformerFactory`. Since in the `KubernetesReconcilerCreatorTest.java`, we called `startAllRegisteredInformers` in the test and registered the `V1Pod`, but did not call `stopAllRegisteredInformers` to stop the registration, and then when next test class was run, there were already something in the database. Eventually, that lead to the unexpected output 2 when we called `getRequestedFor()`for specific `urlPattern`. To fix this order dependent flakiness, I added `sharedInformerFactory.stopAllRegisteredInformers()` at the end of the test `testSimplePodController()` in `KubernetesReconcilerCreatorTest.java`. This can make sure there won't be 2 instance with specific QueryParam came from different test class being stored in the database.

**Java Version**
Java 17

**To Reproduce**
`mvn install -pl spring -am -DskipTests`
(must setup iDFlakies on a Maven project - https://github.com/UT-SE-Research/iDFlakies)
`mvn -pl spring idflakies:detect -Ddetector.detector_type=random-class-method -Ddt.randomize.rounds=10 -Ddt.detector.original_order.all_must_pass=false`

**Expected behavior**
When calling the getRequestedFor() method in KubernetesInformerCreatorTest, we should get the return value as 1 since we only generated the object with specific QueryParam once in this test file.
