### PR TITLE
Add ignoreNotFound flag to KubectlDelete.java

### DIFF
--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlDelete.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlDelete.java
@@ -32,6 +32,7 @@ public class KubectlDelete<ApiType extends KubernetesObject>
     this.ignoreNotFound = ignore;
     return this;
   }
+
   @Override
   public ApiType execute() throws KubectlException {
     verifyArguments();

--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlDelete.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/KubectlDelete.java
@@ -42,7 +42,6 @@ public class KubectlDelete<ApiType extends KubernetesObject>
         return getGenericApi().delete(namespace, name).throwsApiException().getObject();
       } catch (ApiException e) {
         if (ignoreNotFound && e.getCode() == 404) {
-          System.out.println("Ignoring resource not found.");
           return null;
         } else {
           throw new KubectlException(e);
@@ -53,7 +52,6 @@ public class KubectlDelete<ApiType extends KubernetesObject>
         return getGenericApi().delete(name).throwsApiException().getObject();
       } catch (ApiException e) {
         if (ignoreNotFound && e.getCode() == 404) {
-          System.out.println("Ignoring resource not found.");
           return null;
         } else {
           throw new KubectlException(e);


### PR DESCRIPTION
This PR fixes #2876, an issue where attempting to delete a resource that doesn't exist throws an exception and causes the user to catch the exception.

Now, by setting the ignoreNotFound flag, exceptions don't have to be explicitly caught.