### PR TITLE
Fixed overflow issue when handling large inputs in QuantityFormatter

### DIFF
--- a/kubernetes/src/test/java/io/kubernetes/client/custom/QuantityFormatterTest.java
+++ b/kubernetes/src/test/java/io/kubernetes/client/custom/QuantityFormatterTest.java
@@ -179,4 +179,12 @@ public class QuantityFormatterTest {
             .format(new Quantity(BigDecimal.valueOf(12345), Quantity.Format.DECIMAL_EXPONENT));
     assertThat(formattedString, is("12345"));
   }
+
+  @Test
+  public void testFormatLargeDecimalExponent() {
+    final String formattedString2 =
+            new QuantityFormatter()
+                    .format(new Quantity(Float.toString(123456789012.f)));
+    assertThat(formattedString2, is("123456791e3"));
+  }
 }


### PR DESCRIPTION
This issue is caused by the `unscaledValue()` method of BigDecimal returning a BigInteger, which is then forcibly cast to a long, potentially causing overflow. 
If the value of `quantity.getNumber()` is greater than `Long.MAX_VALUE`, then overflow will occur.