### PR TITLE
#2241 fix bug: when running with a fat jar, need to read entries with openConnection

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
+++ b/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.net.JarURLConnection;
 import java.net.URI;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Enumeration;

--- a/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
+++ b/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
@@ -484,7 +484,11 @@ public class ModelMapper {
   }
 
   private static void processJarPackage(URL packageURL, String packageName, String pkg, ArrayList<String> names) throws IOException {
-    logger.info("Loading classes from jar {}", packageURL.getFile());
+    String jarFileName = URLDecoder.decode(packageURL.getFile(), "UTF-8");
+    if (!jarFileName.startsWith("jar:") && !jarFileName.startsWith("nested:")) {
+      logger.error("Loading classes from jar with error packageURL: {}", jarFileName);
+    }
+    logger.info("Loading classes from jar {}", jarFileName);
     try (JarFile jf = ((JarURLConnection) packageURL.openConnection()).getJarFile()) {
       Enumeration<JarEntry> jarEntries = jf.entries();
       while (jarEntries.hasMoreElements()) {

--- a/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
+++ b/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
@@ -486,17 +486,26 @@ public class ModelMapper {
 
   private static void processJarPackage(URL packageURL, String packageName, String pkg, ArrayList<String> names) throws IOException {
     String jarFileName = URLDecoder.decode(packageURL.getFile(), "UTF-8");
-    if (!jarFileName.startsWith("jar:") && !jarFileName.startsWith("nested:")) {
+    JarFile jf = null;
+    // jar: client in repository; nested: client in a fat jar
+    if (jarFileName.startsWith("jar:") || jarFileName.startsWith("nested:")) {
+      jf = ((JarURLConnection) packageURL.openConnection()).getJarFile();
+    }
+    // file: client is a file in target (unit test)
+    if (jarFileName.startsWith("file:") ) {
+      jarFileName = jarFileName.substring(5, jarFileName.indexOf("!"));
+      jf = new JarFile(jarFileName);
+    }
+    if (jf == null) {
       logger.error("Loading classes from jar with error packageURL: {}", jarFileName);
       return;
     }
     logger.info("Loading classes from jar {}", jarFileName);
-    try (JarFile jf = ((JarURLConnection) packageURL.openConnection()).getJarFile()) {
-      Enumeration<JarEntry> jarEntries = jf.entries();
-      while (jarEntries.hasMoreElements()) {
-        processJarEntry(jarEntries.nextElement(), packageName, pkg, names);
-      }
+    Enumeration<JarEntry> jarEntries = jf.entries();
+    while (jarEntries.hasMoreElements()) {
+      processJarEntry(jarEntries.nextElement(), packageName, pkg, names);
     }
+    jf.close();
   }
 
   private static void processJarEntry(JarEntry jarEntry, String packageName, String pkg, ArrayList<String> names) {

--- a/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
+++ b/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
@@ -487,6 +487,7 @@ public class ModelMapper {
     String jarFileName = URLDecoder.decode(packageURL.getFile(), "UTF-8");
     if (!jarFileName.startsWith("jar:") && !jarFileName.startsWith("nested:")) {
       logger.error("Loading classes from jar with error packageURL: {}", jarFileName);
+      return;
     }
     logger.info("Loading classes from jar {}", jarFileName);
     try (JarFile jf = ((JarURLConnection) packageURL.openConnection()).getJarFile()) {

--- a/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
+++ b/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
@@ -22,9 +22,9 @@ import io.kubernetes.client.util.exception.IncompleteDiscoveryException;
 import java.io.File;
 
 import java.io.IOException;
+import java.net.JarURLConnection;
 import java.net.URI;
 import java.net.URL;
-import java.net.URLDecoder;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -484,10 +484,8 @@ public class ModelMapper {
   }
 
   private static void processJarPackage(URL packageURL, String packageName, String pkg, ArrayList<String> names) throws IOException {
-    String jarFileName = URLDecoder.decode(packageURL.getFile(), "UTF-8");
-    jarFileName = jarFileName.substring(5, jarFileName.indexOf("!"));
-    logger.info("Loading classes from jar {}", jarFileName);
-    try (JarFile jf = new JarFile(jarFileName)) {
+    logger.info("Loading classes from jar {}", packageURL.getFile());
+    try (JarFile jf = ((JarURLConnection) packageURL.openConnection()).getJarFile()) {
       Enumeration<JarEntry> jarEntries = jf.entries();
       while (jarEntries.hasMoreElements()) {
         processJarEntry(jarEntries.nextElement(), packageName, pkg, names);


### PR DESCRIPTION
When running in IDE or a thin jar, it is ok.
When running with a fat jar in server, new JarFile can not open and read the entries.