### PR TITLE
Chore: Run github action for PR against `master-java8` branch

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,9 +5,9 @@ name: build
 
 on:
   push:
-    branches: [ "master", "release-**" ]
+    branches: [ "master", "master-java8", "release-**" ]
   pull_request:
-    branches: [ "master", "release-**" ]
+    branches: [ "master", "master-java8", "release-**" ]
 
 jobs:
   verify-format:


### PR DESCRIPTION
@brendandburns i think merging this into master branch should apply to all incoming PRs globally, if it doesn't work i will cherrypick this PR to `master-java8` branch in a follow-up