### PR TITLE
Branch(master-java8): Pin generator version to v4.3.1

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -59,7 +59,7 @@ jobs:
           export PACKAGE_NAME="io.kubernetes.client.openapi"
           EOF
 
-          bash java.sh ../../kubernetes/ settings
+          USE_SINGLE_PARAMETER=false OPENAPI_GENERATOR_COMMIT=v4.3.1 bash java.sh ../../kubernetes/ settings
           popd
           rm -rf gen
       - name: Generate Fluent

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,9 +5,9 @@ name: build
 
 on:
   push:
-    branches: [ "master", "release-**" ]
+    branches: [ "master", "master-java8", "release-**" ]
   pull_request:
-    branches: [ "master", "release-**" ]
+    branches: [ "master", "master-java8", "release-**" ]
 
 jobs:
   verify-format:


### PR DESCRIPTION
This PR (1) pins openapi generator version to v4.3.1 for `master-java8` branch so it will constantly skip java8 non-compatible upgrades (2) enables github action CI so the java8 source code can have test/CI coverage