### PR TITLE
Tracking manual edits in git diffs to unlock openapi ignore

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -62,6 +62,16 @@ jobs:
           USE_SINGLE_PARAMETER=true bash java.sh ../../kubernetes/ settings
           popd
           rm -rf gen
+          git config user.email "k8s.ci.robot@gmail.com"
+          git config user.name "Kubernetes Prow Robot"
+          git checkout -b "$BRANCH"
+          git add .
+          git commit -s -m 'Automated openapi generation from ${{ github.event.inputs.kubernetesBranch }}'
+      - name: Apply Manual Diffs
+        run: |
+          ls scripts/patches/*.diff | xargs git apply
+          git add .
+          git commit -s -m 'Applied patches under scripts/patches/*.diff'
       - name: Generate Fluent
         run: |
           # Only install the generated openapi module because the higher modules' compile
@@ -79,11 +89,8 @@ jobs:
       - name: Commit and push
         run: |
           # Commit and push
-          git config user.email "k8s.ci.robot@gmail.com"
-          git config user.name "Kubernetes Prow Robot"
-          git checkout -b "$BRANCH"
           git add .
-          git commit -s -m 'Automated openapi generation from ${{ github.event.inputs.kubernetesBranch }}'
+          git commit -s -m 'Format and fluent-gen from ${{ github.event.inputs.kubernetesBranch }}'
           git push origin "$BRANCH"
       - name: Pull Request
         uses: repo-sync/pull-request@v2

--- a/kubernetes/.openapi-generator-ignore
+++ b/kubernetes/.openapi-generator-ignore
@@ -5,6 +5,3 @@
 git_push.sh
 README.md
 pom.xml
-
-# Remove when changes in kubernetes-client/java#366,#240 make into upstream openapi-generator
-src/main/java/io/kubernetes/client/openapi/JSON.java

--- a/scripts/patches/json.diff
+++ b/scripts/patches/json.diff
@@ -1,0 +1,85 @@
+diff --git a/kubernetes/src/main/java/io/kubernetes/client/openapi/JSON.java b/kubernetes/src/main/java/io/kubernetes/client/openapi/JSON.java
+index 4406c2199..f56413a25 100644
+--- a/kubernetes/src/main/java/io/kubernetes/client/openapi/JSON.java
++++ b/kubernetes/src/main/java/io/kubernetes/client/openapi/JSON.java
+@@ -23,6 +23,8 @@ import com.google.gson.JsonElement;
+ import io.gsonfire.GsonFireBuilder;
+ import io.gsonfire.TypeSelector;
+ 
++import io.kubernetes.client.gson.V1StatusPreProcessor;
++import io.kubernetes.client.openapi.models.V1Status;
+ import okio.ByteString;
+ 
+ import java.io.IOException;
+@@ -34,6 +36,9 @@ import java.text.ParsePosition;
+ import java.time.LocalDate;
+ import java.time.OffsetDateTime;
+ import java.time.format.DateTimeFormatter;
++import java.time.format.DateTimeFormatterBuilder;
++import java.time.format.DateTimeParseException;
++import java.time.temporal.ChronoField;
+ import java.util.Date;
+ import java.util.Locale;
+ import java.util.Map;
+@@ -48,9 +53,19 @@ import java.util.HashMap;
+ public class JSON {
+     private static Gson gson;
+     private static boolean isLenientOnJson = false;
++
++    private static final DateTimeFormatter RFC3339MICRO_FORMATTER =
++            new DateTimeFormatterBuilder()
++                    .parseDefaulting(ChronoField.OFFSET_SECONDS, 0)
++                    .append(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"))
++                    .optionalStart()
++                    .appendFraction(ChronoField.NANO_OF_SECOND, 6, 6, true)
++                    .optionalEnd()
++                    .appendLiteral("Z")
++                    .toFormatter();
+     private static DateTypeAdapter dateTypeAdapter = new DateTypeAdapter();
+     private static SqlDateTypeAdapter sqlDateTypeAdapter = new SqlDateTypeAdapter();
+-    private static OffsetDateTimeTypeAdapter offsetDateTimeTypeAdapter = new OffsetDateTimeTypeAdapter();
++    private static OffsetDateTimeTypeAdapter offsetDateTimeTypeAdapter = new OffsetDateTimeTypeAdapter(RFC3339MICRO_FORMATTER);
+     private static LocalDateTypeAdapter localDateTypeAdapter = new LocalDateTypeAdapter();
+     private static ByteArrayAdapter byteArrayAdapter = new ByteArrayAdapter();
+ 
+@@ -58,7 +73,10 @@ public class JSON {
+     public static GsonBuilder createGson() {
+         GsonFireBuilder fireBuilder = new GsonFireBuilder()
+         ;
+-        GsonBuilder builder = fireBuilder.createGsonBuilder();
++        GsonBuilder builder =
++                fireBuilder
++                        .registerPreProcessor(V1Status.class, new V1StatusPreProcessor())
++                        .createGsonBuilder();
+         return builder;
+     }
+ 
+@@ -721,11 +739,14 @@ public class JSON {
+ 
+         @Override
+         public void write(JsonWriter out, byte[] value) throws IOException {
++            boolean oldHtmlSafe = out.isHtmlSafe();
++            out.setHtmlSafe(false);
+             if (value == null) {
+                 out.nullValue();
+             } else {
+                 out.value(ByteString.of(value).base64());
+             }
++            out.setHtmlSafe(oldHtmlSafe);
+         }
+ 
+         @Override
+@@ -781,7 +802,12 @@ public class JSON {
+                     if (date.endsWith("+0000")) {
+                         date = date.substring(0, date.length()-5) + "Z";
+                     }
+-                    return OffsetDateTime.parse(date, formatter);
++                    try {
++                        return OffsetDateTime.parse(date, formatter);
++                    } catch (DateTimeParseException e) {
++                        // backward-compatibility for ISO8601 timestamp format
++                        return OffsetDateTime.parse(date, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
++                    }
+             }
+         }
+     }

--- a/scripts/patches/list-meta.diff
+++ b/scripts/patches/list-meta.diff
@@ -1,0 +1,15 @@
+diff --git a/kubernetes/src/main/java/io/kubernetes/client/openapi/models/V1ListMeta.java b/kubernetes/src/main/java/io/kubernetes/client/openapi/models/V1ListMeta.java
+index 60381b312..7fb47e230 100644
+--- a/kubernetes/src/main/java/io/kubernetes/client/openapi/models/V1ListMeta.java
++++ b/kubernetes/src/main/java/io/kubernetes/client/openapi/models/V1ListMeta.java
+@@ -266,7 +266,9 @@ public class V1ListMeta {
+            @Override
+            public V1ListMeta read(JsonReader in) throws IOException {
+              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
+-             validateJsonObject(jsonObj);
++
++             // Disable validation so delete API can tolerate non-status return object (graceful deletion)
++             // validateJsonObject(jsonObj);
+              return thisAdapter.fromJsonTree(jsonObj);
+            }
+ 

--- a/scripts/patches/status.diff
+++ b/scripts/patches/status.diff
@@ -1,0 +1,14 @@
+diff --git a/kubernetes/src/main/java/io/kubernetes/client/openapi/models/V1Status.java b/kubernetes/src/main/java/io/kubernetes/client/openapi/models/V1Status.java
+index b2b6db803..8a8a9765d 100644
+--- a/kubernetes/src/main/java/io/kubernetes/client/openapi/models/V1Status.java
++++ b/kubernetes/src/main/java/io/kubernetes/client/openapi/models/V1Status.java
+@@ -394,7 +394,8 @@ public class V1Status {
+            @Override
+            public V1Status read(JsonReader in) throws IOException {
+              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
+-             validateJsonObject(jsonObj);
++             // Disable validation so delete API can tolerate non-status return object (graceful deletion)
++             // validateJsonObject(jsonObj);
+              return thisAdapter.fromJsonTree(jsonObj);
+            }
+ 


### PR DESCRIPTION
since we bumped the openapi generator to v6 from v4, there're a few additional manual code changes we need to made on top of the generated code. in the past, the only manual edits are in the `JSON` class however now it's extended to `V1ListMeta` and `V1Status` to be compatible with kubernetes graceful deletion (the returned type for k8s delete API is a status object however it will return the deleted object upon graceful/progressive deletion). this pull automates those manual changes by git patches instead of ignoring these models generation by the `.openapi-generator-ignore` configuration file. 

with this PR, the code generation workflow behavior will change from (1) ignoring manually editted source files to (2) always re-generate but apply git patches after generation.

an example of the code-generation PR from the new proposed workflow here can seen at: https://github.com/kubernetes-client/java/pull/3020