### PR TITLE
Update git generated commit author to pass CLA

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -62,8 +62,8 @@ jobs:
           USE_SINGLE_PARAMETER=true bash java.sh ../../kubernetes/ settings
           popd
           rm -rf gen
-          git config user.email "k8s.ci.robot@gmail.com"
-          git config user.name "Kubernetes Prow Robot"
+          git config user.email "k8s-publishing-bot@users.noreply.github.com"
+          git config user.name "Kubernetes Publisher"
           git checkout -b "$BRANCH"
           git add .
           git commit -s -m 'Automated openapi generation from ${{ github.event.inputs.kubernetesBranch }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,8 @@ jobs:
           export GPG_TTY=$(tty)
           (echo 5; echo y; echo save) | gpg --command-fd 0 --no-tty --pinentry-mode loopback --passphrase ${{ secrets.GPG_PASSWORD }} --no-greeting --edit-key 'Kubernetes Client Publishers' trust
           (echo 0; echo y; echo save) | gpg --command-fd 0 --no-tty --pinentry-mode loopback --passphrase ${{ secrets.GPG_PASSWORD }} --no-greeting --edit-key 'Kubernetes Client Publishers' expire
-          git config user.email "k8s.ci.robot@gmail.com"
-          git config user.name "Kubernetes Prow Robot"
+          git config user.email "k8s-publishing-bot@users.noreply.github.com"
+          git config user.name "Kubernetes Publisher"
       - name: Check Current Version
         run: |
           mvn -q \


### PR DESCRIPTION
those PR made by the workflows in this repo doesn't pass CLA validation somehow anymore, updating the git commit author info to another kubernetes robot to bypass the check:

https://github.com/kubernetes-client/java/pull/3042