### PR TITLE
Add null guards for Exec.ExecutionBuilder

### DIFF
--- a/util/src/main/java/io/kubernetes/client/Exec.java
+++ b/util/src/main/java/io/kubernetes/client/Exec.java
@@ -39,6 +39,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -359,9 +360,9 @@ public class Exec {
     private Consumer<Throwable> onUnhandledError;
 
     private ExecutionBuilder(String namespace, String name, String[] command) {
-      this.namespace = namespace;
-      this.name = name;
-      this.command = command;
+      this.namespace = Objects.requireNonNull(namespace, "namespace");
+      this.name = Objects.requireNonNull(name, "name");
+      this.command = Objects.requireNonNull(command, "command");
       this.stdin = true;
       this.stdout = true;
       this.stderr = true;

--- a/util/src/test/java/io/kubernetes/client/ExecTest.java
+++ b/util/src/test/java/io/kubernetes/client/ExecTest.java
@@ -19,6 +19,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -280,5 +281,19 @@ public class ExecTest {
         new ByteArrayInputStream(OUTPUT_EXIT_BAD_INT.getBytes(StandardCharsets.UTF_8));
     int exitCode = Exec.parseExitCode(client, inputStream);
     assertEquals(-1, exitCode);
+  }
+
+  @Test
+  public void testExecutionBuilderNull() {
+    Exec exec = new Exec(null);
+    assertThrows(NullPointerException.class, () -> {
+      exec.newExecutionBuilder(null, null, null);
+    });
+    assertThrows(NullPointerException.class, () -> {
+      exec.newExecutionBuilder("", null, null);
+    });
+    assertThrows(NullPointerException.class, () -> {
+      exec.newExecutionBuilder("", "", null);
+    });
   }
 }


### PR DESCRIPTION
The class `Exec.ExecutionBuilder` has three `private final` properties: `namespace`, `name`, and `command`. While it makes little sense to provide `null` as their values, if this happens, this would throw a `NullPointerException` at a much later time, complicating the debugging process.
This commit implements a fail-fast `null` guards for these variables.

Example:
```java
import io.kubernetes.client.Exec;

public class Test {
    public static void main(String args[]) throws Exception {
        Exec exec = new Exec(null);
        Exec.ExecutionBuilder builder = exec.newExecutionBuilder("", "", null);
        builder.execute();
    }
}
```

```console
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "io.kubernetes.client.openapi.ApiClient.escapeString(String)" because "this.localVarApiClient" is null
        at io.kubernetes.client.openapi.apis.CoreV1Api.readNamespacedPodCall(CoreV1Api.java:26682)
        at io.kubernetes.client.openapi.apis.CoreV1Api.readNamespacedPodValidateBeforeCall(CoreV1Api.java:26726)
        at io.kubernetes.client.openapi.apis.CoreV1Api.readNamespacedPodWithHttpInfo(CoreV1Api.java:26767)
        at io.kubernetes.client.openapi.apis.CoreV1Api.readNamespacedPod(CoreV1Api.java:26747)
        at io.kubernetes.client.Exec$ExecutionBuilder.execute(Exec.java:466)
        at Test.main(Test.java:7)
```