### PR TITLE
Change DefaultSharedIndexInformer constructor to use threadFactory

### DIFF
--- a/util/src/main/java/io/kubernetes/client/informer/impl/DefaultSharedIndexInformer.java
+++ b/util/src/main/java/io/kubernetes/client/informer/impl/DefaultSharedIndexInformer.java
@@ -24,9 +24,11 @@ import io.kubernetes.client.informer.cache.DeltaFIFO;
 import io.kubernetes.client.informer.cache.Indexer;
 import io.kubernetes.client.informer.cache.ProcessorListener;
 import io.kubernetes.client.informer.cache.SharedProcessor;
+import io.kubernetes.client.util.Threads;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ThreadFactory;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import org.apache.commons.collections4.CollectionUtils;
@@ -142,8 +144,9 @@ public class DefaultSharedIndexInformer<
             resyncCheckPeriodMillis,
             exceptionHandler);
 
-    controllerThread =
-        new Thread(controller::run, "informer-controller-" + apiTypeClass.getSimpleName());
+    ThreadFactory threadFactory =
+        Threads.threadFactory("informer-controller-" + apiTypeClass.getSimpleName());
+    controllerThread = threadFactory.newThread(controller::run);
   }
 
   /** add event callback */


### PR DESCRIPTION
While internally, controllers use `Threads.threadFactory`, `DefaultSharedIndexInformer` starts an ad-hoc thread. This makes it invisible to instrumentation setup via `Threads.setDefaultThreadFactory`. This changes the constructor to also use the same.

 I noticed this trying to instrument spring-cloud-kubernetes, and was wondering why I didn't see this thread.