### PR TITLE
Redact API key from debug logging

### DIFF
--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -198,8 +198,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>mockwebserver</artifactId>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -197,5 +197,9 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiClient.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiClient.java
@@ -38,7 +38,6 @@ import java.security.SecureRandom;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
 import java.text.DateFormat;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -51,7 +50,6 @@ import java.util.regex.Pattern;
 
 import io.kubernetes.client.openapi.auth.Authentication;
 import io.kubernetes.client.openapi.auth.HttpBasicAuth;
-import io.kubernetes.client.openapi.auth.HttpBearerAuth;
 import io.kubernetes.client.openapi.auth.ApiKeyAuth;
 
 /**
@@ -88,6 +86,8 @@ public class ApiClient {
     private OkHttpClient httpClient;
     private JSON json;
 
+    // Visible for testing
+    HttpLoggingInterceptor.Logger debugLogger = HttpLoggingInterceptor.Logger.DEFAULT;
     private HttpLoggingInterceptor loggingInterceptor;
 
     /**
@@ -518,8 +518,9 @@ public class ApiClient {
     public ApiClient setDebugging(boolean debugging) {
         if (debugging != this.debugging) {
             if (debugging) {
-                loggingInterceptor = new HttpLoggingInterceptor();
+                loggingInterceptor = new HttpLoggingInterceptor(debugLogger);
                 loggingInterceptor.setLevel(Level.BODY);
+                loggingInterceptor.redactHeader("authorization");
                 httpClient = httpClient.newBuilder().addInterceptor(loggingInterceptor).build();
             } else {
                 final OkHttpClient.Builder builder = httpClient.newBuilder();

--- a/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiClient.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiClient.java
@@ -12,16 +12,9 @@ limitations under the License.
 */
 package io.kubernetes.client.openapi;
 
-import okhttp3.*;
-import okhttp3.internal.http.HttpMethod;
-import okhttp3.internal.tls.OkHostnameVerifier;
-import okhttp3.logging.HttpLoggingInterceptor;
-import okhttp3.logging.HttpLoggingInterceptor.Level;
-import okio.Buffer;
-import okio.BufferedSink;
-import okio.Okio;
-
-import javax.net.ssl.*;
+import io.kubernetes.client.openapi.auth.ApiKeyAuth;
+import io.kubernetes.client.openapi.auth.Authentication;
+import io.kubernetes.client.openapi.auth.HttpBasicAuth;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -47,15 +40,21 @@ import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import io.kubernetes.client.openapi.auth.Authentication;
-import io.kubernetes.client.openapi.auth.HttpBasicAuth;
-import io.kubernetes.client.openapi.auth.ApiKeyAuth;
+import javax.net.ssl.*;
+import okhttp3.*;
+import okhttp3.internal.http.HttpMethod;
+import okhttp3.internal.tls.OkHostnameVerifier;
+import okhttp3.logging.HttpLoggingInterceptor;
+import okhttp3.logging.HttpLoggingInterceptor.Level;
+import okio.Buffer;
+import okio.BufferedSink;
+import okio.Okio;
 
 /**
  * <p>ApiClient class.</p>
  */
 public class ApiClient {
+    static final String AUTHORIZATION_NAME = "authorization";
 
     private String basePath = "http://localhost";
     protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
@@ -114,7 +113,7 @@ public class ApiClient {
         httpClient = client;
 
         // Setup authentications (key: authentication name, value: authentication).
-        authentications.put("BearerToken", new ApiKeyAuth("header", "authorization"));
+        authentications.put("BearerToken", new ApiKeyAuth("header", AUTHORIZATION_NAME));
         // Prevent the authentications from being modified.
         authentications = Collections.unmodifiableMap(authentications);
     }

--- a/kubernetes/src/test/java/io/kubernetes/client/openapi/ApiClientTest.java
+++ b/kubernetes/src/test/java/io/kubernetes/client/openapi/ApiClientTest.java
@@ -1,0 +1,101 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.openapi;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import okhttp3.Call;
+import okhttp3.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ApiClientTest {
+  static final String TEST_PATH =
+      "/api/v1/namespaces/default/services?resourceVersion=1&watch=false";
+  static final String TEST_API_KEY = "abracadabra";
+  static final String TEST_RESPONSE_BODY =
+      "{\n"
+          + "  \"kind\": \"ServiceList\",\n"
+          + "  \"apiVersion\": \"v1\",\n"
+          + "  \"metadata\": {\n"
+          + "    \"resourceVersion\": \"1\"\n"
+          + "  },\n"
+          + "  \"items\": [\n"
+          + "    {\n"
+          + "      \"metadata\": {\n"
+          + "        \"name\": \"demo\",\n"
+          + "        \"namespace\": \"default\",\n"
+          + "        \"uid\": \"48990dee-79af-4b80-b3f4-b81f51dea645\",\n"
+          + "        \"resourceVersion\": \"1\",\n"
+          + "      }\n"
+          + "    }\n"
+          + "  ]\n"
+          + "}\n";
+
+  @Rule public MockWebServer server = new MockWebServer();
+
+  @Test
+  public void testRedactsAuthorizationHeader() throws Exception {
+    // Set up the client with an API key
+    ApiClient apiClient = new ApiClient().setBasePath(server.url("").toString());
+    apiClient.setApiKey(TEST_API_KEY);
+
+    // Setup debug logging, taking care to capture logs instead of propagating to Java logging
+    StringBuilder logs = new StringBuilder();
+    apiClient.debugLogger = l -> logs.append(l).append('\n');
+    apiClient.setDebugging(true);
+
+    // Make a request in the same fashion openapi generated code does
+    Map<String, String> headers = new HashMap<>();
+    headers.put("Accept", "application/json");
+    Call testCall =
+        apiClient.buildCall(
+            null,
+            TEST_PATH,
+            "GET",
+            Collections.emptyList(),
+            Collections.emptyList(),
+            null,
+            headers,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            new String[] {"BearerToken"},
+            null);
+
+    // Enqueue a response on the mock server
+    server.enqueue(
+        new MockResponse()
+            .addHeader("Content-Type", "application/json")
+            .setBody(TEST_RESPONSE_BODY));
+
+    // Ensure the request completes, by verifying it received the expected response
+    try (Response response = testCall.execute()) {
+      assertThat(response.body().string(), equalTo(TEST_RESPONSE_BODY));
+    }
+
+    // Verify the server saw the API key
+    assertThat(server.takeRequest().getHeader("authorization"), equalTo(TEST_API_KEY));
+
+    // Verify the logs never saw the API key
+    assertThat(logs.toString(), containsString("authorization: ██"));
+    assertThat(logs.toString(), not(containsString("authorization: " + TEST_API_KEY)));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -291,7 +291,7 @@
       <dependency>
         <groupId>com.github.tomakehurst</groupId>
         <artifactId>wiremock</artifactId>
-        <version>3.0.1</version>
+        <version>2.27.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -220,11 +220,6 @@
         <version>${okhttp3.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.squareup.okhttp3</groupId>
-        <artifactId>mockwebserver</artifactId>
-        <version>${okhttp3.version}</version>
-      </dependency>
-      <dependency>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-annotations</artifactId>
         <version>${swagger-core.version}</version>
@@ -296,7 +291,7 @@
       <dependency>
         <groupId>com.github.tomakehurst</groupId>
         <artifactId>wiremock</artifactId>
-        <version>2.27.2</version>
+        <version>3.0.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,11 @@
         <version>${okhttp3.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>mockwebserver</artifactId>
+        <version>${okhttp3.version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-annotations</artifactId>
         <version>${swagger-core.version}</version>


### PR DESCRIPTION
This redacts the API key, which ends up in Authorization header in debug logs. This helps both reduce the size and also protect secrets.

As a side effect, this adds a mockwebserver test, matching version with the okhttp client used in openapi generated code. This part is important as we improve the debug experience for watch events later.