### PR TITLE
build: remove redundant groupId in poms that do it

### DIFF
--- a/client-java-contrib/admissionreview/pom.xml
+++ b/client-java-contrib/admissionreview/pom.xml
@@ -1,6 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>io.kubernetes</groupId>
     <artifactId>client-java-admission-review</artifactId>
     <name>admission-review</name>
     <url>https://github.com/kubernetes-client/java</url>

--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>io.kubernetes</groupId>
     <artifactId>e2e-tests</artifactId>
     <packaging>bundle</packaging>
     <name>client-java-e2e-tests</name>

--- a/fluent-gen/pom.xml
+++ b/fluent-gen/pom.xml
@@ -1,6 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>io.kubernetes</groupId>
   <artifactId>client-java-api-fluent-gen</artifactId>
   <packaging>bundle</packaging>
   <name>client-java-fluent-gen</name>

--- a/fluent/pom.xml
+++ b/fluent/pom.xml
@@ -1,6 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>io.kubernetes</groupId>
     <artifactId>client-java-api-fluent</artifactId>
     <packaging>bundle</packaging>
     <name>client-java-fluent</name>

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -1,6 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>io.kubernetes</groupId>
   <artifactId>client-java-api</artifactId>
   <packaging>bundle</packaging>
   <name>client-java-api</name>

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -1,6 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>io.kubernetes</groupId>
 	<artifactId>client-java-proto</artifactId>
 	<packaging>bundle</packaging>
 	<name>client-java-proto</name>

--- a/spring-aot/pom.xml
+++ b/spring-aot/pom.xml
@@ -2,7 +2,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>io.kubernetes</groupId>
     <artifactId>client-java-spring-aot-integration</artifactId>
     <packaging>bundle</packaging>
     <name>client-java-spring-aot-integration</name>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>io.kubernetes</groupId>
   <artifactId>client-java-spring-integration</artifactId>
   <packaging>bundle</packaging>
   <name>client-java-spring-integration</name>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -1,6 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>io.kubernetes</groupId>
     <artifactId>client-java</artifactId>
     <packaging>bundle</packaging>
     <name>client-java</name>


### PR DESCRIPTION
the group ID is inherited from the parent, and causes an IDE warning in IntelliJ