### PR TITLE
update: update wiremock & jackson

### DIFF
--- a/examples/examples-release-17/pom.xml
+++ b/examples/examples-release-17/pom.xml
@@ -75,7 +75,7 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
+			<groupId>org.wiremock</groupId>
 			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/examples/examples-release-18/pom.xml
+++ b/examples/examples-release-18/pom.xml
@@ -75,7 +75,7 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
+			<groupId>org.wiremock</groupId>
 			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/examples/examples-release-19/pom.xml
+++ b/examples/examples-release-19/pom.xml
@@ -75,7 +75,7 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
+			<groupId>org.wiremock</groupId>
 			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/examples/examples-release-20/pom.xml
+++ b/examples/examples-release-20/pom.xml
@@ -75,7 +75,7 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
+			<groupId>org.wiremock</groupId>
 			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/examples/examples-release-latest/pom.xml
+++ b/examples/examples-release-latest/pom.xml
@@ -75,7 +75,7 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
+			<groupId>org.wiremock</groupId>
 			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/extended/pom.xml
+++ b/extended/pom.xml
@@ -67,7 +67,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
+            <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
     <bucket4j.version>7.6.0</bucket4j.version>
     <bouncycastle.version>1.77</bouncycastle.version>
     <gson.version>2.10.1</gson.version>
+    <jackson.version>2.16.1</jackson.version>
     <jsr305.version>3.0.2</jsr305.version>
     <okhttp3.version>4.12.0</okhttp3.version>
     <swagger-core.version>1.6.13</swagger-core.version>
@@ -205,6 +206,11 @@
         <version>${gson.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.gsonfire</groupId>
         <artifactId>gson-fire</artifactId>
         <version>${gsonfire.version}</version>
@@ -289,9 +295,9 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>com.github.tomakehurst</groupId>
+        <groupId>org.wiremock</groupId>
         <artifactId>wiremock</artifactId>
-        <version>2.27.2</version>
+        <version>3.4.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -310,6 +316,12 @@
         <groupId>com.flipkart.zjsonpatch</groupId>
         <artifactId>zjsonpatch</artifactId>
         <version>0.4.16</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -60,7 +60,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
+      <groupId>org.wiremock</groupId>
       <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -105,7 +105,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
+            <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
wiremock contains lower version of jackson. new version wiremock can only work with new jackson (2.16.1)
