### PR TITLE
fix: Add JacksonSerializer to serialize IntOrString

### DIFF
--- a/examples/examples-release-17/pom.xml
+++ b/examples/examples-release-17/pom.xml
@@ -75,7 +75,7 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
+			<groupId>org.wiremock</groupId>
 			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/examples/examples-release-18/pom.xml
+++ b/examples/examples-release-18/pom.xml
@@ -75,7 +75,7 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
+			<groupId>org.wiremock</groupId>
 			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/examples/examples-release-19/pom.xml
+++ b/examples/examples-release-19/pom.xml
@@ -75,7 +75,7 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
+			<groupId>org.wiremock</groupId>
 			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/examples/examples-release-20/pom.xml
+++ b/examples/examples-release-20/pom.xml
@@ -75,7 +75,7 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
+			<groupId>org.wiremock</groupId>
 			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/examples/examples-release-latest/pom.xml
+++ b/examples/examples-release-latest/pom.xml
@@ -75,7 +75,7 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
+			<groupId>org.wiremock</groupId>
 			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/extended/pom.xml
+++ b/extended/pom.xml
@@ -67,7 +67,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
+            <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -165,6 +165,10 @@
       <artifactId>gson</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.gsonfire</groupId>
       <artifactId>gson-fire</artifactId>
     </dependency>

--- a/kubernetes/src/main/java/io/kubernetes/client/custom/IntOrString.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/custom/IntOrString.java
@@ -12,6 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.custom;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
@@ -21,6 +22,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 @JsonAdapter(IntOrString.IntOrStringAdapter.class)
+@JsonSerialize(using = IntOrStringJacksonSerializer.class)
 public class IntOrString {
   private final boolean isInt;
   private final String strValue;
@@ -67,7 +69,9 @@ public class IntOrString {
   }
 
   private boolean equals(IntOrString o) {
-    if (isInt != o.isInt) return false;
+    if (isInt != o.isInt) {
+      return false;
+    }
     return isInt ? Objects.equals(intValue, o.intValue) : Objects.equals(strValue, o.strValue);
   }
 

--- a/kubernetes/src/main/java/io/kubernetes/client/custom/IntOrStringJacksonSerializer.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/custom/IntOrStringJacksonSerializer.java
@@ -1,0 +1,39 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.custom;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+public class IntOrStringJacksonSerializer extends StdSerializer<IntOrString> {
+
+  public IntOrStringJacksonSerializer() {
+    this(null);
+  }
+
+  public IntOrStringJacksonSerializer(Class<IntOrString> t) {
+    super(IntOrString.class);
+  }
+
+  @Override
+  public void serialize(IntOrString value, JsonGenerator jg, SerializerProvider provider) throws IOException {
+    if (value.isInteger()) {
+      jg.writeNumber(value.getIntValue());
+    } else {
+      jg.writeString(value.getStrValue());
+    }
+  }
+}

--- a/kubernetes/src/test/java/io/kubernetes/client/custom/IntOrStringTest.java
+++ b/kubernetes/src/test/java/io/kubernetes/client/custom/IntOrStringTest.java
@@ -17,6 +17,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.*;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
 public class IntOrStringTest {
@@ -114,5 +116,15 @@ public class IntOrStringTest {
     IntOrString intOrString2 = new IntOrString("13");
 
     assertThat(intOrString1, not(equalTo(intOrString2)));
+  }
+
+  @Test
+  public void jacksonSerializer_writeValueAsString() throws JsonProcessingException {
+    IntOrString intOrString1 = new IntOrString(17);
+    IntOrString intOrString2 = new IntOrString("17");
+
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.writeValueAsString(intOrString1);
+    mapper.writeValueAsString(intOrString2);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
     <bucket4j.version>7.6.0</bucket4j.version>
     <bouncycastle.version>1.77</bouncycastle.version>
     <gson.version>2.10.1</gson.version>
+    <jackson.version>2.16.1</jackson.version>
     <jsr305.version>3.0.2</jsr305.version>
     <okhttp3.version>4.12.0</okhttp3.version>
     <swagger-core.version>1.6.13</swagger-core.version>
@@ -205,6 +206,11 @@
         <version>${gson.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.gsonfire</groupId>
         <artifactId>gson-fire</artifactId>
         <version>${gsonfire.version}</version>
@@ -289,9 +295,9 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>com.github.tomakehurst</groupId>
+        <groupId>org.wiremock</groupId>
         <artifactId>wiremock</artifactId>
-        <version>2.27.2</version>
+        <version>3.4.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -310,6 +316,12 @@
         <groupId>com.flipkart.zjsonpatch</groupId>
         <artifactId>zjsonpatch</artifactId>
         <version>0.4.16</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -60,7 +60,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
+      <groupId>org.wiremock</groupId>
       <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -105,7 +105,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
+            <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
It's OK when using Gson, but not all of the project want to dependency Gson when jackson is the default serialize tool.

Serialization tool would serialize any field with getter even if you don't want to serialize it.. When we serialize an object witch contant IntOrString, we got the exception.

Here is an adapter with Gson, but not for Jackson, Jackson is the default serialization tool in spring framework. So we got the issues like: https://github.com/kubernetes-client/java/issues/2593, https://github.com/kubernetes-client/java/issues/2566, (34 issues).

So it added a JacksonSerializer for Jackson.

This PR depends on another PR #3126