### PR TITLE
Migrate all test assertions to AssertJ

### DIFF
--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/e2e/src/test/java/io/kubernetes/client/e2e/extended/leaderelection/LeaderElectorTest.java
+++ b/e2e/src/test/java/io/kubernetes/client/e2e/extended/leaderelection/LeaderElectorTest.java
@@ -12,6 +12,8 @@ limitations under the License.
 */
 package io.kubernetes.client.e2e.extended.leaderelection;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.kubernetes.client.extended.leaderelection.LeaderElectionConfig;
 import io.kubernetes.client.extended.leaderelection.LeaderElector;
 import io.kubernetes.client.extended.leaderelection.Lock;
@@ -34,7 +36,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -165,8 +166,8 @@ public class LeaderElectorTest {
 
     // wait till someone becomes leader
     startBeingLeader.await();
-    Assert.assertNotNull(leaderRef.get());
-    Assert.assertTrue(candidate1.equals(leaderRef.get()) || candidate2.equals(leaderRef.get()));
+    assertThat(leaderRef).doesNotHaveNullValue();
+    assertThat(candidate1.equals(leaderRef.get()) || candidate2.equals(leaderRef.get())).isTrue();
 
     // stop both LeaderElectors, in order .. non-leader, then leader so that
     // non-leader doesn't get to become leader
@@ -181,8 +182,8 @@ public class LeaderElectorTest {
     stopBeingLeader.await();
 
     // make sure that only one candidate became leader
-    Assert.assertEquals(1, startBeingLeaderCount.get());
-    Assert.assertEquals(1, stopBeingLeaderCount.get());
+    assertThat(startBeingLeaderCount).hasValue(1);
+    assertThat(stopBeingLeaderCount).hasValue(1);
   }
 
   @Test(timeout = 45000L)

--- a/examples/examples-release-17/src/test/java/io/kubernetes/client/examples/ExampleTest.java
+++ b/examples/examples-release-17/src/test/java/io/kubernetes/client/examples/ExampleTest.java
@@ -25,7 +25,6 @@ import io.kubernetes.client.openapi.Configuration;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -34,7 +33,7 @@ public class ExampleTest {
   @Rule public WireMockRule wireMockRule = new WireMockRule(PORT);
 
   @Test
-  public void exactUrlOnly() throws IOException, ApiException {
+  public void exactUrlOnly() throws ApiException {
     ApiClient client = new ApiClient();
     client.setBasePath("http://localhost:" + PORT);
     Configuration.setDefaultApiClient(client);

--- a/examples/examples-release-18/src/test/java/io/kubernetes/client/examples/ExampleTest.java
+++ b/examples/examples-release-18/src/test/java/io/kubernetes/client/examples/ExampleTest.java
@@ -25,7 +25,6 @@ import io.kubernetes.client.openapi.Configuration;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -34,7 +33,7 @@ public class ExampleTest {
   @Rule public WireMockRule wireMockRule = new WireMockRule(PORT);
 
   @Test
-  public void exactUrlOnly() throws IOException, ApiException {
+  public void exactUrlOnly() throws ApiException {
     ApiClient client = new ApiClient();
     client.setBasePath("http://localhost:" + PORT);
     Configuration.setDefaultApiClient(client);

--- a/examples/examples-release-19/src/test/java/io/kubernetes/client/examples/ExampleTest.java
+++ b/examples/examples-release-19/src/test/java/io/kubernetes/client/examples/ExampleTest.java
@@ -25,7 +25,6 @@ import io.kubernetes.client.openapi.Configuration;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -34,7 +33,7 @@ public class ExampleTest {
   @Rule public WireMockRule wireMockRule = new WireMockRule(PORT);
 
   @Test
-  public void exactUrlOnly() throws IOException, ApiException {
+  public void exactUrlOnly() throws ApiException {
     ApiClient client = new ApiClient();
     client.setBasePath("http://localhost:" + PORT);
     Configuration.setDefaultApiClient(client);

--- a/examples/examples-release-20/src/test/java/io/kubernetes/client/examples/ExampleTest.java
+++ b/examples/examples-release-20/src/test/java/io/kubernetes/client/examples/ExampleTest.java
@@ -25,7 +25,6 @@ import io.kubernetes.client.openapi.Configuration;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -34,7 +33,7 @@ public class ExampleTest {
   @Rule public WireMockRule wireMockRule = new WireMockRule(PORT);
 
   @Test
-  public void exactUrlOnly() throws IOException, ApiException {
+  public void exactUrlOnly() throws ApiException {
     ApiClient client = new ApiClient();
     client.setBasePath("http://localhost:" + PORT);
     Configuration.setDefaultApiClient(client);

--- a/examples/examples-release-latest/src/test/java/io/kubernetes/client/examples/ExampleTest.java
+++ b/examples/examples-release-latest/src/test/java/io/kubernetes/client/examples/ExampleTest.java
@@ -25,7 +25,6 @@ import io.kubernetes.client.openapi.Configuration;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
-import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -34,7 +33,7 @@ public class ExampleTest {
   @Rule public WireMockRule wireMockRule = new WireMockRule(PORT);
 
   @Test
-  public void exactUrlOnly() throws IOException, ApiException {
+  public void exactUrlOnly() throws ApiException {
     ApiClient client = new ApiClient();
     client.setBasePath("http://localhost:" + PORT);
     Configuration.setDefaultApiClient(client);

--- a/extended/pom.xml
+++ b/extended/pom.xml
@@ -76,6 +76,11 @@
             <artifactId>commons-collections4</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extended/src/test/java/io/kubernetes/client/extended/controller/ControllerManagerTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/controller/ControllerManagerTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.controller;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.informer.SharedInformerFactory;
 import org.junit.Test;
@@ -27,12 +27,12 @@ public class ControllerManagerTest {
     ControllerManager cm = new ControllerManager(new SharedInformerFactory(), dummy1, dummy2);
 
     cm.run();
-    assertTrue(dummy1.started);
-    assertTrue(dummy2.started);
+    assertThat(dummy1.started).isTrue();
+    assertThat(dummy2.started).isTrue();
 
     cm.shutdown();
-    assertTrue(dummy1.stopped);
-    assertTrue(dummy2.stopped);
+    assertThat(dummy1.stopped).isTrue();
+    assertThat(dummy2.stopped).isTrue();
   }
 
   static class DummyController implements Controller {

--- a/extended/src/test/java/io/kubernetes/client/extended/controller/ControllerWatchTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/controller/ControllerWatchTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.controller;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.extended.controller.reconciler.Request;
 import io.kubernetes.client.extended.workqueue.DefaultWorkQueue;
@@ -34,11 +34,11 @@ public class ControllerWatchTest {
         new DefaultControllerWatch(
             V1Pod.class, workQueue, Controllers.defaultReflectiveKeyFunc(), Duration.ZERO);
     controllerWatch.getResourceEventHandler().onAdd(testPod);
-    assertEquals(1, workQueue.length());
+    assertThat(workQueue.length()).isEqualTo(1);
 
     controllerWatch.setOnAddFilterPredicate((V1Pod addedPod) -> false);
     controllerWatch.getResourceEventHandler().onAdd(testPod);
-    assertEquals(1, workQueue.length());
+    assertThat(workQueue.length()).isEqualTo(1);
   }
 
   @Test
@@ -48,11 +48,11 @@ public class ControllerWatchTest {
         new DefaultControllerWatch(
             V1Pod.class, workQueue, Controllers.defaultReflectiveKeyFunc(), Duration.ZERO);
     controllerWatch.getResourceEventHandler().onUpdate(null, testPod);
-    assertEquals(1, workQueue.length());
+    assertThat(workQueue.length()).isEqualTo(1);
 
     controllerWatch.setOnUpdateFilterPredicate((V1Pod oldPod, V1Pod newPod) -> false);
     controllerWatch.getResourceEventHandler().onUpdate(null, testPod);
-    assertEquals(1, workQueue.length());
+    assertThat(workQueue.length()).isEqualTo(1);
   }
 
   @Test
@@ -62,10 +62,10 @@ public class ControllerWatchTest {
         new DefaultControllerWatch(
             V1Pod.class, workQueue, Controllers.defaultReflectiveKeyFunc(), Duration.ZERO);
     controllerWatch.getResourceEventHandler().onDelete(testPod, false);
-    assertEquals(1, workQueue.length());
+    assertThat(workQueue.length()).isEqualTo(1);
 
     controllerWatch.setOnDeleteFilterPredicate((V1Pod newPod, Boolean stateUnknown) -> false);
     controllerWatch.getResourceEventHandler().onDelete(testPod, false);
-    assertEquals(1, workQueue.length());
+    assertThat(workQueue.length()).isEqualTo(1);
   }
 }

--- a/extended/src/test/java/io/kubernetes/client/extended/controller/DefaultControllerTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/controller/DefaultControllerTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.controller;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import io.kubernetes.client.extended.controller.reconciler.Reconciler;
@@ -54,10 +54,10 @@ public class DefaultControllerTest {
   }
 
   @Before
-  public void setUp() throws Exception {}
+  public void setUp() {}
 
   @After
-  public void tearDown() throws Exception {}
+  public void tearDown() {}
 
   @Mock private Reconciler mockReconciler;
 
@@ -181,7 +181,7 @@ public class DefaultControllerTest {
     latch.acquire();
     testController.shutdown();
 
-    assertTrue(resumed.get());
-    assertTrue(finishedRequests.size() >= 1);
+    assertThat(resumed).isTrue();
+    assertThat(finishedRequests).isNotEmpty();
   }
 }

--- a/extended/src/test/java/io/kubernetes/client/extended/controller/builder/DefaultControllerBuilderTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/controller/builder/DefaultControllerBuilderTest.java
@@ -13,7 +13,7 @@ limitations under the License.
 package io.kubernetes.client.extended.controller.builder;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.kubernetes.client.extended.controller.Controller;
@@ -56,12 +56,12 @@ public class DefaultControllerBuilderTest {
   @Rule public WireMockRule wireMockRule = new WireMockRule(PORT);
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     client = new ClientBuilder().setBasePath("http://localhost:" + PORT).build();
   }
 
   @After
-  public void tearDown() throws Exception {}
+  public void tearDown() {}
 
   @Test
   public void testWithLeaderElectorProxiesDefaultController() {}
@@ -188,10 +188,7 @@ public class DefaultControllerBuilderTest {
     latch.acquire(1);
 
     Request expectedRequest = new Request("hostname1/test-pod1");
-    assertEquals(1, keyFuncReceivingRequests.size());
-    assertEquals(expectedRequest, keyFuncReceivingRequests.get(0));
-
-    assertEquals(1, controllerReceivingRequests.size());
-    assertEquals(expectedRequest, controllerReceivingRequests.get(0));
+    assertThat(keyFuncReceivingRequests).containsExactly(expectedRequest);
+    assertThat(controllerReceivingRequests).containsExactly(expectedRequest);
   }
 }

--- a/extended/src/test/java/io/kubernetes/client/extended/event/EventAggregatorTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/event/EventAggregatorTest.java
@@ -12,8 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.event;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.extended.event.legacy.EventAggregator;
 import io.kubernetes.client.extended.event.legacy.EventUtils;
@@ -42,7 +41,7 @@ public class EventAggregatorTest {
                       .build())
               .getLeft()
               .getMessage();
-      assertNotEquals(aggregatedMessage, message);
+      assertThat(message).isNotEqualTo(aggregatedMessage);
     }
     CoreV1Event aggregatedEvent =
         aggregator
@@ -53,6 +52,6 @@ public class EventAggregatorTest {
                     .withMessage("not_noxu")
                     .build())
             .getLeft();
-    assertEquals(aggregatedMessage, aggregatedEvent.getMessage());
+    assertThat(aggregatedEvent.getMessage()).isEqualTo(aggregatedMessage);
   }
 }

--- a/extended/src/test/java/io/kubernetes/client/extended/event/EventLoggerTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/event/EventLoggerTest.java
@@ -12,9 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.event;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.extended.event.legacy.EventLogger;
@@ -50,11 +48,11 @@ public class EventLoggerTest {
     String aggregatedKey = EventUtils.getAggregatedAndLocalKeyByReason(event1).getRight();
     EventLogger eventLogger = new EventLogger(100, EventUtils::getEventKey);
     MutablePair<CoreV1Event, V1Patch> result1 = eventLogger.observe(event1, aggregatedKey);
-    assertEquals(event1, result1.getLeft());
-    assertNull(result1.getRight());
+    assertThat(result1.getLeft()).isEqualTo(event1);
+    assertThat(result1.getRight()).isNull();
 
     MutablePair<CoreV1Event, V1Patch> result2 = eventLogger.observe(event2, aggregatedKey);
-    assertEquals(event2, result2.getLeft());
-    assertNotNull(result2.getRight());
+    assertThat(result2.getLeft()).isEqualTo(event2);
+    assertThat(result2.getRight()).isNotNull();
   }
 }

--- a/extended/src/test/java/io/kubernetes/client/extended/event/EventSpamFilterTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/event/EventSpamFilterTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.event;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.extended.event.legacy.EventSpamFilter;
 import io.kubernetes.client.extended.event.legacy.EventUtils;
@@ -50,10 +50,10 @@ public class EventSpamFilterTest {
             .withInvolvedObject(new V1ObjectReference())
             .build();
     for (int i = 0; i < burst; i++) {
-      assertEquals(true, filter.filter(spammingEvent1));
+      assertThat(filter.filter(spammingEvent1)).isTrue();
     }
-    assertEquals(false, filter.filter(spammingEvent1));
-    assertEquals(false, filter.filter(spammingEvent2));
-    assertEquals(true, filter.filter(spammingEvent3));
+    assertThat(filter.filter(spammingEvent1)).isFalse();
+    assertThat(filter.filter(spammingEvent2)).isFalse();
+    assertThat(filter.filter(spammingEvent3)).isTrue();
   }
 }

--- a/extended/src/test/java/io/kubernetes/client/extended/event/legacy/EventLoggerTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/event/legacy/EventLoggerTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.event.legacy;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.custom.V1Patch;
 import java.time.OffsetDateTime;
@@ -25,8 +25,7 @@ public class EventLoggerTest {
     String expectedStr = "2021-03-02T15:02:48.179000Z";
     OffsetDateTime expected = OffsetDateTime.parse("2021-03-02T15:02:48.179000Z");
     V1Patch patch = EventLogger.buildEventPatch(1, "foo", expected);
-    assertEquals(
-        "{\"message\":\"foo\",\"count\":1,\"lastTimestamp\":\"" + expectedStr + "\"}",
-        patch.getValue());
+    assertThat(patch.getValue())
+        .isEqualTo("{\"message\":\"foo\",\"count\":1,\"lastTimestamp\":\"" + expectedStr + "\"}");
   }
 }

--- a/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlApplyTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlApplyTest.java
@@ -18,7 +18,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.patch;
 import static com.github.tomakehurst.wiremock.client.WireMock.patchRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
@@ -63,7 +63,7 @@ public class KubectlApplyTest {
   @Rule public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
   @Before
-  public void setup() throws IOException {
+  public void setup() {
     apiClient = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
   }
 
@@ -111,7 +111,7 @@ public class KubectlApplyTest {
             .execute();
     wireMockRule.verify(
         1, patchRequestedFor(urlPathEqualTo("/api/v1/namespaces/foo/configmaps/bar")));
-    assertNotNull(configMap);
+    assertThat(configMap).isNotNull();
   }
 
   @Test
@@ -155,6 +155,6 @@ public class KubectlApplyTest {
         Kubectl.apply(DynamicKubernetesObject.class).apiClient(apiClient).resource(obj).execute();
     wireMockRule.verify(
         1, patchRequestedFor(urlPathEqualTo("/apis/example.com/v1/namespaces/foo/bars/something")));
-    assertNotNull(out);
+    assertThat(out).isNotNull();
   }
 }

--- a/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlCreateTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlCreateTest.java
@@ -14,7 +14,7 @@ package io.kubernetes.client.extended.kubectl;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.kubernetes.client.extended.kubectl.exception.KubectlException;
@@ -55,7 +55,7 @@ public class KubectlCreateTest {
   @Rule public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
   @Before
-  public void setup() throws IOException {
+  public void setup() {
     apiClient = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
   }
 
@@ -102,6 +102,6 @@ public class KubectlCreateTest {
                             }))
                 .execute();
     wireMockRule.verify(1, postRequestedFor(urlPathEqualTo("/api/v1/namespaces/foo/configmaps")));
-    assertNotNull(configMap);
+    assertThat(configMap).isNotNull();
   }
 }

--- a/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlDeleteTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlDeleteTest.java
@@ -14,12 +14,10 @@ package io.kubernetes.client.extended.kubectl;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
-import io.kubernetes.client.extended.kubectl.Kubectl;
-import io.kubernetes.client.extended.kubectl.KubectlDelete;
 import io.kubernetes.client.extended.kubectl.exception.KubectlException;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
@@ -132,7 +130,7 @@ public class KubectlDeleteTest {
     }
 
     @Test
-    public void testKubectlDelete() throws KubectlException, IOException, ApiException {
+    public void testKubectlDelete() throws KubectlException, ApiException {
         wireMockRule.stubFor(
                 post(urlPathEqualTo("/apis/batch/v1/namespaces/foo/jobs"))
                         .willReturn(
@@ -209,12 +207,12 @@ public class KubectlDeleteTest {
         kubectlDelete.namespace("foo").name("bar");
         kubectlDelete.execute();
 
-        assertThrows(KubectlException.class, () -> {
+        assertThatThrownBy(() -> {
             KubectlDelete<V1Job> kubectlDelete2 = Kubectl.delete(V1Job.class);
             kubectlDelete2.apiClient(apiClient);
             kubectlDelete2.namespace("foo").name("bar");
             kubectlDelete2.execute();
-        });
+        }).isInstanceOf(KubectlException.class);
 
         KubectlDelete<V1Job> kubectlDelete2 = Kubectl.delete(V1Job.class);
         kubectlDelete2.apiClient(apiClient);

--- a/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlPatchTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlPatchTest.java
@@ -18,7 +18,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.patch;
 import static com.github.tomakehurst.wiremock.client.WireMock.patchRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
@@ -58,7 +58,7 @@ public class KubectlPatchTest {
   @Rule public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
 
   @Before
-  public void setup() throws IOException {
+  public void setup() {
     apiClient = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
   }
 
@@ -101,6 +101,6 @@ public class KubectlPatchTest {
             .execute();
     wireMockRule.verify(
         1, patchRequestedFor(urlPathEqualTo("/api/v1/namespaces/foo/configmaps/bar")));
-    assertNotNull(configMap);
+    assertThat(configMap).isNotNull();
   }
 }

--- a/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlRolloutTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlRolloutTest.java
@@ -19,7 +19,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.patch;
 import static com.github.tomakehurst.wiremock.client.WireMock.patchRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
@@ -39,7 +40,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
-import org.junit.Assert;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -103,7 +104,7 @@ public class KubectlRolloutTest {
           .toString();
 
   @Before
-  public void setup() throws IOException {
+  public void setup() {
     ModelMapper.addModelMap(
         "apps",
         "v1",
@@ -154,7 +155,7 @@ public class KubectlRolloutTest {
         1,
         getRequestedFor((urlPathEqualTo("/apis/apps/v1/namespaces/default/replicasets")))
             .withQueryParam("labelSelector", new EqualToPattern("app = bar")));
-    Assert.assertEquals(3, histories.size());
+    assertThat(histories).hasSize(3);
   }
 
   @Test
@@ -187,7 +188,7 @@ public class KubectlRolloutTest {
         1,
         getRequestedFor((urlPathEqualTo("/apis/apps/v1/namespaces/default/replicasets")))
             .withQueryParam("labelSelector", new EqualToPattern("app = bar")));
-    Assert.assertNotNull(template);
+    assertThat(template).isNotNull();
   }
 
   @Test
@@ -220,7 +221,7 @@ public class KubectlRolloutTest {
         1,
         getRequestedFor((urlPathEqualTo("/apis/apps/v1/namespaces/default/controllerrevisions")))
             .withQueryParam("labelSelector", new EqualToPattern("app = bar")));
-    Assert.assertEquals(3, histories.size());
+    assertThat(histories).hasSize(3);
   }
 
   @Test
@@ -265,7 +266,7 @@ public class KubectlRolloutTest {
         1,
         patchRequestedFor((urlPathEqualTo("/apis/apps/v1/namespaces/default/daemonsets/foo")))
             .withQueryParam("dryRun", new EqualToPattern("All")));
-    Assert.assertNotNull(template);
+    assertThat(template).isNotNull();
   }
 
   @Test
@@ -300,7 +301,7 @@ public class KubectlRolloutTest {
         1,
         getRequestedFor((urlPathEqualTo("/apis/apps/v1/namespaces/default/controllerrevisions")))
             .withQueryParam("labelSelector", new EqualToPattern("app = bar")));
-    Assert.assertEquals(3, histories.size());
+    assertThat(histories).hasSize(3);
   }
 
   @Test
@@ -346,7 +347,7 @@ public class KubectlRolloutTest {
         1,
         patchRequestedFor((urlPathEqualTo("/apis/apps/v1/namespaces/default/statefulsets/foo")))
             .withQueryParam("dryRun", new EqualToPattern("All")));
-    Assert.assertNotNull(template);
+    assertThat(template).isNotNull();
   }
 
   @Test
@@ -364,16 +365,16 @@ public class KubectlRolloutTest {
                     .withStatus(200)
                     .withBody(new String(Files.readAllBytes(Paths.get(REPLICASET_LIST))))));
 
-    assertThrows(
-        KubectlException.class,
-        () ->
-            Kubectl.rollout(V1Deployment.class)
-                .history()
-                .apiClient(apiClient)
-                .name("foo")
-                .namespace("default")
-                .revision(999)
-                .skipDiscovery()
-                .execute());
+    assertThatThrownBy(
+            () ->
+                Kubectl.rollout(V1Deployment.class)
+                    .history()
+                    .apiClient(apiClient)
+                    .name("foo")
+                    .namespace("default")
+                    .revision(999)
+                    .skipDiscovery()
+                    .execute())
+        .isInstanceOf(KubectlException.class);
   }
 }

--- a/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlScaleTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/kubectl/KubectlScaleTest.java
@@ -18,8 +18,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.patch;
 import static com.github.tomakehurst.wiremock.client.WireMock.patchRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.kubernetes.client.extended.kubectl.exception.KubectlException;
@@ -29,7 +29,6 @@ import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1ReplicaSet;
 import io.kubernetes.client.openapi.models.V1StatefulSet;
 import io.kubernetes.client.util.ClientBuilder;
-import java.io.IOException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,7 +40,7 @@ public class KubectlScaleTest {
   @Rule public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort(), false);
 
   @Before
-  public void setup() throws IOException {
+  public void setup() {
     apiClient = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
   }
 
@@ -65,7 +64,7 @@ public class KubectlScaleTest {
         patchRequestedFor(urlPathEqualTo("/apis/apps/v1/namespaces/default/deployments/foo"))
             .withRequestBody(
                 equalToJson("[{\"op\":\"replace\",\"path\":\"/spec/replicas\",\"value\":2}]")));
-    assertNotNull(scaled);
+    assertThat(scaled).isNotNull();
   }
 
   @Test
@@ -88,7 +87,7 @@ public class KubectlScaleTest {
         patchRequestedFor(urlPathEqualTo("/apis/apps/v1/namespaces/default/replicasets/foo"))
             .withRequestBody(
                 equalToJson("[{\"op\":\"replace\",\"path\":\"/spec/replicas\",\"value\":4}]")));
-    assertNotNull(scaled);
+    assertThat(scaled).isNotNull();
   }
 
   @Test
@@ -111,21 +110,19 @@ public class KubectlScaleTest {
         patchRequestedFor(urlPathEqualTo("/apis/apps/v1/namespaces/default/statefulsets/foo"))
             .withRequestBody(
                 equalToJson("[{\"op\":\"replace\",\"path\":\"/spec/replicas\",\"value\":8}]")));
-    assertNotNull(scaled);
+    assertThat(scaled).isNotNull();
   }
 
   @Test
   public void testKubectlScaleShouldThrow() {
-    assertThrows(
-        KubectlException.class,
-        () -> {
-          V1Pod scaled =
-              Kubectl.scale(V1Pod.class)
-                  .apiClient(apiClient)
-                  .name("foo")
-                  .namespace("default")
-                  .replicas(2)
-                  .execute();
-        });
+    assertThatThrownBy(
+            () ->
+                Kubectl.scale(V1Pod.class)
+                    .apiClient(apiClient)
+                    .name("foo")
+                    .namespace("default")
+                    .replicas(2)
+                    .execute())
+        .isInstanceOf(KubectlException.class);
   }
 }

--- a/extended/src/test/java/io/kubernetes/client/extended/kubectl/util/deployment/DeploymentHelperTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/kubectl/util/deployment/DeploymentHelperTest.java
@@ -17,6 +17,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
@@ -35,7 +36,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -59,7 +59,7 @@ public class DeploymentHelperTest {
           .toString();
 
   @Before
-  public void setup() throws IOException {
+  public void setup() {
     apiClient = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
   }
 
@@ -83,9 +83,9 @@ public class DeploymentHelperTest {
         1,
         getRequestedFor((urlPathEqualTo("/apis/apps/v1/namespaces/default/replicasets")))
             .withQueryParam("labelSelector", new EqualToPattern("app = bar")));
-    Assert.assertNotNull(newRs);
-    Assert.assertEquals(1, oldRSes.size());
-    Assert.assertEquals(2, allOldRSes.size());
+    assertThat(newRs).isNotNull();
+    assertThat(oldRSes).hasSize(1);
+    assertThat(allOldRSes).hasSize(2);
   }
 
   @Test
@@ -100,6 +100,6 @@ public class DeploymentHelperTest {
     }
     revisions.sort(Long::compareTo);
     List<Long> exceptRevisions = Arrays.asList(1L, 2L, 2L, 3L, 4L);
-    Assert.assertEquals(exceptRevisions, revisions);
+    assertThat(revisions).isEqualTo(exceptRevisions);
   }
 }

--- a/extended/src/test/java/io/kubernetes/client/extended/leaderelection/LeaderElectionTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/leaderelection/LeaderElectionTest.java
@@ -13,7 +13,7 @@ limitations under the License.
 package io.kubernetes.client.extended.leaderelection;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.kubernetes.client.openapi.ApiException;
@@ -28,7 +28,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -263,17 +262,16 @@ public class LeaderElectionTest {
   }
 
   private void assertHistory(List<String> history, String... expected) {
-    Assert.assertNotNull(expected);
-    Assert.assertNotNull(history);
-    Assert.assertEquals(expected.length, history.size());
+    assertThat(expected).isNotNull();
+    assertThat(history).isNotNull();
+    assertThat(history).hasSize(expected.length);
 
     for (int index = 0; index < history.size(); ++index) {
-      Assert.assertEquals(
-          String.format(
+      assertThat(history.get(index))
+          .withFailMessage(
               "Not equal at index %d, expected %s, got %s",
-              index, expected[index], history.get(index)),
-          expected[index],
-          history.get(index));
+              index, expected[index], history.get(index))
+          .isEqualTo(expected[index]);
     }
   }
 
@@ -281,8 +279,8 @@ public class LeaderElectionTest {
   // comparison with a '+' suffix. This allows for a semantic rather than literal
   // comparison to avoid issues of timing.
   private void assertWildcardHistory(List<String> history, String... expected) {
-    Assert.assertNotNull(expected);
-    Assert.assertNotNull(history);
+    assertThat(expected).isNotNull();
+    assertThat(history).isNotNull();
 
     // TODO: This code is too complicated and a little bit buggy, but it works
     // for the current limited use case. Clean this up!
@@ -299,11 +297,10 @@ public class LeaderElectionTest {
       } else {
         expectedIx++;
       }
-      Assert.assertEquals(
-          String.format(
-              "Not equal at index %d, expected %s, got %s", index, compare, history.get(index)),
-          compare,
-          history.get(index));
+      assertThat(history.get(index))
+          .withFailMessage(
+              "Not equal at index %d, expected %s, got %s", index, compare, history.get(index))
+          .isEqualTo(compare);
     }
   }
 
@@ -333,7 +330,7 @@ public class LeaderElectionTest {
         });
     cLatch.await();
 
-    assertEquals(expectedException, actualException.get().getCause());
+    assertThat(actualException.get()).hasCause(expectedException);
   }
 
   @Test
@@ -384,9 +381,7 @@ public class LeaderElectionTest {
     // wait for two notifications to occur.
     cLatch.await();
 
-    assertEquals(2, notifications.size());
-    assertEquals("foo2", notifications.get(0));
-    assertEquals("foo3", notifications.get(1));
+    assertThat(notifications).containsExactly("foo2", "foo3");
   }
 
   @Test
@@ -425,8 +420,8 @@ public class LeaderElectionTest {
         });
 
     cLatch.await();
-    assertEquals(1, notifications.size());
-    assertEquals("foo1", notifications.get(0));
+    assertThat(notifications).hasSize(1);
+    assertThat(notifications.get(0)).isEqualTo("foo1");
   }
 
   public static class MockResourceLock implements Lock {

--- a/extended/src/test/java/io/kubernetes/client/extended/network/EndpointsLoadBalancerTests.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/network/EndpointsLoadBalancerTests.java
@@ -12,14 +12,13 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.network;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.extended.network.exception.NoAvailableAddressException;
 import io.kubernetes.client.openapi.models.CoreV1EndpointPort;
 import io.kubernetes.client.openapi.models.V1EndpointAddress;
 import io.kubernetes.client.openapi.models.V1EndpointSubset;
 import io.kubernetes.client.openapi.models.V1Endpoints;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
@@ -67,7 +66,7 @@ public class EndpointsLoadBalancerTests {
               return null;
             });
     endpointsLoadBalancer.getTargetIP();
-    assertEquals(Arrays.asList("127.0.0.1", "127.0.0.2"), receivingAvailableIPs.get());
+    assertThat(receivingAvailableIPs.get()).containsExactly("127.0.0.1", "127.0.0.2");
   }
 
   @Test
@@ -81,7 +80,7 @@ public class EndpointsLoadBalancerTests {
               return null;
             });
     endpointsLoadBalancer.getTargetIP();
-    assertEquals(Arrays.asList("127.0.0.1", "127.0.0.2"), receivingAvailableIPs.get());
+    assertThat(receivingAvailableIPs.get()).containsExactly("127.0.0.1", "127.0.0.2");
   }
 
   @Test
@@ -95,6 +94,6 @@ public class EndpointsLoadBalancerTests {
               return null;
             });
     endpointsLoadBalancer.getTargetIP(8082);
-    assertEquals(Arrays.asList("127.0.0.3"), receivingAvailableIPs.get());
+    assertThat(receivingAvailableIPs.get()).containsExactly("127.0.0.3");
   }
 }

--- a/extended/src/test/java/io/kubernetes/client/extended/network/RoundRobinEndpointsLoadBalancerTests.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/network/RoundRobinEndpointsLoadBalancerTests.java
@@ -12,7 +12,8 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.network;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.kubernetes.client.extended.network.exception.NoAvailableAddressException;
 import io.kubernetes.client.openapi.models.CoreV1EndpointPort;
@@ -38,33 +39,27 @@ public class RoundRobinEndpointsLoadBalancerTests {
   @Test
   public void testChooseIPFromNullListShouldThrowException() {
     RoundRobinLoadBalanceStrategy strategy = new RoundRobinLoadBalanceStrategy();
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> {
-          strategy.chooseIP(null);
-        });
+    assertThatThrownBy(() -> strategy.chooseIP(null))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   public void testChooseIPFromEmptyListShouldThrowException() {
     RoundRobinLoadBalanceStrategy strategy = new RoundRobinLoadBalanceStrategy();
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> {
-          strategy.chooseIP(new ArrayList<>());
-        });
+    assertThatThrownBy(() -> strategy.chooseIP(new ArrayList<>()))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   public void testChooseFixedMultipleIPShouldWork() {
     RoundRobinLoadBalanceStrategy strategy = new RoundRobinLoadBalanceStrategy();
     List<String> availables = Arrays.asList("127.0.0.1", "127.0.0.2", "127.0.0.3");
-    assertEquals("127.0.0.1", strategy.chooseIP(availables));
-    assertEquals("127.0.0.2", strategy.chooseIP(availables));
-    assertEquals("127.0.0.3", strategy.chooseIP(availables));
-    assertEquals("127.0.0.1", strategy.chooseIP(availables));
-    assertEquals("127.0.0.2", strategy.chooseIP(availables));
-    assertEquals("127.0.0.3", strategy.chooseIP(availables));
+    assertThat(strategy.chooseIP(availables)).isEqualTo("127.0.0.1");
+    assertThat(strategy.chooseIP(availables)).isEqualTo("127.0.0.2");
+    assertThat(strategy.chooseIP(availables)).isEqualTo("127.0.0.3");
+    assertThat(strategy.chooseIP(availables)).isEqualTo("127.0.0.1");
+    assertThat(strategy.chooseIP(availables)).isEqualTo("127.0.0.2");
+    assertThat(strategy.chooseIP(availables)).isEqualTo("127.0.0.3");
   }
 
   @Test
@@ -73,25 +68,22 @@ public class RoundRobinEndpointsLoadBalancerTests {
     List<String> availables = Arrays.asList("127.0.0.1", "127.0.0.2", "127.0.0.3");
     List<String> availablesChanged =
         Arrays.asList("127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4", "127.0.0.5");
-    assertEquals("127.0.0.1", strategy.chooseIP(availables));
-    assertEquals("127.0.0.2", strategy.chooseIP(availables));
-    assertEquals("127.0.0.3", strategy.chooseIP(availables));
+    assertThat(strategy.chooseIP(availables)).isEqualTo("127.0.0.1");
+    assertThat(strategy.chooseIP(availables)).isEqualTo("127.0.0.2");
+    assertThat(strategy.chooseIP(availables)).isEqualTo("127.0.0.3");
 
-    assertEquals("127.0.0.4", strategy.chooseIP(availablesChanged));
-    assertEquals("127.0.0.5", strategy.chooseIP(availablesChanged));
+    assertThat(strategy.chooseIP(availablesChanged)).isEqualTo("127.0.0.4");
+    assertThat(strategy.chooseIP(availablesChanged)).isEqualTo("127.0.0.5");
   }
 
   @Test
   public void testEndpointLoadBalancing() throws NoAvailableAddressException {
     EndpointsLoadBalancer loadBalancer =
         new EndpointsLoadBalancer(() -> twoPortTwoHostEp, new RoundRobinLoadBalanceStrategy());
-    assertEquals("127.0.0.1", loadBalancer.getTargetIP());
-    assertEquals("127.0.0.2", loadBalancer.getTargetIP());
-    assertEquals("127.0.0.1", loadBalancer.getTargetIP(8081));
-    assertThrows(
-        NoAvailableAddressException.class,
-        () -> {
-          loadBalancer.getTargetIP(9999);
-        });
+    assertThat(loadBalancer.getTargetIP()).isEqualTo("127.0.0.1");
+    assertThat(loadBalancer.getTargetIP()).isEqualTo("127.0.0.2");
+    assertThat(loadBalancer.getTargetIP(8081)).isEqualTo("127.0.0.1");
+    assertThatThrownBy(() ->loadBalancer.getTargetIP(9999))
+        .isInstanceOf(NoAvailableAddressException.class);
   }
 }

--- a/extended/src/test/java/io/kubernetes/client/extended/pager/PagerTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/pager/PagerTest.java
@@ -20,8 +20,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
@@ -64,7 +63,7 @@ public class PagerTest {
   @Rule public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
 
   @Before
-  public void setup() throws IOException {
+  public void setup() {
     client = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
   }
 
@@ -94,7 +93,7 @@ public class PagerTest {
             1,
             V1NamespaceList.class);
     Iterator<V1Namespace> it = pager.iterator();
-    assertFalse("Iterator should be empty.", it.hasNext());
+    assertThat(it).isExhausted();
   }
 
   @Test
@@ -146,10 +145,10 @@ public class PagerTest {
           () -> {
             int size = 0;
             for (V1Namespace namespace : pager) {
-              assertEquals("default", namespace.getMetadata().getName());
+              assertThat(namespace.getMetadata().getName()).isEqualTo("default");
               size++;
             }
-            assertEquals(2, size);
+            assertThat(size).isEqualTo(2);
             latch.countDown();
           });
     }
@@ -197,11 +196,11 @@ public class PagerTest {
     int count = 0;
     try {
       for (V1Namespace namespace : pager) {
-        assertEquals("default", namespace.getMetadata().getName());
+        assertThat(namespace.getMetadata().getName()).isEqualTo("default");
         count++;
       }
     } catch (Exception e) {
-      assertEquals(status400Str, e.getMessage());
+      assertThat(e.getMessage()).isEqualTo(status400Str);
     }
 
     verify(
@@ -243,10 +242,10 @@ public class PagerTest {
     try {
       for (V1Namespace namespace : pager) {
         count++;
-        assertEquals("default", namespace.getMetadata().getName());
+        assertThat(namespace.getMetadata().getName()).isEqualTo("default");
       }
     } catch (Exception e) {
-      assertEquals(status400Str, e.getMessage());
+      assertThat(e.getMessage()).isEqualTo(status400Str);
     }
 
     verify(

--- a/extended/src/test/java/io/kubernetes/client/extended/workqueue/DefaultDelayingQueueTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/workqueue/DefaultDelayingQueueTest.java
@@ -12,8 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.workqueue;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.extended.wait.Wait;
 import java.time.Duration;
@@ -34,20 +33,20 @@ public class DefaultDelayingQueueTest {
     queue.addAfter("foo", Duration.ofMillis(50));
 
     // Verify that we haven't released it
-    assertTrue(waitForWaitingQueueToFill(queue));
-    assertEquals(queue.length(), 0);
+    assertThat(waitForWaitingQueueToFill(queue)).isTrue();
+    assertThat(0).isEqualTo(queue.length());
 
     // Advance time
     queue.injectTimeSource(
         () -> {
           return staticTime.plusMillis(100).toEpochMilli();
         });
-    assertTrue(waitForAdded(queue, 1));
+    assertThat(waitForAdded(queue, 1)).isTrue();
     String item = queue.get();
     queue.done(item);
 
     Thread.sleep(10 * 1000L);
-    assertEquals(queue.length(), 0);
+    assertThat(0).isEqualTo(queue.length());
   }
 
   @Test
@@ -63,17 +62,17 @@ public class DefaultDelayingQueueTest {
         });
 
     queue.addAfter(item, Duration.ofMillis(50));
-    assertTrue(waitForWaitingQueueToFill(queue));
+    assertThat(waitForWaitingQueueToFill(queue)).isTrue();
     queue.addAfter(item, Duration.ofMillis(70));
-    assertTrue(waitForWaitingQueueToFill(queue));
-    assertTrue("should not have added", queue.length() == 0);
+    assertThat(waitForWaitingQueueToFill(queue)).isTrue();
+    assertThat(queue.length()).withFailMessage("should not have added").isZero();
 
     // Advance time
     queue.injectTimeSource(
         () -> {
           return staticTime.plusMillis(60).toEpochMilli();
         });
-    assertTrue(waitForAdded(queue, 1));
+    assertThat(waitForAdded(queue, 1)).isTrue();
     item = queue.get();
     queue.done(item);
 
@@ -83,20 +82,20 @@ public class DefaultDelayingQueueTest {
         () -> {
           return staticTime.plusMillis(90).toEpochMilli();
         });
-    assertTrue("should not have added", queue.length() == 0);
+    assertThat(queue.length()).withFailMessage("should not have added").isZero();
 
     // test again, but this time the earlier should override
     queue.addAfter(item, Duration.ofMillis(50));
     queue.addAfter(item, Duration.ofMillis(30));
-    assertTrue(waitForWaitingQueueToFill(queue));
-    assertTrue("should not have added", queue.length() == 0);
+    assertThat(waitForWaitingQueueToFill(queue)).isTrue();
+    assertThat(queue.length()).withFailMessage("should not have added").isZero();
 
     // Advance time
     queue.injectTimeSource(
         () -> {
           return staticTime.plusMillis(150).toEpochMilli();
         });
-    assertTrue(waitForAdded(queue, 1));
+    assertThat(waitForAdded(queue, 1)).isTrue();
     item = queue.get();
     queue.done(item);
 
@@ -106,7 +105,7 @@ public class DefaultDelayingQueueTest {
         () -> {
           return staticTime.plusMillis(190).toEpochMilli();
         });
-    assertTrue("should not have added", queue.length() == 0);
+    assertThat(queue.length()).withFailMessage("should not have added").isZero();
   }
 
   @Test
@@ -125,20 +124,20 @@ public class DefaultDelayingQueueTest {
     queue.addAfter(first, Duration.ofSeconds(1));
     queue.addAfter(second, Duration.ofMillis(500));
     queue.addAfter(third, Duration.ofMillis(250));
-    assertTrue(waitForWaitingQueueToFill(queue));
-    assertTrue("should not have added", queue.length() == 0);
+    assertThat(waitForWaitingQueueToFill(queue)).isTrue();
+    assertThat(queue.length()).withFailMessage("should not have added").isZero();
 
     queue.injectTimeSource(
         () -> {
           return staticTime.plusMillis(2000).toEpochMilli();
         });
-    assertTrue(waitForAdded(queue, 3));
+    assertThat(waitForAdded(queue, 3)).isTrue();
     String actualFirst = queue.get();
-    assertEquals(actualFirst, third);
+    assertThat(third).isEqualTo(actualFirst);
     String actualSecond = queue.get();
-    assertEquals(actualSecond, second);
+    assertThat(second).isEqualTo(actualSecond);
     String actualThird = queue.get();
-    assertEquals(actualThird, first);
+    assertThat(first).isEqualTo(actualThird);
   }
 
   private boolean waitForAdded(DefaultDelayingQueue queue, int size) {

--- a/extended/src/test/java/io/kubernetes/client/extended/workqueue/DefaultRateLimitQueueTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/workqueue/DefaultRateLimitQueueTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.workqueue;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.extended.workqueue.ratelimiter.RateLimiter;
 import java.time.Duration;
@@ -57,8 +57,6 @@ public class DefaultRateLimitQueueTest {
     long elapsed = t2-t1;
     long elapsedMillis = Math.round((float) elapsed / 1000_000f);
     long backoffMillis = Math.round((float) MockRateLimiter.mockConstantBackoff.toNanos() / 1000_000f);
-    assertTrue(
-        "Unexpected time: " + elapsedMillis + " vs " + backoffMillis,
-            elapsedMillis >= backoffMillis);
+    assertThat(elapsedMillis).isGreaterThanOrEqualTo(backoffMillis);
   }
 }

--- a/extended/src/test/java/io/kubernetes/client/extended/workqueue/DefaultWorkQueueTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/workqueue/DefaultWorkQueueTest.java
@@ -12,8 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.workqueue;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -63,8 +62,9 @@ public class DefaultWorkQueueTest {
                 try {
                   for (; ; ) {
                     String item = queue.get();
-                    assertNotEquals(
-                        "Got an item added after shutdown.", "added after shutdown!", item);
+                    assertThat(item)
+                        .withFailMessage("Got an item added after shutdown")
+                        .isNotEqualTo("added after shutdown!");
                     if (item == null) {
                       return;
                     }
@@ -145,14 +145,14 @@ public class DefaultWorkQueueTest {
   }
 
   @Test
-  public void testLen() throws Exception {
+  public void testLen() {
     DefaultWorkQueue<String> queue = new DefaultWorkQueue<>();
     queue.add("foo");
-    assertEquals(1, queue.length());
+    assertThat(queue.length()).isEqualTo(1);
     queue.add("bar");
-    assertEquals(2, queue.length());
+    assertThat(queue.length()).isEqualTo(2);
     queue.add("foo"); // should not increase the queue length.
-    assertEquals(2, queue.length());
+    assertThat(queue.length()).isEqualTo(2);
   }
 
   @Test
@@ -162,7 +162,7 @@ public class DefaultWorkQueueTest {
 
     // Start processing
     String item = queue.get();
-    assertEquals("foo", item);
+    assertThat(item).isEqualTo("foo");
 
     // Add it back while processing
     queue.add(item);
@@ -172,11 +172,11 @@ public class DefaultWorkQueueTest {
 
     // It should be back on the queue
     item = queue.get();
-    assertEquals("foo", item);
+    assertThat(item).isEqualTo("foo");
 
     // Finish that one up
     queue.done(item);
 
-    assertEquals(0, queue.length());
+    assertThat(queue.length()).isZero();
   }
 }

--- a/extended/src/test/java/io/kubernetes/client/extended/workqueue/ratelimiter/BucketRateLimiterTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/workqueue/ratelimiter/BucketRateLimiterTest.java
@@ -12,8 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.workqueue.ratelimiter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 import org.junit.Rule;
@@ -26,39 +25,39 @@ public class BucketRateLimiterTest {
   @Test
   public void testBucketRateLimiterBasic() {
     RateLimiter<String> rateLimiter = new BucketRateLimiter<>(2, 1, Duration.ofMinutes(10));
-    assertEquals(Duration.ZERO, rateLimiter.when("one"));
-    assertEquals(Duration.ZERO, rateLimiter.when("one"));
+    assertThat(rateLimiter.when("one")).isZero();
+    assertThat(rateLimiter.when("one")).isZero();
 
     Duration waitDuration = rateLimiter.when("one");
     Duration expectDuration = Duration.ofMinutes(10);
 
     Duration diff = waitDuration.minus(expectDuration);
     // waitDuration might be smaller than expect duration because of time is elapsed.
-    assertTrue(diff.isZero() || (diff.isNegative() && !diff.plusSeconds(1).isNegative()));
+    assertThat(diff.isZero() || (diff.isNegative() && !diff.plusSeconds(1).isNegative())).isTrue();
 
     waitDuration = rateLimiter.when("one");
     expectDuration = Duration.ofMinutes(20);
     diff = waitDuration.minus(expectDuration);
 
-    assertTrue(diff.isZero() || (diff.isNegative() && !diff.plusSeconds(1).isNegative()));
+    assertThat(diff.isZero() || (diff.isNegative() && !diff.plusSeconds(1).isNegative())).isTrue();
   }
 
   @Test
   public void testBucketRateLimiterTokenAdded() throws InterruptedException {
     RateLimiter<String> rateLimiter = new BucketRateLimiter<>(2, 1, Duration.ofSeconds(2));
 
-    assertEquals(Duration.ZERO, rateLimiter.when("one"));
-    assertEquals(Duration.ZERO, rateLimiter.when("one"));
+    assertThat(rateLimiter.when("one")).isZero();
+    assertThat(rateLimiter.when("one")).isZero();
 
     Duration waitDuration = rateLimiter.when("one");
-    assertTrue(waitDuration.getSeconds() > 0);
+    assertThat(waitDuration.getSeconds()).isPositive();
 
     Thread.sleep(4000);
 
-    assertEquals(Duration.ZERO, rateLimiter.when("two"));
+    assertThat(rateLimiter.when("two")).isZero();
 
     waitDuration = rateLimiter.when("two");
-    assertTrue(waitDuration.getSeconds() > 0);
+    assertThat(waitDuration.getSeconds()).isPositive();
   }
 
   @Test

--- a/extended/src/test/java/io/kubernetes/client/extended/workqueue/ratelimiter/ItemExponentialFailureRateLimiterTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/workqueue/ratelimiter/ItemExponentialFailureRateLimiterTest.java
@@ -12,8 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.workqueue.ratelimiter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 import org.junit.Test;
@@ -25,21 +24,21 @@ public class ItemExponentialFailureRateLimiterTest {
     RateLimiter<String> rateLimiter =
         new ItemExponentialFailureRateLimiter<>(Duration.ofMillis(1), Duration.ofSeconds(1));
 
-    assertEquals(Duration.ofMillis(1), rateLimiter.when("one"));
-    assertEquals(Duration.ofMillis(2), rateLimiter.when("one"));
-    assertEquals(Duration.ofMillis(4), rateLimiter.when("one"));
-    assertEquals(Duration.ofMillis(8), rateLimiter.when("one"));
-    assertEquals(Duration.ofMillis(16), rateLimiter.when("one"));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofMillis(1));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofMillis(2));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofMillis(4));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofMillis(8));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofMillis(16));
 
-    assertEquals(5, rateLimiter.numRequeues("one"));
+    assertThat(rateLimiter.numRequeues("one")).isEqualTo(5);
 
-    assertEquals(Duration.ofMillis(1), rateLimiter.when("two"));
-    assertEquals(Duration.ofMillis(2), rateLimiter.when("two"));
-    assertEquals(2, rateLimiter.numRequeues("two"));
+    assertThat(rateLimiter.when("two")).isEqualTo(Duration.ofMillis(1));
+    assertThat(rateLimiter.when("two")).isEqualTo(Duration.ofMillis(2));
+    assertThat(rateLimiter.numRequeues("two")).isEqualTo(2);
 
     rateLimiter.forget("one");
-    assertEquals(0, rateLimiter.numRequeues("one"));
-    assertEquals(Duration.ofMillis(1), rateLimiter.when("one"));
+    assertThat(rateLimiter.numRequeues("one")).isZero();
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofMillis(1));
   }
 
   @Test
@@ -50,24 +49,24 @@ public class ItemExponentialFailureRateLimiterTest {
     for (int i = 0; i < 5; i++) {
       rateLimiter.when("one");
     }
-    assertEquals(Duration.ofMillis(32), rateLimiter.when("one"));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofMillis(32));
 
     for (int i = 0; i < 1000; i++) {
       rateLimiter.when("overflow1");
     }
-    assertEquals(Duration.ofSeconds(1000), rateLimiter.when("overflow1"));
+    assertThat(rateLimiter.when("overflow1")).isEqualTo(Duration.ofSeconds(1000));
 
     rateLimiter =
         new ItemExponentialFailureRateLimiter<>(Duration.ofMinutes(1), Duration.ofHours(1000));
     for (int i = 0; i < 2; i++) {
       rateLimiter.when("two");
     }
-    assertEquals(Duration.ofMinutes(4), rateLimiter.when("two"));
+    assertThat(rateLimiter.when("two")).isEqualTo(Duration.ofMinutes(4));
 
     for (int i = 0; i < 1000; i++) {
       rateLimiter.when("overflow2");
     }
-    assertEquals(Duration.ofHours(1000), rateLimiter.when("overflow2"));
+    assertThat(rateLimiter.when("overflow2")).isEqualTo(Duration.ofHours(1000));
   }
 
   @Test
@@ -78,11 +77,11 @@ public class ItemExponentialFailureRateLimiterTest {
     for (int i = 0; i < 5; i++) {
       rateLimiter.when("one");
     }
-    assertEquals(Duration.ofMillis(-32), rateLimiter.when("one"));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofMillis(-32));
     for (int i = 0; i < 1000; i++) {
       rateLimiter.when("overflow1");
     }
-    assertTrue(rateLimiter.when("overflow1").isNegative());
+    assertThat(rateLimiter.when("overflow1")).isNegative();
   }
 
   @Test
@@ -90,9 +89,9 @@ public class ItemExponentialFailureRateLimiterTest {
     RateLimiter<String> rateLimiter =
         new ItemExponentialFailureRateLimiter<>(Duration.ofMillis(1), Duration.ofSeconds(-1000));
 
-    assertEquals(Duration.ofSeconds(-1000), rateLimiter.when("one"));
-    assertEquals(Duration.ofSeconds(-1000), rateLimiter.when("one"));
-    assertEquals(Duration.ofSeconds(-1000), rateLimiter.when("one"));
-    assertEquals(Duration.ofSeconds(-1000), rateLimiter.when("one"));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofSeconds(-1000));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofSeconds(-1000));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofSeconds(-1000));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofSeconds(-1000));
   }
 }

--- a/extended/src/test/java/io/kubernetes/client/extended/workqueue/ratelimiter/ItemFastSlowRateLimiterTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/workqueue/ratelimiter/ItemFastSlowRateLimiterTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.workqueue.ratelimiter;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 import org.junit.Test;
@@ -24,22 +24,22 @@ public class ItemFastSlowRateLimiterTest {
     RateLimiter<String> rateLimiter =
         new ItemFastSlowRateLimiter<>(Duration.ofMillis(5), Duration.ofSeconds(10), 3);
 
-    assertEquals(Duration.ofMillis(5), rateLimiter.when("one"));
-    assertEquals(Duration.ofMillis(5), rateLimiter.when("one"));
-    assertEquals(Duration.ofMillis(5), rateLimiter.when("one"));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofMillis(5));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofMillis(5));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofMillis(5));
 
-    assertEquals(Duration.ofSeconds(10), rateLimiter.when("one"));
-    assertEquals(Duration.ofSeconds(10), rateLimiter.when("one"));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofSeconds(10));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofSeconds(10));
 
-    assertEquals(5, rateLimiter.numRequeues("one"));
+    assertThat(rateLimiter.numRequeues("one")).isEqualTo(5);
 
-    assertEquals(Duration.ofMillis(5), rateLimiter.when("two"));
-    assertEquals(Duration.ofMillis(5), rateLimiter.when("two"));
-    assertEquals(2, rateLimiter.numRequeues("two"));
+    assertThat(rateLimiter.when("two")).isEqualTo(Duration.ofMillis(5));
+    assertThat(rateLimiter.when("two")).isEqualTo(Duration.ofMillis(5));
+    assertThat(rateLimiter.numRequeues("two")).isEqualTo(2);
 
     rateLimiter.forget("one");
-    assertEquals(0, rateLimiter.numRequeues("one"));
-    assertEquals(Duration.ofMillis(5), rateLimiter.when("one"));
+    assertThat(rateLimiter.numRequeues("one")).isZero();
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofMillis(5));
   }
 
   @Test
@@ -47,13 +47,13 @@ public class ItemFastSlowRateLimiterTest {
     RateLimiter<String> rateLimiter =
         new ItemFastSlowRateLimiter<>(Duration.ofMillis(5), Duration.ofSeconds(10), -1);
 
-    assertEquals(Duration.ofSeconds(10), rateLimiter.when("one"));
-    assertEquals(Duration.ofSeconds(10), rateLimiter.when("one"));
-    assertEquals(Duration.ofSeconds(10), rateLimiter.when("one"));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofSeconds(10));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofSeconds(10));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofSeconds(10));
 
     rateLimiter = new ItemFastSlowRateLimiter<>(Duration.ofMillis(5), Duration.ofSeconds(10), 0);
-    assertEquals(Duration.ofSeconds(10), rateLimiter.when("two"));
-    assertEquals(Duration.ofSeconds(10), rateLimiter.when("two"));
-    assertEquals(Duration.ofSeconds(10), rateLimiter.when("two"));
+    assertThat(rateLimiter.when("two")).isEqualTo(Duration.ofSeconds(10));
+    assertThat(rateLimiter.when("two")).isEqualTo(Duration.ofSeconds(10));
+    assertThat(rateLimiter.when("two")).isEqualTo(Duration.ofSeconds(10));
   }
 }

--- a/extended/src/test/java/io/kubernetes/client/extended/workqueue/ratelimiter/MaxOfRateLimiterTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/workqueue/ratelimiter/MaxOfRateLimiterTest.java
@@ -12,8 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.extended.workqueue.ratelimiter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 import org.junit.Test;
@@ -27,44 +26,44 @@ public class MaxOfRateLimiterTest {
             new ItemFastSlowRateLimiter<>(Duration.ofMillis(5), Duration.ofSeconds(3), 3),
             new ItemExponentialFailureRateLimiter<>(Duration.ofMillis(1), Duration.ofSeconds(1)));
 
-    assertEquals(Duration.ofMillis(5), rateLimiter.when("one"));
-    assertEquals(Duration.ofMillis(5), rateLimiter.when("one"));
-    assertEquals(Duration.ofMillis(5), rateLimiter.when("one"));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofMillis(5));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofMillis(5));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofMillis(5));
 
-    assertEquals(Duration.ofSeconds(3), rateLimiter.when("one"));
-    assertEquals(Duration.ofSeconds(3), rateLimiter.when("one"));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofSeconds(3));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofSeconds(3));
 
-    assertEquals(5, rateLimiter.numRequeues("one"));
+    assertThat(rateLimiter.numRequeues("one")).isEqualTo(5);
 
-    assertEquals(Duration.ofMillis(5), rateLimiter.when("two"));
-    assertEquals(Duration.ofMillis(5), rateLimiter.when("two"));
-    assertEquals(2, rateLimiter.numRequeues("two"));
+    assertThat(rateLimiter.when("two")).isEqualTo(Duration.ofMillis(5));
+    assertThat(rateLimiter.when("two")).isEqualTo(Duration.ofMillis(5));
+    assertThat(rateLimiter.numRequeues("two")).isEqualTo(2);
 
     rateLimiter.forget("one");
-    assertEquals(0, rateLimiter.numRequeues("one"));
-    assertEquals(Duration.ofMillis(5), rateLimiter.when("one"));
+    assertThat(rateLimiter.numRequeues("one")).isZero();
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofMillis(5));
   }
 
   @Test
   public void testDefaultRateLimiter() {
     RateLimiter<String> rateLimiter = new DefaultControllerRateLimiter<>();
 
-    assertEquals(Duration.ofMillis(5), rateLimiter.when("one"));
-    assertEquals(Duration.ofMillis(10), rateLimiter.when("one"));
-    assertEquals(Duration.ofMillis(20), rateLimiter.when("one"));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofMillis(5));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofMillis(10));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofMillis(20));
 
     for (int i = 0; i < 20; i++) {
       rateLimiter.when("one");
     }
 
-    assertEquals(Duration.ofSeconds(1000), rateLimiter.when("one"));
-    assertEquals(Duration.ofSeconds(1000), rateLimiter.when("one"));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofSeconds(1000));
+    assertThat(rateLimiter.when("one")).isEqualTo(Duration.ofSeconds(1000));
 
     for (int i = 0; i < 75; i++) {
       rateLimiter.when("one");
     }
 
-    assertTrue(rateLimiter.when("one").getSeconds() > 0);
-    assertTrue(rateLimiter.when("two").getSeconds() > 0);
+    assertThat(rateLimiter.when("one").getSeconds()).isPositive();
+    assertThat(rateLimiter.when("two").getSeconds()).isPositive();
   }
 }

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -189,11 +189,6 @@
 
     <!-- test dependencies -->
     <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-junit</artifactId>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
@@ -201,6 +196,11 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kubernetes/src/test/java/io/kubernetes/client/custom/IntOrStringTest.java
+++ b/kubernetes/src/test/java/io/kubernetes/client/custom/IntOrStringTest.java
@@ -12,28 +12,26 @@ limitations under the License.
 */
 package io.kubernetes.client.custom;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
+// Note: Do not use AssertJ .isEquqlTo to test .equals, as this doesn't necessarily invoke it!
 public class IntOrStringTest {
   @Test
   public void whenCreatedWithInt_isInteger() {
     IntOrString intOrString = new IntOrString(17);
 
-    assertThat(intOrString.isInteger(), is(true));
+    assertThat(intOrString.isInteger()).isTrue();
   }
 
   @Test
   public void whenCreatedWithInt_canRetrieveIntValue() {
     IntOrString intOrString = new IntOrString(17);
 
-    assertThat(intOrString.getIntValue(), equalTo(17));
+    assertThat(intOrString.getIntValue()).isEqualTo(17);
   }
 
   @Test(expected = IllegalStateException.class)
@@ -47,7 +45,7 @@ public class IntOrStringTest {
   public void whenCreatedWithInt_equalsItself() {
     IntOrString intOrString = new IntOrString(17);
 
-    assertThat(intOrString, equalTo(intOrString));
+    assertThat(intOrString.equals(intOrString)).isTrue();
   }
 
   @Test
@@ -55,7 +53,7 @@ public class IntOrStringTest {
     IntOrString intOrString1 = new IntOrString(17);
     IntOrString intOrString2 = new IntOrString(17);
 
-    assertThat(intOrString1, equalTo(intOrString2));
+    assertThat(intOrString1.equals(intOrString2)).isTrue();
   }
 
   @Test
@@ -63,7 +61,7 @@ public class IntOrStringTest {
     IntOrString intOrString1 = new IntOrString(17);
     IntOrString intOrString2 = new IntOrString(13);
 
-    assertThat(intOrString1, not(equalTo(intOrString2)));
+    assertThat(intOrString1.equals(intOrString2)).isFalse();
   }
 
   @Test
@@ -71,14 +69,14 @@ public class IntOrStringTest {
     IntOrString intOrString1 = new IntOrString(17);
     IntOrString intOrString2 = new IntOrString("17");
 
-    assertThat(intOrString1, not(equalTo(intOrString2)));
+    assertThat(intOrString1.equals(intOrString2)).isFalse();
   }
 
   @Test
   public void whenCreatedWithString_isNotInteger() {
     IntOrString intOrString = new IntOrString("17");
 
-    assertThat(intOrString.isInteger(), is(false));
+    assertThat(intOrString.isInteger()).isFalse();
   }
 
   @Test(expected = IllegalStateException.class)
@@ -92,14 +90,14 @@ public class IntOrStringTest {
   public void whenCreatedWithString_canRetrieveStringValue() {
     IntOrString intOrString = new IntOrString("17");
 
-    assertThat(intOrString.getStrValue(), equalTo("17"));
+    assertThat(intOrString.getStrValue()).isEqualTo("17");
   }
 
   @Test
   public void whenCreatedWithString_equalsItself() {
     IntOrString intOrString = new IntOrString("17");
 
-    assertThat(intOrString, equalTo(intOrString));
+    assertThat(intOrString.equals(intOrString)).isTrue();
   }
 
   @Test
@@ -107,7 +105,7 @@ public class IntOrStringTest {
     IntOrString intOrString1 = new IntOrString("17");
     IntOrString intOrString2 = new IntOrString("17");
 
-    assertThat(intOrString1, equalTo(intOrString2));
+    assertThat(intOrString1.equals(intOrString2)).isTrue();
   }
 
   @Test
@@ -115,7 +113,7 @@ public class IntOrStringTest {
     IntOrString intOrString1 = new IntOrString("17");
     IntOrString intOrString2 = new IntOrString("13");
 
-    assertThat(intOrString1, not(equalTo(intOrString2)));
+    assertThat(intOrString1.equals(intOrString2)).isFalse();
   }
 
   @Test

--- a/kubernetes/src/test/java/io/kubernetes/client/custom/MapUtilsTest.java
+++ b/kubernetes/src/test/java/io/kubernetes/client/custom/MapUtilsTest.java
@@ -17,8 +17,7 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MapUtilsTest {
     @Test
@@ -29,7 +28,7 @@ public class MapUtilsTest {
         Map<String, byte[]> right = new HashMap<String, byte[]>() {{
             put("foo", "bar".getBytes());
         }};
-        assertTrue(MapUtils.equals(left, right));
+        assertThat(MapUtils.equals(left, right)).isTrue();
     }
 
     @Test
@@ -40,6 +39,6 @@ public class MapUtilsTest {
         Map<String, byte[]> right = new HashMap<String, byte[]>() {{
             put("foo", "bar".getBytes());
         }};
-        assertFalse(MapUtils.equals(left, right));
+        assertThat(MapUtils.equals(left, right)).isFalse();
     }
 }

--- a/kubernetes/src/test/java/io/kubernetes/client/custom/QuantityFormatterTest.java
+++ b/kubernetes/src/test/java/io/kubernetes/client/custom/QuantityFormatterTest.java
@@ -12,12 +12,10 @@ limitations under the License.
 */
 package io.kubernetes.client.custom;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 public class QuantityFormatterTest {
@@ -42,57 +40,57 @@ public class QuantityFormatterTest {
     // simulate the deserialize-method, @see io.kubernetes.client.custom.Quantity.QuantityAdapter
     Quantity deSerial = Quantity.fromString(suffixedString);
 
-    Assert.assertEquals(quantity,deSerial);
+    assertThat(deSerial).isEqualTo(quantity);
   }
 
   @Test
   public void testParsePlain() {
     final Quantity quantity = new QuantityFormatter().parse("1");
-    assertThat(quantity.getFormat(), is(Quantity.Format.DECIMAL_SI));
-    assertThat(quantity.getNumber(), is(BigDecimal.valueOf(1)));
+    assertThat(quantity.getFormat()).isEqualTo(Quantity.Format.DECIMAL_SI);
+    assertThat(quantity.getNumber()).isEqualTo(BigDecimal.valueOf(1));
   }
 
   @Test
   public void testParseFractional() {
     final Quantity quantity = new QuantityFormatter().parse("0.001");
-    assertThat(quantity.getFormat(), is(Quantity.Format.DECIMAL_SI));
-    assertThat(quantity.getNumber(), is(BigDecimal.valueOf(0.001)));
+    assertThat(quantity.getFormat()).isEqualTo(Quantity.Format.DECIMAL_SI);
+    assertThat(quantity.getNumber()).isEqualTo(BigDecimal.valueOf(0.001));
   }
 
   @Test
   public void testParseFractionalUnit() {
     final Quantity quantity = new QuantityFormatter().parse("0.001m");
-    assertThat(quantity.getFormat(), is(Quantity.Format.DECIMAL_SI));
-    assertThat(quantity.getNumber(), is(new BigDecimal("0.000001")));
+    assertThat(quantity.getFormat()).isEqualTo(Quantity.Format.DECIMAL_SI);
+    assertThat(quantity.getNumber()).isEqualTo(new BigDecimal("0.000001"));
   }
 
   @Test
   public void testParseBinarySi() {
     final Quantity quantity = new QuantityFormatter().parse("1Ki");
-    assertThat(quantity.getFormat(), is(Quantity.Format.BINARY_SI));
-    assertThat(quantity.getNumber(), is(BigDecimal.valueOf(1024)));
+    assertThat(quantity.getFormat()).isEqualTo(Quantity.Format.BINARY_SI);
+    assertThat(quantity.getNumber()).isEqualTo(BigDecimal.valueOf(1024));
   }
 
   @Test
   public void testParseLargeNumeratorBinarySi() {
     final Quantity quantity = new QuantityFormatter().parse("32Mi");
-    assertThat(quantity.getFormat(), is(Quantity.Format.BINARY_SI));
+    assertThat(quantity.getFormat()).isEqualTo(Quantity.Format.BINARY_SI);
     assertThat(
-        quantity.getNumber(), is(BigDecimal.valueOf(2).pow(20).multiply(BigDecimal.valueOf(32))));
+        quantity.getNumber()).isEqualTo(BigDecimal.valueOf(2).pow(20).multiply(BigDecimal.valueOf(32)));
   }
 
   @Test
   public void testParseExponent() {
     final Quantity quantity = new QuantityFormatter().parse("1e3");
-    assertThat(quantity.getFormat(), is(Quantity.Format.DECIMAL_EXPONENT));
-    assertThat(quantity.getNumber(), is(BigDecimal.valueOf(1000)));
+    assertThat(quantity.getFormat()).isEqualTo(Quantity.Format.DECIMAL_EXPONENT);
+    assertThat(quantity.getNumber()).isEqualTo(BigDecimal.valueOf(1000));
   }
 
   @Test
   public void testParseNegativeExponent() {
     final Quantity quantity = new QuantityFormatter().parse("1e-3");
-    assertThat(quantity.getFormat(), is(Quantity.Format.DECIMAL_EXPONENT));
-    assertThat(quantity.getNumber(), is(BigDecimal.valueOf(0.001)));
+    assertThat(quantity.getFormat()).isEqualTo(Quantity.Format.DECIMAL_EXPONENT);
+    assertThat(quantity.getNumber()).isEqualTo(BigDecimal.valueOf(0.001));
   }
 
   @Test(expected = QuantityFormatException.class)
@@ -105,7 +103,7 @@ public class QuantityFormatterTest {
     final String formattedString =
         new QuantityFormatter()
             .format(new Quantity(new BigDecimal("100"), Quantity.Format.DECIMAL_SI));
-    assertThat(formattedString, is("100"));
+    assertThat(formattedString).isEqualTo("100");
   }
 
   @Test
@@ -113,7 +111,7 @@ public class QuantityFormatterTest {
     final String formattedString =
         new QuantityFormatter()
             .format(new Quantity(new BigDecimal("100000"), Quantity.Format.DECIMAL_SI));
-    assertThat(formattedString, is("100k"));
+    assertThat(formattedString).isEqualTo("100k");
   }
 
   @Test
@@ -121,7 +119,7 @@ public class QuantityFormatterTest {
     final String formattedString =
         new QuantityFormatter()
             .format(new Quantity(new BigDecimal("100.001"), Quantity.Format.DECIMAL_SI));
-    assertThat(formattedString, is("100001m"));
+    assertThat(formattedString).isEqualTo("100001m");
   }
 
   @Test
@@ -129,7 +127,7 @@ public class QuantityFormatterTest {
     final String formattedString =
         new QuantityFormatter()
             .format(new Quantity(new BigDecimal(2).pow(20), Quantity.Format.BINARY_SI));
-    assertThat(formattedString, is("1Mi"));
+    assertThat(formattedString).isEqualTo("1Mi");
   }
 
   @Test
@@ -137,7 +135,7 @@ public class QuantityFormatterTest {
     final String formattedString =
         new QuantityFormatter()
             .format(new Quantity(BigDecimal.valueOf(128), Quantity.Format.BINARY_SI));
-    assertThat(formattedString, is("128"));
+    assertThat(formattedString).isEqualTo("128");
   }
 
   @Test
@@ -145,7 +143,7 @@ public class QuantityFormatterTest {
     final String formattedString =
         new QuantityFormatter()
             .format(new Quantity(BigDecimal.valueOf(2056), Quantity.Format.BINARY_SI));
-    assertThat(formattedString, is("2056"));
+    assertThat(formattedString).isEqualTo("2056");
   }
 
   @Test
@@ -153,7 +151,7 @@ public class QuantityFormatterTest {
     final String formattedString =
         new QuantityFormatter()
             .format(new Quantity(BigDecimal.valueOf(123.123), Quantity.Format.BINARY_SI));
-    assertThat(formattedString, is("123123m"));
+    assertThat(formattedString).isEqualTo("123123m");
   }
 
   @Test
@@ -161,7 +159,7 @@ public class QuantityFormatterTest {
     final String formattedString =
         new QuantityFormatter()
             .format(new Quantity(BigDecimal.valueOf(1000000), Quantity.Format.DECIMAL_EXPONENT));
-    assertThat(formattedString, is("1e6"));
+    assertThat(formattedString).isEqualTo("1e6");
   }
 
   @Test
@@ -169,7 +167,7 @@ public class QuantityFormatterTest {
     final String formattedString =
         new QuantityFormatter()
             .format(new Quantity(BigDecimal.valueOf(100000), Quantity.Format.DECIMAL_EXPONENT));
-    assertThat(formattedString, is("100e3"));
+    assertThat(formattedString).isEqualTo("100e3");
   }
 
   @Test
@@ -177,7 +175,7 @@ public class QuantityFormatterTest {
     final String formattedString =
         new QuantityFormatter()
             .format(new Quantity(BigDecimal.valueOf(12345), Quantity.Format.DECIMAL_EXPONENT));
-    assertThat(formattedString, is("12345"));
+    assertThat(formattedString).isEqualTo("12345");
   }
 
   @Test
@@ -185,6 +183,7 @@ public class QuantityFormatterTest {
     final String formattedString2 =
             new QuantityFormatter()
                     .format(new Quantity(Float.toString(123456789012.f)));
-    assertThat(formattedString2, is("123456791e3"));
+    // TODO: JDK 21, this is rounds down to 123456790e3
+    assertThat(formattedString2).isEqualTo("123456791e3");
   }
 }

--- a/kubernetes/src/test/java/io/kubernetes/client/custom/SuffixFormatterTest.java
+++ b/kubernetes/src/test/java/io/kubernetes/client/custom/SuffixFormatterTest.java
@@ -12,8 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.custom;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
@@ -22,49 +21,49 @@ public class SuffixFormatterTest {
   @Test
   public void testParseBinaryKi() {
     final BaseExponent baseExponent = new SuffixFormatter().parse("Ki");
-    assertThat(baseExponent.getBase(), is(2));
-    assertThat(baseExponent.getExponent(), is(10));
-    assertThat(baseExponent.getFormat(), is(Quantity.Format.BINARY_SI));
+    assertThat(baseExponent.getBase()).isEqualTo(2);
+    assertThat(baseExponent.getExponent()).isEqualTo(10);
+    assertThat(baseExponent.getFormat()).isEqualTo(Quantity.Format.BINARY_SI);
   }
 
   @Test
   public void testParseDecimalZero() {
     final BaseExponent baseExponent = new SuffixFormatter().parse("");
-    assertThat(baseExponent.getBase(), is(10));
-    assertThat(baseExponent.getExponent(), is(0));
-    assertThat(baseExponent.getFormat(), is(Quantity.Format.DECIMAL_SI));
+    assertThat(baseExponent.getBase()).isEqualTo(10);
+    assertThat(baseExponent.getExponent()).isZero();
+    assertThat(baseExponent.getFormat()).isEqualTo(Quantity.Format.DECIMAL_SI);
   }
 
   @Test
   public void testParseDecimalK() {
     final BaseExponent baseExponent = new SuffixFormatter().parse("k");
-    assertThat(baseExponent.getBase(), is(10));
-    assertThat(baseExponent.getExponent(), is(3));
-    assertThat(baseExponent.getFormat(), is(Quantity.Format.DECIMAL_SI));
+    assertThat(baseExponent.getBase()).isEqualTo(10);
+    assertThat(baseExponent.getExponent()).isEqualTo(3);
+    assertThat(baseExponent.getFormat()).isEqualTo(Quantity.Format.DECIMAL_SI);
   }
 
   @Test
   public void testParseDecimalExponent() {
     final BaseExponent baseExponent = new SuffixFormatter().parse("E2");
-    assertThat(baseExponent.getBase(), is(10));
-    assertThat(baseExponent.getExponent(), is(2));
-    assertThat(baseExponent.getFormat(), is(Quantity.Format.DECIMAL_EXPONENT));
+    assertThat(baseExponent.getBase()).isEqualTo(10);
+    assertThat(baseExponent.getExponent()).isEqualTo(2);
+    assertThat(baseExponent.getFormat()).isEqualTo(Quantity.Format.DECIMAL_EXPONENT);
   }
 
   @Test
   public void testParseDecimalExponentPositive() {
     final BaseExponent baseExponent = new SuffixFormatter().parse("e+3");
-    assertThat(baseExponent.getBase(), is(10));
-    assertThat(baseExponent.getExponent(), is(3));
-    assertThat(baseExponent.getFormat(), is(Quantity.Format.DECIMAL_EXPONENT));
+    assertThat(baseExponent.getBase()).isEqualTo(10);
+    assertThat(baseExponent.getExponent()).isEqualTo(3);
+    assertThat(baseExponent.getFormat()).isEqualTo(Quantity.Format.DECIMAL_EXPONENT);
   }
 
   @Test
   public void testParseDecimalExponentNegative() {
     final BaseExponent baseExponent = new SuffixFormatter().parse("e-3");
-    assertThat(baseExponent.getBase(), is(10));
-    assertThat(baseExponent.getExponent(), is(-3));
-    assertThat(baseExponent.getFormat(), is(Quantity.Format.DECIMAL_EXPONENT));
+    assertThat(baseExponent.getBase()).isEqualTo(10);
+    assertThat(baseExponent.getExponent()).isEqualTo(-3);
+    assertThat(baseExponent.getFormat()).isEqualTo(Quantity.Format.DECIMAL_EXPONENT);
   }
 
   @Test(expected = QuantityFormatException.class)
@@ -76,20 +75,20 @@ public class SuffixFormatterTest {
   public void testFormatZeroDecimalExponent() {
     final String formattedString =
         new SuffixFormatter().format(Quantity.Format.DECIMAL_EXPONENT, 0);
-    assertThat(formattedString, is(""));
+    assertThat(formattedString).isEmpty();
   }
 
   @Test
   public void testFormatDecimalExponent() {
     final String formattedString =
         new SuffixFormatter().format(Quantity.Format.DECIMAL_EXPONENT, 3);
-    assertThat(formattedString, is("e3"));
+    assertThat(formattedString).isEqualTo("e3");
   }
 
   @Test
   public void testFormatZeroDecimalSi() {
     final String formattedString = new SuffixFormatter().format(Quantity.Format.DECIMAL_SI, 0);
-    assertThat(formattedString, is(""));
+    assertThat(formattedString).isEmpty();
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -100,25 +99,25 @@ public class SuffixFormatterTest {
   @Test
   public void testFormatDecimalSi() {
     final String formattedString = new SuffixFormatter().format(Quantity.Format.DECIMAL_SI, 3);
-    assertThat(formattedString, is("k"));
+    assertThat(formattedString).isEqualTo("k");
   }
 
   @Test
   public void testFormatNegativeDecimalSi() {
     final String formattedString = new SuffixFormatter().format(Quantity.Format.DECIMAL_SI, -6);
-    assertThat(formattedString, is("u"));
+    assertThat(formattedString).isEqualTo("u");
   }
 
   @Test
   public void testFormatBinarySi() {
     final String formattedString = new SuffixFormatter().format(Quantity.Format.BINARY_SI, 10);
-    assertThat(formattedString, is("Ki"));
+    assertThat(formattedString).isEqualTo("Ki");
   }
 
   @Test
   public void testFormatNoExponentBinarySi() {
     final String formattedString = new SuffixFormatter().format(Quantity.Format.BINARY_SI, 0);
-    assertThat(formattedString, is(""));
+    assertThat(formattedString).isEmpty();
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/kubernetes/src/test/java/io/kubernetes/client/gson/V1StatusJsonDeserializerTest.java
+++ b/kubernetes/src/test/java/io/kubernetes/client/gson/V1StatusJsonDeserializerTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.gson;
 
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.gson.Gson;
 import io.gsonfire.GsonFireBuilder;
@@ -37,18 +37,18 @@ public class V1StatusJsonDeserializerTest {
   @Test
   public void testDeserializeNormalStatusIntoStatus() {
     V1Status status = gson.fromJson(JSON_STATUS, V1Status.class);
-    assertNotNull(status);
+    assertThat(status).isNotNull();
   }
 
   @Test
   public void testDeserializeNullStatusIntoStatus() {
     V1Status status = gson.fromJson(JSON_STATUS_NULL, V1Status.class);
-    assertNotNull(status);
+    assertThat(status).isNotNull();
   }
 
   @Test
   public void testDeserializeDeploymentIntoStatus() {
     V1Status status = gson.fromJson(JSON_DEPLOYMENT, V1Status.class);
-    assertNotNull(status);
+    assertThat(status).isNotNull();
   }
 }

--- a/kubernetes/src/test/java/io/kubernetes/client/openapi/JSONTest.java
+++ b/kubernetes/src/test/java/io/kubernetes/client/openapi/JSONTest.java
@@ -12,8 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.openapi;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -25,7 +24,6 @@ import com.google.gson.stream.JsonReader;
 import io.kubernetes.client.openapi.models.V1ListMeta;
 import io.kubernetes.client.openapi.models.V1Status;
 import okio.ByteString;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class JSONTest {
@@ -41,11 +39,11 @@ public class JSONTest {
     final ByteString byteStr = ByteString.decodeBase64(pureString);
 
     // Check encoded to valid base64
-    assertNotNull(byteStr);
+    assertThat(byteStr).isNotNull();
 
     // Check encoded string correctly
     final String decodedText = new String(byteStr.toByteArray());
-    assertThat(decodedText, is(plainText));
+    assertThat(decodedText).isEqualTo(plainText);
   }
 
   @Test
@@ -53,7 +51,7 @@ public class JSONTest {
     String timeStr = "\"2018-04-03T11:32:26.123456Z\"";
     OffsetDateTime dateTime = json.deserialize(timeStr, OffsetDateTime.class);
     String serializedTsStr = json.serialize(dateTime);
-    assertEquals(timeStr, serializedTsStr);
+    assertThat(serializedTsStr).isEqualTo(timeStr);
   }
 
   @Test
@@ -62,7 +60,7 @@ public class JSONTest {
     OffsetDateTime dateTime = json.deserialize(timeStr, OffsetDateTime.class);
     String serializedTsStr = json.serialize(dateTime);
     String expectedStr = "\"2018-04-03T11:32:26.123400Z\"";
-    assertEquals(expectedStr, serializedTsStr);
+    assertThat(serializedTsStr).isEqualTo(expectedStr);
   }
 
   @Test
@@ -71,7 +69,7 @@ public class JSONTest {
     OffsetDateTime dateTime = json.deserialize(timeStr, OffsetDateTime.class);
     String serializedTsStr = json.serialize(dateTime);
     String expectedStr = "\"2018-04-03T11:32:26.123000Z\"";
-    assertEquals(expectedStr, serializedTsStr);
+    assertThat(serializedTsStr).isEqualTo(expectedStr);
   }
 
   @Test
@@ -80,7 +78,7 @@ public class JSONTest {
     OffsetDateTime dateTime = json.deserialize(timeStr, OffsetDateTime.class);
     String serializedTsStr = json.serialize(dateTime);
     String expectedStr = "\"2018-04-03T11:32:26.000000Z\"";
-    assertEquals(expectedStr, serializedTsStr);
+    assertThat(serializedTsStr).isEqualTo(expectedStr);
   }
 
   @Test

--- a/kubernetes/src/test/java/io/kubernetes/client/openapi/V1SecretTest.java
+++ b/kubernetes/src/test/java/io/kubernetes/client/openapi/V1SecretTest.java
@@ -15,7 +15,7 @@ package io.kubernetes.client.openapi;
 import io.kubernetes.client.openapi.models.V1Secret;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 
@@ -30,6 +30,6 @@ public class V1SecretTest {
                 .data(new HashMap<String, byte[]>() {{
                     put("foo", "bar".getBytes());
                 }});
-        assertEquals(left, right);
+        assertThat(right).isEqualTo(left);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -324,21 +324,15 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-junit</artifactId>
-        <version>2.0.0.0</version>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>3.25.3</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
         <version>4.2.0</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.assertj</groupId>
-        <artifactId>assertj-core</artifactId>
-        <version>3.25.3</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -72,6 +72,11 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/spring/src/test/java/io/kubernetes/client/spring/extended/controller/KubernetesInformerCreatorTest.java
+++ b/spring/src/test/java/io/kubernetes/client/spring/extended/controller/KubernetesInformerCreatorTest.java
@@ -20,8 +20,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.extension.Parameters;
@@ -110,8 +109,8 @@ public class KubernetesInformerCreatorTest {
 
   @Test
   public void testInformerInjection() throws InterruptedException {
-    assertNotNull(podInformer);
-    assertNotNull(configMapInformer);
+    assertThat(podInformer).isNotNull();
+    assertThat(configMapInformer).isNotNull();
 
     Semaphore getCount = new Semaphore(2);
     Semaphore watchCount = new Semaphore(2);
@@ -188,7 +187,7 @@ public class KubernetesInformerCreatorTest {
         getRequestedFor(urlPathEqualTo("/api/v1/namespaces/default/configmaps"))
             .withQueryParam("watch", equalTo("true")));
 
-    assertEquals(1, new Lister<>(podInformer.getIndexer()).list().size());
-    assertEquals(1, new Lister<>(configMapInformer.getIndexer()).list().size());
+    assertThat(new Lister<>(podInformer.getIndexer()).list()).hasSize(1);
+    assertThat(new Lister<>(configMapInformer.getIndexer()).list()).hasSize(1);
   }
 }

--- a/spring/src/test/java/io/kubernetes/client/spring/extended/controller/KubernetesReconcilerCreatorTest.java
+++ b/spring/src/test/java/io/kubernetes/client/spring/extended/controller/KubernetesReconcilerCreatorTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.spring.extended.controller;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.kubernetes.client.common.KubernetesObject;
@@ -178,8 +178,8 @@ public class KubernetesReconcilerCreatorTest {
 
   @Test
   public void testSimplePodController() throws InterruptedException {
-    assertNotNull(testController);
-    assertNotNull(testReconciler);
+    assertThat(testController).isNotNull();
+    assertThat(testReconciler).isNotNull();
 
     sharedInformerFactory.startAllRegisteredInformers();
 
@@ -197,11 +197,8 @@ public class KubernetesReconcilerCreatorTest {
     Thread.sleep(500);
 
     WorkQueue<Request> workQueue = ((DefaultController) testController).getWorkQueue();
-    assertEquals(1, workQueue.length());
-    if (workQueue.length() != 1) {
-      fail();
-    }
-    assertEquals("foo", workQueue.get().getName());
+    assertThat(workQueue.length()).isEqualTo(1);
+    assertThat(workQueue.get().getName()).isEqualTo("foo");
     sharedInformerFactory.stopAllRegisteredInformers();
   }
 }

--- a/spring/src/test/java/io/kubernetes/client/spring/extended/controller/KubernetesReconcilerProcessorTest.java
+++ b/spring/src/test/java/io/kubernetes/client/spring/extended/controller/KubernetesReconcilerProcessorTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.spring.extended.controller;
 
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.extended.controller.Controller;
 import io.kubernetes.client.extended.controller.reconciler.Reconciler;
@@ -100,7 +100,7 @@ public class KubernetesReconcilerProcessorTest {
 
   @Test
   public void testAutowiredFieldsOfReconcilerBeansAreSet() {
-    assertNotNull(testReconciler1ToBeInjected.informerToBeInjected);
-    assertNotNull(testReconciler2ToBeInjected.informerToBeInjected);
+    assertThat(testReconciler1ToBeInjected.informerToBeInjected).isNotNull();
+    assertThat(testReconciler2ToBeInjected.informerToBeInjected).isNotNull();
   }
 }

--- a/spring/src/test/java/io/kubernetes/client/spring/extended/manifests/KubernetesFromConfigMapTest.java
+++ b/spring/src/test/java/io/kubernetes/client/spring/extended/manifests/KubernetesFromConfigMapTest.java
@@ -13,8 +13,7 @@ limitations under the License.
 package io.kubernetes.client.spring.extended.manifests;
 
 import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.spring.extended.manifests.annotation.FromConfigMap;
@@ -80,15 +79,15 @@ public class KubernetesFromConfigMapTest {
 
   @Test
   public void testReadOnce() {
-    assertNotNull(myBean.staticData);
-    assertEquals("bar", myBean.staticData.get("foo"));
+    assertThat(myBean.staticData).isNotNull();
+    assertThat(myBean.staticData).containsEntry("foo", "bar");
   }
 
   @Test
-  public void testValueUpdate() throws InterruptedException {
-    assertEquals(Duration.ofSeconds(1), manifestsProperties.getRefreshInterval());
-    assertNotNull(myBean.dynamicData);
-    assertEquals("bar1", myBean.dynamicData.get("foo"));
+  public void testValueUpdate() {
+    assertThat(manifestsProperties.getRefreshInterval()).isEqualTo(Duration.ofSeconds(1));
+    assertThat(myBean.dynamicData).isNotNull();
+    assertThat(myBean.dynamicData).containsEntry("foo", "bar1");
     mockAtomicConfigMapGetter.configMapAtomicReference.set(
         new V1ConfigMap().putDataItem("foo", "bar2"));
     await()
@@ -97,10 +96,10 @@ public class KubernetesFromConfigMapTest {
   }
 
   @Test
-  public void testKeyUpdate() throws InterruptedException {
-    assertEquals(Duration.ofSeconds(1), manifestsProperties.getRefreshInterval());
-    assertNotNull(myBean.dynamicData);
-    assertEquals("bar1", myBean.dynamicData.get("foo"));
+  public void testKeyUpdate() {
+    assertThat(manifestsProperties.getRefreshInterval()).isEqualTo(Duration.ofSeconds(1));
+    assertThat(myBean.dynamicData).isNotNull();
+    assertThat(myBean.dynamicData).containsEntry("foo", "bar1");
     mockAtomicConfigMapGetter.configMapAtomicReference.set(
         new V1ConfigMap().putDataItem("foo1", "bar"));
     await()

--- a/spring/src/test/java/io/kubernetes/client/spring/extended/manifests/KubernetesFromYamlTest.java
+++ b/spring/src/test/java/io/kubernetes/client/spring/extended/manifests/KubernetesFromYamlTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.spring.extended.manifests;
 
-import static junit.framework.TestCase.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.spring.extended.manifests.annotation.FromYaml;
@@ -63,7 +63,7 @@ public class KubernetesFromYamlTest {
 
   @Test
   public void test() {
-    assertNotNull(myBean.service);
-    assertNotNull(service);
+    assertThat(myBean.service).isNotNull();
+    assertThat(service).isNotNull();
   }
 }

--- a/spring/src/test/java/io/kubernetes/client/spring/extended/manifests/KubernetesManifestTest.java
+++ b/spring/src/test/java/io/kubernetes/client/spring/extended/manifests/KubernetesManifestTest.java
@@ -18,8 +18,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.patch;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.kubernetes.client.openapi.ApiClient;
@@ -197,12 +196,12 @@ public class KubernetesManifestTest {
 
   @Test
   public void test() {
-    assertNotNull(createdNamespace);
-    assertNotNull(createdServiceAccount);
-    assertNotNull(createdPod);
+    assertThat(createdNamespace).isNotNull();
+    assertThat(createdServiceAccount).isNotNull();
+    assertThat(createdPod).isNotNull();
 
-    assertEquals("true", createdNamespace.getMetadata().getLabels().get("created"));
-    assertEquals("true", createdServiceAccount.getMetadata().getLabels().get("created"));
-    assertEquals("true", createdPod.getMetadata().getLabels().get("created"));
+    assertThat(createdNamespace.getMetadata().getLabels()).containsEntry("created", "true");
+    assertThat(createdServiceAccount.getMetadata().getLabels()).containsEntry("created", "true");
+    assertThat(createdPod.getMetadata().getLabels()).containsEntry("created", "true");
   }
 }

--- a/spring/src/test/java/io/kubernetes/client/spring/extended/network/KubernetesEndpointsLoadBalancerCreatorTest.java
+++ b/spring/src/test/java/io/kubernetes/client/spring/extended/network/KubernetesEndpointsLoadBalancerCreatorTest.java
@@ -12,9 +12,8 @@ limitations under the License.
 */
 package io.kubernetes.client.spring.extended.network;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.kubernetes.client.extended.network.EndpointsLoadBalancer;
 import io.kubernetes.client.extended.network.LoadBalanceStrategy;
@@ -124,33 +123,34 @@ public class KubernetesEndpointsLoadBalancerCreatorTest {
   @Test
   public void testLoadBalancer() throws NoAvailableAddressException {
 
-    assertNotNull(myBean.fooLoadBalancer);
+    assertThat(myBean.fooLoadBalancer).isNotNull();
     endpointsCache.add(twoPortTwoHostEp);
 
-    assertEquals("127.0.0.1", myBean.fooLoadBalancer.getTargetIP());
-    assertEquals("127.0.0.1", myBean.fooLoadBalancer.getTargetIP(8080));
+    assertThat(myBean.fooLoadBalancer.getTargetIP()).isEqualTo("127.0.0.1");
+    assertThat(myBean.fooLoadBalancer.getTargetIP(8080)).isEqualTo("127.0.0.1");
   }
 
   @Test
   public void testCustomStrategyLoadBalancer() throws NoAvailableAddressException {
-    assertNotNull(myBean.customStrategyLoadBalancer);
+    assertThat(myBean.customStrategyLoadBalancer).isNotNull();
     endpointsCache.add(twoPortTwoHostEp);
-    assertEquals(MyStrategy.alwaysReturn, myBean.customStrategyLoadBalancer.getTargetIP());
-    assertEquals(MyStrategy.alwaysReturn, myBean.customStrategyLoadBalancer.getTargetIP(8080));
+    assertThat(myBean.customStrategyLoadBalancer.getTargetIP()).isEqualTo(MyStrategy.alwaysReturn);
+    assertThat(myBean.customStrategyLoadBalancer.getTargetIP(8080)).isEqualTo(MyStrategy.alwaysReturn);
   }
 
   @Test
   public void testCustomEndpointsGetterLoadBalancer() throws NoAvailableAddressException {
-    assertNotNull(myBean.customEndpointGetterLoadBalancer);
-    assertEquals("127.0.0.2", myBean.customEndpointGetterLoadBalancer.getTargetIP());
-    assertEquals("127.0.0.2", myBean.customEndpointGetterLoadBalancer.getTargetIP(8080));
+    assertThat(myBean.customEndpointGetterLoadBalancer).isNotNull();
+    assertThat(myBean.customEndpointGetterLoadBalancer.getTargetIP()).isEqualTo("127.0.0.2");
+    assertThat(myBean.customEndpointGetterLoadBalancer.getTargetIP(8080)).isEqualTo("127.0.0.2");
   }
 
   @Test
   public void testDeletedEndpointLoadBalancer() {
-    assertNotNull(myBean.noSuchLoadBalancer);
-    assertThrows(NoAvailableAddressException.class, () -> myBean.noSuchLoadBalancer.getTargetIP());
-    assertThrows(
-        NoAvailableAddressException.class, () -> myBean.noSuchLoadBalancer.getTargetIP(8080));
+    assertThat(myBean.noSuchLoadBalancer).isNotNull();
+    assertThatThrownBy(() -> myBean.noSuchLoadBalancer.getTargetIP())
+        .isInstanceOf(NoAvailableAddressException.class);
+    assertThatThrownBy(() -> myBean.noSuchLoadBalancer.getTargetIP(8080))
+        .isInstanceOf(NoAvailableAddressException.class);
   }
 }

--- a/util/src/test/java/io/kubernetes/client/AttachTest.java
+++ b/util/src/test/java/io/kubernetes/client/AttachTest.java
@@ -41,7 +41,7 @@ public class AttachTest {
   @Rule public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
 
   @Before
-  public void setup() throws IOException {
+  public void setup() {
     client = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
 
     namespace = "default";
@@ -50,7 +50,7 @@ public class AttachTest {
   }
 
   @Test
-  public void testUrl() throws IOException, ApiException, InterruptedException {
+  public void testUrl() throws IOException, ApiException {
     Attach attach = new Attach(client);
 
     wireMockRule.stubFor(

--- a/util/src/test/java/io/kubernetes/client/CopyTest.java
+++ b/util/src/test/java/io/kubernetes/client/CopyTest.java
@@ -48,7 +48,7 @@ public class CopyTest {
   @Rule public TemporaryFolder folder = new TemporaryFolder();
 
   @Before
-  public void setup() throws IOException {
+  public void setup() {
     client = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
 
     namespace = "default";
@@ -56,7 +56,7 @@ public class CopyTest {
   }
 
   @Test
-  public void testUrl() throws IOException, ApiException, InterruptedException {
+  public void testUrl() throws IOException, ApiException {
     Copy copy = new Copy(client);
 
     V1Pod pod = new V1Pod().metadata(new V1ObjectMeta().name(podName).namespace(namespace));

--- a/util/src/test/java/io/kubernetes/client/ExecCallbacksTest.java
+++ b/util/src/test/java/io/kubernetes/client/ExecCallbacksTest.java
@@ -12,7 +12,8 @@ limitations under the License.
 */
 package io.kubernetes.client;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import io.kubernetes.client.custom.IOTrio;
 import io.kubernetes.client.openapi.ApiException;
@@ -44,9 +45,10 @@ public class ExecCallbacksTest {
     int exitCode = promise.get(10_000, TimeUnit.MILLISECONDS);
     long delta = System.currentTimeMillis() - startTime;
 
-    assertTrue(delta <= 10_000);
-    assertTrue(delta >= 1_000L);
-    assertEquals(Integer.MAX_VALUE, exitCode);
+    assertThat(delta)
+        .isGreaterThanOrEqualTo(1_000L)
+        .isLessThanOrEqualTo(10_000L);
+    assertThat(exitCode).isEqualTo(Integer.MAX_VALUE);
   }
 
   @Test
@@ -75,9 +77,8 @@ public class ExecCallbacksTest {
             true,
             "random-command");
 
-    assertEquals(Integer.valueOf(1), promise.get());
-    assertEquals(1, errors.size());
-    assertEquals("Some error", errors.get(0));
+    assertThat(promise.get()).isEqualTo(1);
+    assertThat(errors).containsExactly("Some error");
   }
 
   @Test
@@ -107,9 +108,8 @@ public class ExecCallbacksTest {
             true,
             "random-command");
 
-    assertEquals(Integer.valueOf(0), promise.get());
-    assertEquals(1, output.size());
-    assertEquals("Some stream", output.get(0));
+    assertThat(promise.get()).isZero();
+    assertThat(output).containsExactly("Some stream");
   }
 
   @Test
@@ -128,9 +128,8 @@ public class ExecCallbacksTest {
             true,
             "random-command");
 
-    assertEquals(Integer.valueOf(9), promise.get());
-    assertEquals(1, codes.size());
-    assertEquals(Integer.valueOf(9), codes.get(0));
+    assertThat(promise.get()).isEqualTo(9);
+    assertThat(codes).containsExactly(9);
   }
 
   @Test
@@ -190,10 +189,9 @@ public class ExecCallbacksTest {
             "bash",
             "-i");
 
-    assertEquals(Integer.valueOf(5), promise.get());
-    assertEquals(1, codes.size());
-    assertEquals(Integer.valueOf(5), codes.get(0));
-    assertTrue(callbackInvoked.get());
+    assertThat(promise.get()).isEqualTo(5);
+    assertThat(codes).containsExactly(5);
+    assertThat(callbackInvoked).isTrue();
   }
 
   // helper functions
@@ -206,14 +204,14 @@ public class ExecCallbacksTest {
     try {
       task.run();
     } catch (Exception e) {
-      e.printStackTrace();
-      fail();
+      e.printStackTrace(); // TODO: junit-jupiter fail(e);
+      fail(e.getMessage());
     }
   }
 
   private String read(InputStream is, String expectedText) {
     String readText = read(is, expectedText.length());
-    assertEquals(expectedText, readText);
+    assertThat(readText).isEqualTo(expectedText);
     return readText;
   }
 
@@ -227,8 +225,8 @@ public class ExecCallbacksTest {
       is.read(buff);
       return new String(buff);
     } catch (IOException e) {
-      e.printStackTrace();
-      fail();
+      e.printStackTrace(); // TODO: junit-jupiter fail(e);
+      fail(e.getMessage());
     }
     return null;
   }

--- a/util/src/test/java/io/kubernetes/client/MetricsTest.java
+++ b/util/src/test/java/io/kubernetes/client/MetricsTest.java
@@ -14,14 +14,13 @@ package io.kubernetes.client;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.util.ClientBuilder;
-import java.io.IOException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,7 +32,7 @@ public class MetricsTest {
   @Rule public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
 
   @Before
-  public void setup() throws IOException {
+  public void setup() {
     client = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
   }
 
@@ -50,9 +49,9 @@ public class MetricsTest {
                     .withBody("Service Unavailable")));
     try {
       metrics.getPodMetrics(namespace);
-      fail("Expected ApiException to be thrown");
+      failBecauseExceptionWasNotThrown(ApiException.class);
     } catch (ApiException ex) {
-      assertEquals(503, ex.getCode());
+      assertThat(ex.getCode()).isEqualTo(503);
     }
   }
 
@@ -68,9 +67,9 @@ public class MetricsTest {
                     .withBody("Service Unavailable")));
     try {
       metrics.getNodeMetrics();
-      fail("Expected ApiException to be thrown");
+      failBecauseExceptionWasNotThrown(ApiException.class);
     } catch (ApiException ex) {
-      assertEquals(503, ex.getCode());
+      assertThat(ex.getCode()).isEqualTo(503);
     }
   }
 }

--- a/util/src/test/java/io/kubernetes/client/PodLogsTest.java
+++ b/util/src/test/java/io/kubernetes/client/PodLogsTest.java
@@ -18,8 +18,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -56,7 +55,7 @@ public class PodLogsTest {
   @Rule public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
 
   @Before
-  public void setup() throws IOException {
+  public void setup() {
     client = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
 
     namespace = "default";
@@ -86,10 +85,10 @@ public class PodLogsTest {
     try {
       logs.streamNamespacedPodLog(pod);
     } catch (ApiException ex) {
-      assertEquals(404, ex.getCode());
+      assertThat(ex.getCode()).isEqualTo(404);
       thrown = true;
     }
-    assertEquals(thrown, true);
+    assertThat(thrown).isTrue();
     wireMockRule.verify(
         getRequestedFor(
                 urlPathEqualTo("/api/v1/namespaces/" + namespace + "/pods/" + podName + "/log"))
@@ -133,7 +132,7 @@ public class PodLogsTest {
 
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
     Streams.copy(is, bos);
-    assertEquals(content, bos.toString());
+    assertThat(bos).hasToString(content);
   }
 
   @Test
@@ -162,11 +161,11 @@ public class PodLogsTest {
     try (InputStream ignored = logs.streamNamespacedPodLog(pod)) {
       thrown = false;
     } catch (ApiException ex) {
-      assertEquals(404, ex.getCode());
+      assertThat(ex.getCode()).isEqualTo(404);
       thrown = true;
     }
 
-    assertTrue(thrown);
+    assertThat(thrown).isTrue();
     verify(mockResponse).close();
   }
 }

--- a/util/src/test/java/io/kubernetes/client/WebsocketStreamHandlerTest.java
+++ b/util/src/test/java/io/kubernetes/client/WebsocketStreamHandlerTest.java
@@ -12,9 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.util.WebSocketStreamHandler;
 import java.io.ByteArrayInputStream;
@@ -53,9 +51,9 @@ public class WebsocketStreamHandlerTest {
     inputStream.read(receivingData);
     handler.close();
 
-    assertEquals(testData, receivingData[0]);
-    assertEquals(testData, receivingData[1]);
-    assertTrue(mockWebSocket.closed);
+    assertThat(receivingData[0]).isEqualTo(testData);
+    assertThat(receivingData[1]).isEqualTo(testData);
+    assertThat(mockWebSocket.closed).isTrue();
   }
 
   @Test
@@ -82,7 +80,7 @@ public class WebsocketStreamHandlerTest {
     outputStream.write(bytes);
     outputStream.flush();
 
-    assertArrayEquals(output, mockWebSocket.data);
+    assertThat(mockWebSocket.data).containsExactly(output);
   }
 
   @Test
@@ -119,7 +117,7 @@ public class WebsocketStreamHandlerTest {
     outputStream.write(bytes);
     outputStream.flush();
 
-    assertArrayEquals(output, mockWebSocket.data);
+    assertThat(mockWebSocket.data).containsExactly(output);
   }
 
   private static class MockWebSocket implements WebSocket {

--- a/util/src/test/java/io/kubernetes/client/apimachinery/GroupVersionKindTest.java
+++ b/util/src/test/java/io/kubernetes/client/apimachinery/GroupVersionKindTest.java
@@ -12,9 +12,9 @@ limitations under the License.
 */
 package io.kubernetes.client.apimachinery;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 public class GroupVersionKindTest {
@@ -28,7 +28,7 @@ public class GroupVersionKindTest {
 
   @Test
   public void testValidKind() {
-    Assertions.assertThatNoException()
+    assertThatNoException()
         .isThrownBy(() -> new GroupVersionKind("group", "version", "kind"));
   }
 }

--- a/util/src/test/java/io/kubernetes/client/apimachinery/GroupVersionResourceTest.java
+++ b/util/src/test/java/io/kubernetes/client/apimachinery/GroupVersionResourceTest.java
@@ -12,9 +12,9 @@ limitations under the License.
 */
 package io.kubernetes.client.apimachinery;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 public class GroupVersionResourceTest {
@@ -27,7 +27,7 @@ public class GroupVersionResourceTest {
 
   @Test
   public void testValidResource() {
-    Assertions.assertThatNoException()
+    assertThatNoException()
         .isThrownBy(() -> new GroupVersionResource("group", "version", "resource"));
   }
 }

--- a/util/src/test/java/io/kubernetes/client/apimachinery/NamespaceNameTest.java
+++ b/util/src/test/java/io/kubernetes/client/apimachinery/NamespaceNameTest.java
@@ -12,9 +12,9 @@ limitations under the License.
 */
 package io.kubernetes.client.apimachinery;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 public class NamespaceNameTest {
@@ -35,6 +35,6 @@ public class NamespaceNameTest {
 
   @Test
   public void testValidNamespaceName() {
-    Assertions.assertThatNoException().isThrownBy(() -> new NamespaceName("namespace", "name"));
+    assertThatNoException().isThrownBy(() -> new NamespaceName("namespace", "name"));
   }
 }

--- a/util/src/test/java/io/kubernetes/client/informer/cache/CacheTest.java
+++ b/util/src/test/java/io/kubernetes/client/informer/cache/CacheTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.informer.cache;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -94,17 +94,16 @@ public class CacheTest {
 
     String index = mockIndexFunc(this.obj).get(0);
     String key = mockKeyFunc(this.obj);
-    assertEquals(this.index, index);
+    assertThat(index).isEqualTo(this.index);
 
     List indexedObjectList = cache.byIndex(mockIndexName, index);
-    assertEquals(this.obj, indexedObjectList.get(0));
+    assertThat(indexedObjectList).containsExactly(this.obj);
 
     List indexedObjectlist2 = cache.index(mockIndexName, this.obj);
-    assertEquals(this.obj, indexedObjectlist2.get(0));
+    assertThat(indexedObjectlist2).containsExactly(this.obj);
 
     List<String> allExistingKeys = cache.listKeys();
-    assertEquals(1, allExistingKeys.size());
-    assertEquals(key, allExistingKeys.get(0));
+    assertThat(allExistingKeys).containsExactly(key);
   }
 
   @Test
@@ -120,8 +119,8 @@ public class CacheTest {
 
     V1Pod pod = ((V1Pod) this.obj);
     List indexedObjectList = cache.byIndex(mockIndexName, this.index);
-    assertEquals(0, indexedObjectList.size());
-    assertEquals(null, pod.getMetadata().getResourceVersion());
+    assertThat(indexedObjectList).isEmpty();
+    assertThat(pod.getMetadata().getResourceVersion()).isEqualTo(null);
 
     cache.add(this.obj);
 
@@ -130,8 +129,8 @@ public class CacheTest {
     pod.getMetadata().setResourceVersion(newClusterName);
     cache.update(this.obj);
 
-    assertEquals(1, cache.list().size());
-    assertEquals(newClusterName, pod.getMetadata().getResourceVersion());
+    assertThat(cache.list()).hasSize(1);
+    assertThat(pod.getMetadata().getResourceVersion()).isEqualTo(newClusterName);
   }
 
   @Test
@@ -151,10 +150,10 @@ public class CacheTest {
     podCache.add(testPod);
 
     List<V1Pod> namespaceIndexedPods = podCache.byIndex(Caches.NAMESPACE_INDEX, "ns");
-    assertEquals(1, namespaceIndexedPods.size());
+    assertThat(namespaceIndexedPods).hasSize(1);
 
     List<V1Pod> nodeNameIndexedPods = podCache.byIndex(testIndexFuncName, "node1");
-    assertEquals(1, nodeNameIndexedPods.size());
+    assertThat(nodeNameIndexedPods).hasSize(1);
   }
 
   @Test
@@ -181,9 +180,9 @@ public class CacheTest {
     podCache.add(testPod);
 
     List<V1Pod> namespaceIndexedPods = podCache.byIndex(Caches.NAMESPACE_INDEX, "ns");
-    assertEquals(1, namespaceIndexedPods.size());
+    assertThat(namespaceIndexedPods).hasSize(1);
 
     List<V1Pod> nodeNameIndexedPods = podCache.byIndex(nodeIndex, "node1");
-    assertEquals(1, nodeNameIndexedPods.size());
+    assertThat(nodeNameIndexedPods).hasSize(1);
   }
 }

--- a/util/src/test/java/io/kubernetes/client/informer/cache/CachesTest.java
+++ b/util/src/test/java/io/kubernetes/client/informer/cache/CachesTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.informer.cache;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
@@ -26,7 +26,7 @@ public class CachesTest {
     String testName = "test-name";
     String testNamespace = "test-namespace";
     V1Pod pod = new V1Pod().metadata(new V1ObjectMeta().name(testName).namespace(testNamespace));
-    assertEquals(testNamespace + "/" + testName, Caches.metaNamespaceKeyFunc(pod));
+    assertThat(Caches.metaNamespaceKeyFunc(pod)).isEqualTo(testNamespace + "/" + testName);
   }
 
   @Test
@@ -35,6 +35,6 @@ public class CachesTest {
     String testNamespace = "test-namespace";
     V1Pod pod = new V1Pod().metadata(new V1ObjectMeta().name(testName).namespace(testNamespace));
     List<String> indices = Caches.metaNamespaceIndexFunc(pod);
-    assertEquals(pod.getMetadata().getNamespace(), indices.get(0));
+    assertThat(indices).containsExactly(pod.getMetadata().getNamespace());
   }
 }

--- a/util/src/test/java/io/kubernetes/client/informer/cache/ControllerTest.java
+++ b/util/src/test/java/io/kubernetes/client/informer/cache/ControllerTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.informer.cache;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.informer.EventType;
@@ -31,7 +31,6 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.awaitility.Awaitility;
-import org.hamcrest.core.IsEqual;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -91,10 +90,8 @@ public class ControllerTest {
       Awaitility.await()
           .pollInterval(Duration.ofSeconds(1))
           .timeout(Duration.ofSeconds(5))
-          .untilAtomic(receivingDeltasCount, IsEqual.equalTo(4));
-      assertEquals(4, receivingDeltasCount.get());
-    } catch (Throwable t) {
-      throw new RuntimeException(t);
+          .until(() -> receivingDeltasCount.get() == 4);
+      assertThat(receivingDeltasCount).hasValue(4);
     } finally {
       controller.stop();
     }
@@ -111,11 +108,11 @@ public class ControllerTest {
             resyncFuncMock,
             anyFullResyncPeriod,
             exceptionHandlerMock);
-    assertSame(exceptionHandlerMock, controller.exceptionHandler);
+    assertThat(controller.exceptionHandler).isSameAs(exceptionHandlerMock);
 
     ReflectorRunnable<V1Pod, V1PodList> reflector = controller.newReflector();
 
-    assertSame(exceptionHandlerMock, reflector.exceptionHandler);
+    assertThat(reflector.exceptionHandler).isSameAs(exceptionHandlerMock);
   }
 
   @Test
@@ -130,6 +127,6 @@ public class ControllerTest {
             resyncFuncMock,
             anyFullResyncPeriod);
 
-    assertNull(controller.exceptionHandler);
+    assertThat(controller.exceptionHandler).isNull();
   }
 }

--- a/util/src/test/java/io/kubernetes/client/informer/cache/DeltaFIFOTest.java
+++ b/util/src/test/java/io/kubernetes/client/informer/cache/DeltaFIFOTest.java
@@ -12,8 +12,9 @@ limitations under the License.
 */
 package io.kubernetes.client.informer.cache;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -44,8 +45,8 @@ public class DeltaFIFOTest {
         });
     receivingDelta = receivingDeltas.peekFirst();
     receivingDeltas.removeFirst();
-    assertEquals(foo1, receivingDelta.getRight());
-    assertEquals(DeltaFIFO.DeltaType.Added, receivingDelta.getLeft());
+    assertThat(receivingDelta.getRight()).isEqualTo(foo1);
+    assertThat(receivingDelta.getLeft()).isEqualTo(DeltaFIFO.DeltaType.Added);
 
     // basic update operation
     deltaFIFO.update(foo1);
@@ -57,8 +58,8 @@ public class DeltaFIFOTest {
         });
     receivingDelta = receivingDeltas.peekFirst();
     receivingDeltas.removeFirst();
-    assertEquals(foo1, receivingDelta.getRight());
-    assertEquals(DeltaFIFO.DeltaType.Updated, receivingDelta.getLeft());
+    assertThat(receivingDelta.getRight()).isEqualTo(foo1);
+    assertThat(receivingDelta.getLeft()).isEqualTo(DeltaFIFO.DeltaType.Updated);
 
     // basic delete operation
     deltaFIFO.delete(foo1);
@@ -70,8 +71,8 @@ public class DeltaFIFOTest {
         });
     receivingDelta = receivingDeltas.peekFirst();
     receivingDeltas.removeFirst();
-    assertEquals(foo1, receivingDelta.getRight());
-    assertEquals(DeltaFIFO.DeltaType.Deleted, receivingDelta.getLeft());
+    assertThat(receivingDelta.getRight()).isEqualTo(foo1);
+    assertThat(receivingDelta.getLeft()).isEqualTo(DeltaFIFO.DeltaType.Deleted);
 
     // basic sync operation
     deltaFIFO.replace(Arrays.asList(foo1), "0");
@@ -83,8 +84,8 @@ public class DeltaFIFOTest {
         });
     receivingDelta = receivingDeltas.peekFirst();
     receivingDeltas.removeFirst();
-    assertEquals(foo1, receivingDelta.getRight());
-    assertEquals(DeltaFIFO.DeltaType.Sync, receivingDelta.getLeft());
+    assertThat(receivingDelta.getRight()).isEqualTo(foo1);
+    assertThat(receivingDelta.getLeft()).isEqualTo(DeltaFIFO.DeltaType.Sync);
   }
 
   @Test
@@ -100,11 +101,11 @@ public class DeltaFIFOTest {
     deltaFIFO.add(foo1);
     deltaFIFO.delete(foo1);
     deltas = deltaFIFO.getItems().get(Caches.deletionHandlingMetaNamespaceKeyFunc(foo1));
-    assertEquals(DeltaFIFO.DeltaType.Deleted, deltas.peekLast().getLeft());
-    assertEquals(foo1, deltas.peekLast().getRight());
-    assertEquals(DeltaFIFO.DeltaType.Added, deltas.peekFirst().getLeft());
-    assertEquals(foo1, deltas.peekFirst().getRight());
-    assertEquals(2, deltas.size());
+    assertThat(deltas.peekLast().getLeft()).isEqualTo(DeltaFIFO.DeltaType.Deleted);
+    assertThat(deltas.peekLast().getRight()).isEqualTo(foo1);
+    assertThat(deltas.peekFirst().getLeft()).isEqualTo(DeltaFIFO.DeltaType.Added);
+    assertThat(deltas.peekFirst().getRight()).isEqualTo(foo1);
+    assertThat(deltas).hasSize(2);
     deltaFIFO.getItems().remove(Caches.deletionHandlingMetaNamespaceKeyFunc(foo1));
 
     // add-delete-delete dedup
@@ -112,18 +113,18 @@ public class DeltaFIFOTest {
     deltaFIFO.delete(foo1);
     deltaFIFO.delete(foo1);
     deltas = deltaFIFO.getItems().get(Caches.deletionHandlingMetaNamespaceKeyFunc(foo1));
-    assertEquals(DeltaFIFO.DeltaType.Deleted, deltas.peekLast().getLeft());
-    assertEquals(foo1, deltas.peekLast().getRight());
-    assertEquals(DeltaFIFO.DeltaType.Added, deltas.peekFirst().getLeft());
-    assertEquals(foo1, deltas.peekFirst().getRight());
-    assertEquals(2, deltas.size());
+    assertThat(deltas.peekLast().getLeft()).isEqualTo(DeltaFIFO.DeltaType.Deleted);
+    assertThat(deltas.peekLast().getRight()).isEqualTo(foo1);
+    assertThat(deltas.peekFirst().getLeft()).isEqualTo(DeltaFIFO.DeltaType.Added);
+    assertThat(deltas.peekFirst().getRight()).isEqualTo(foo1);
+    assertThat(deltas).hasSize(2);
     deltaFIFO.getItems().remove(Caches.deletionHandlingMetaNamespaceKeyFunc(foo1));
 
     // add-sync dedupe
     deltaFIFO.add(foo1);
     deltaFIFO.replace(Collections.singletonList(foo1), foo1.getMetadata().getResourceVersion());
     deltas = deltaFIFO.getItems().get(Caches.deletionHandlingMetaNamespaceKeyFunc(foo1));
-    assertEquals(1, deltas.size());
+    assertThat(deltas).hasSize(1);
   }
 
   @Test
@@ -139,9 +140,9 @@ public class DeltaFIFOTest {
     Deque<MutablePair<DeltaFIFO.DeltaType, KubernetesObject>> deltas =
         deltaFIFO.getItems().get(Caches.deletionHandlingMetaNamespaceKeyFunc(foo1));
 
-    assertEquals(1, deltas.size());
-    assertEquals(foo1, deltas.peekLast().getRight());
-    assertEquals(DeltaFIFO.DeltaType.Sync, deltas.peekLast().getLeft());
+    assertThat(deltas).hasSize(1);
+    assertThat(deltas.peekLast().getRight()).isEqualTo(foo1);
+    assertThat(deltas.peekLast().getLeft()).isEqualTo(DeltaFIFO.DeltaType.Sync);
   }
 
   @Test
@@ -158,14 +159,14 @@ public class DeltaFIFOTest {
 
     deltaFIFO.pop(
         (deltas) -> {
-          assertEquals(DeltaFIFO.DeltaType.Deleted, deltas.getFirst().getLeft());
-          assertEquals(oldPod, deltas.getFirst().getRight());
+          assertThat(deltas.getFirst().getLeft()).isEqualTo(DeltaFIFO.DeltaType.Deleted);
+          assertThat(deltas.getFirst().getRight()).isEqualTo(oldPod);
         });
 
     deltaFIFO.pop(
         (deltas) -> {
-          assertEquals(DeltaFIFO.DeltaType.Sync, deltas.getFirst().getLeft());
-          assertEquals(newPod, deltas.getFirst().getRight());
+          assertThat(deltas.getFirst().getLeft()).isEqualTo(DeltaFIFO.DeltaType.Sync);
+          assertThat(deltas.getFirst().getRight()).isEqualTo(newPod);
         });
   }
 }

--- a/util/src/test/java/io/kubernetes/client/informer/cache/ListerTest.java
+++ b/util/src/test/java/io/kubernetes/client/informer/cache/ListerTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.informer.cache;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
@@ -27,7 +27,7 @@ public class ListerTest {
 
     Lister<V1Pod> namespacedPodLister = new Lister<>(podCache, "default");
     List<V1Pod> emptyPodList = namespacedPodLister.list();
-    assertEquals(0, emptyPodList.size());
+    assertThat(emptyPodList).isEmpty();
 
     podCache.replace(
         Arrays.asList(
@@ -36,13 +36,13 @@ public class ListerTest {
             new V1Pod().metadata(new V1ObjectMeta().name("foo3").namespace("default"))),
         "0");
     List<V1Pod> namespacedPodList = namespacedPodLister.list();
-    assertEquals(3, namespacedPodList.size());
+    assertThat(namespacedPodList).hasSize(3);
 
     Lister<V1Pod> allNamespacedPodLister = new Lister<>(podCache);
     List<V1Pod> allPodList = allNamespacedPodLister.list();
-    assertEquals(3, allPodList.size());
+    assertThat(allPodList).hasSize(3);
 
     namespacedPodList = allNamespacedPodLister.namespace("default").list();
-    assertEquals(3, namespacedPodList.size());
+    assertThat(namespacedPodList).hasSize(3);
   }
 }

--- a/util/src/test/java/io/kubernetes/client/informer/cache/ProcessorListenerTest.java
+++ b/util/src/test/java/io/kubernetes/client/informer/cache/ProcessorListenerTest.java
@@ -12,8 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.informer.cache;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.informer.ResourceEventHandler;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -38,21 +37,21 @@ public class ProcessorListenerTest {
 
               @Override
               public void onAdd(V1Pod obj) {
-                assertEquals(pod, obj);
+                assertThat(obj).isEqualTo(pod);
                 addNotificationReceived = true;
                 cLatch.countDown();
               }
 
               @Override
               public void onUpdate(V1Pod oldObj, V1Pod newObj) {
-                assertEquals(pod, newObj);
+                assertThat(newObj).isEqualTo(pod);
                 updateNotificationReceived = true;
                 cLatch.countDown();
               }
 
               @Override
               public void onDelete(V1Pod obj, boolean deletedFinalStateUnknown) {
-                assertEquals(pod, obj);
+                assertThat(obj).isEqualTo(pod);
                 deleteNotificationReceived = true;
                 cLatch.countDown();
               }
@@ -70,9 +69,9 @@ public class ProcessorListenerTest {
     // wait until consumption of notifications from queue
     cLatch.await();
 
-    assertTrue(addNotificationReceived);
-    assertTrue(updateNotificationReceived);
-    assertTrue(deleteNotificationReceived);
+    assertThat(addNotificationReceived).isTrue();
+    assertThat(updateNotificationReceived).isTrue();
+    assertThat(deleteNotificationReceived).isTrue();
   }
 
   @Test
@@ -87,7 +86,7 @@ public class ProcessorListenerTest {
             new ResourceEventHandler<V1Pod>() {
               @Override
               public void onAdd(V1Pod obj) {
-                assertEquals(pod, obj);
+                assertThat(obj).isEqualTo(pod);
                 count[0]++;
                 cLatch.countDown();
               }
@@ -110,6 +109,6 @@ public class ProcessorListenerTest {
 
     cLatch.await();
 
-    assertEquals(count[0], 2000);
+    assertThat(2000).isEqualTo(count[0]);
   }
 }

--- a/util/src/test/java/io/kubernetes/client/informer/cache/ReflectorRunnableTest.java
+++ b/util/src/test/java/io/kubernetes/client/informer/cache/ReflectorRunnableTest.java
@@ -12,10 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.informer.cache;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -39,7 +36,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import org.awaitility.Awaitility;
-import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -89,7 +85,7 @@ public class ReflectorRunnableTest {
   }
 
   @Test
-  public void testReflectorWatchConnectionCloseOnError() throws InterruptedException {
+  public void testReflectorWatchConnectionCloseOnError() {
     Watchable<V1Pod> watch =
         new MockWatch<V1Pod>(
             new Watch.Response<V1Pod>(EventType.ERROR.name(), new V1Status().status("403")));
@@ -141,7 +137,7 @@ public class ReflectorRunnableTest {
       Awaitility.await()
           .atMost(Duration.ofSeconds(1))
           .pollInterval(Duration.ofMillis(100))
-          .untilAtomic(actualException, new IsEqual<>(expectedException));
+          .until(() -> expectedException.equals(actualException.get()));
     } finally {
       reflectorRunnable.stop();
     }
@@ -196,7 +192,7 @@ public class ReflectorRunnableTest {
       Awaitility.await()
           .atMost(Duration.ofSeconds(1))
           .pollInterval(Duration.ofMillis(100))
-          .untilAtomic(actualException, new IsEqual<>(expectedException));
+          .until(() -> expectedException.equals(actualException.get()));
     } finally {
       reflectorRunnable.stop();
     }
@@ -223,7 +219,7 @@ public class ReflectorRunnableTest {
       Awaitility.await()
           .atMost(Duration.ofSeconds(1))
           .pollInterval(Duration.ofMillis(100))
-          .untilAtomic(actualException, new IsEqual<>(expectedException));
+          .until(() -> expectedException.equals(actualException.get()));
     } finally {
       reflectorRunnable.stop();
     }
@@ -273,7 +269,7 @@ public class ReflectorRunnableTest {
       Awaitility.await()
           .atMost(Duration.ofSeconds(1))
           .pollInterval(Duration.ofMillis(100))
-          .untilAtomic(requestedResourceVersion, new IsEqual<>(expectedResourceVersion));
+          .until(() -> expectedResourceVersion.equals(requestedResourceVersion.get()));
     } finally {
       reflectorRunnable.stop();
     }
@@ -294,7 +290,7 @@ public class ReflectorRunnableTest {
         .atMost(Duration.ofSeconds(2))
         .pollInterval(Duration.ofMillis(100))
         .until(() -> future.isDone());
-    assertFalse(future.isCompletedExceptionally());
+    assertThat(future.isCompletedExceptionally()).isFalse();
   }
 
   @Test
@@ -318,7 +314,7 @@ public class ReflectorRunnableTest {
         .atMost(Duration.ofSeconds(2))
         .pollInterval(Duration.ofMillis(100))
         .until(() -> future.isDone());
-    assertFalse(future.isCompletedExceptionally());
+    assertThat(future.isCompletedExceptionally()).isFalse();
   }
 
   @Test
@@ -345,7 +341,7 @@ public class ReflectorRunnableTest {
           .pollInterval(Duration.ofMillis(100))
           .until(
               () -> expectedResourceVersion.equals(reflectorRunnable.getLastSyncResourceVersion()));
-      assertTrue(reflectorRunnable.isLastSyncResourceVersionUnavailable());
+      assertThat(reflectorRunnable.isLastSyncResourceVersionUnavailable()).isTrue();
     } finally {
       reflectorRunnable.stop();
     }
@@ -356,7 +352,7 @@ public class ReflectorRunnableTest {
     ReflectorRunnable<V1Pod, V1PodList> reflector =
         new ReflectorRunnable<>(anyApiType, listerWatcher, deltaFIFO);
 
-    assertNotNull(reflector.exceptionHandler);
+    assertThat(reflector.exceptionHandler).isNotNull();
   }
 
   @Test
@@ -364,6 +360,6 @@ public class ReflectorRunnableTest {
     ReflectorRunnable<V1Pod, V1PodList> reflector =
         new ReflectorRunnable<>(anyApiType, listerWatcher, deltaFIFO, exceptionHandler);
 
-    assertSame(exceptionHandler, reflector.exceptionHandler);
+    assertThat(reflector.exceptionHandler).isSameAs(exceptionHandler);
   }
 }

--- a/util/src/test/java/io/kubernetes/client/informer/cache/SharedProcessorTest.java
+++ b/util/src/test/java/io/kubernetes/client/informer/cache/SharedProcessorTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.informer.cache;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.informer.ResourceEventHandler;
@@ -57,9 +57,9 @@ public class SharedProcessorTest {
 
     latch.await();
 
-    assertTrue(expectAddHandler.isSatisfied());
-    assertTrue(expectUpdateHandler.isSatisfied());
-    assertTrue(expectDeleteHandler.isSatisfied());
+    assertThat(expectAddHandler.isSatisfied()).isTrue();
+    assertThat(expectUpdateHandler.isSatisfied()).isTrue();
+    assertThat(expectDeleteHandler.isSatisfied()).isTrue();
   }
 
   @Test
@@ -83,7 +83,7 @@ public class SharedProcessorTest {
     sharedProcessor.addAndStartListener(slowWorker);
     sharedProcessor.stop();
     latch.await();
-    assertTrue(interrupted[0]);
+    assertThat(interrupted[0]).isTrue();
   }
 
   private static class ExpectingNoticationHandler<ApiType extends KubernetesObject>

--- a/util/src/test/java/io/kubernetes/client/informer/impl/DefaultSharedIndexInformerWireMockTest.java
+++ b/util/src/test/java/io/kubernetes/client/informer/impl/DefaultSharedIndexInformerWireMockTest.java
@@ -17,13 +17,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.moreThan;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.extension.Parameters;
@@ -47,7 +44,6 @@ import io.kubernetes.client.openapi.models.V1Status;
 import io.kubernetes.client.util.CallGeneratorParams;
 import io.kubernetes.client.util.ClientBuilder;
 import io.kubernetes.client.util.Watch;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
@@ -81,7 +77,7 @@ public class DefaultSharedIndexInformerWireMockTest {
   @Rule public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort().extensions(new CountRequestAction()));
 
   @Before
-  public void setup() throws IOException {
+  public void setup() {
     client = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
 
     namespace = "default";
@@ -176,8 +172,8 @@ public class DefaultSharedIndexInformerWireMockTest {
     getCount.acquire(1);
     watchCount.acquire(2);
 
-    assertEquals(true, foundExistingPod.get());
-    assertEquals(endRV, podInformer.lastSyncResourceVersion());
+    assertThat(foundExistingPod).isTrue();
+    assertThat(podInformer.lastSyncResourceVersion()).isEqualTo(endRV);
 
     verify(
         1,
@@ -310,10 +306,10 @@ public class DefaultSharedIndexInformerWireMockTest {
     } catch (IllegalStateException e) {
     }
 
-    assertTrue(foundExistingPod.get());
-    assertTrue(transformed.get());
-    assertFalse(setTransformAfterStarted.get());
-    assertEquals(endRV, podInformer.lastSyncResourceVersion());
+    assertThat(foundExistingPod).isTrue();
+    assertThat(transformed).isTrue();
+    assertThat(setTransformAfterStarted).isFalse();
+    assertThat(podInformer.lastSyncResourceVersion()).isEqualTo(endRV);
 
     verify(
         1,
@@ -419,8 +415,8 @@ public class DefaultSharedIndexInformerWireMockTest {
     watchCount.acquire(2);
 
     // cannot find the pod due to transform failure
-    assertFalse(foundExistingPod.get());
-    assertEquals(endRV, podInformer.lastSyncResourceVersion());
+    assertThat(foundExistingPod).isFalse();
+    assertThat(podInformer.lastSyncResourceVersion()).isEqualTo(endRV);
 
     verify(
         1,

--- a/util/src/test/java/io/kubernetes/client/util/ClientBuilderTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/ClientBuilderTest.java
@@ -14,10 +14,8 @@ package io.kubernetes.client.util;
 
 import static io.kubernetes.client.util.Config.ENV_SERVICE_HOST;
 import static io.kubernetes.client.util.Config.ENV_SERVICE_PORT;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariable;
@@ -71,7 +69,7 @@ public class ClientBuilderTest {
                   final ApiClient client = ClientBuilder.defaultClient();
                   return client.getBasePath();
                 });
-    assertEquals("http://localhost:8080", path);
+    assertThat(path).isEqualTo("http://localhost:8080");
   }
 
   @Test
@@ -83,7 +81,7 @@ public class ClientBuilderTest {
                   ApiClient client = ClientBuilder.defaultClient();
                   return client.getBasePath();
                 });
-    assertEquals("http://home.dir.com", path);
+    assertThat(path).isEqualTo("http://home.dir.com");
   }
 
   @Test
@@ -95,7 +93,7 @@ public class ClientBuilderTest {
                   final ApiClient client = ClientBuilder.defaultClient();
                   return client.getBasePath();
                 });
-    assertEquals("http://kubeconfig.dir.com", path);
+    assertThat(path).isEqualTo("http://kubeconfig.dir.com");
   }
 
   @Test
@@ -107,7 +105,7 @@ public class ClientBuilderTest {
                   final ApiClient client = ClientBuilder.defaultClient();
                   return client.getBasePath();
                 });
-    assertEquals("http://kubeconfig.dir.com", path);
+    assertThat(path).isEqualTo("http://kubeconfig.dir.com");
   }
 
   @Test
@@ -120,7 +118,7 @@ public class ClientBuilderTest {
                   final ApiClient client = ClientBuilder.defaultClient();
                   return client.getBasePath();
                 });
-    assertEquals("http://kubeconfig.dir.com", path);
+    assertThat(path).isEqualTo("http://kubeconfig.dir.com");
   }
 
   @Test
@@ -134,7 +132,7 @@ public class ClientBuilderTest {
                   return client.getBasePath();
                 });
     // $KUBECONFIG should take precedence over $HOME/.kube/config
-    assertEquals("http://kubeconfig.dir.com", path);
+    assertThat(path).isEqualTo("http://kubeconfig.dir.com");
   }
 
   @Test
@@ -149,7 +147,7 @@ public class ClientBuilderTest {
                   final ApiClient client = ClientBuilder.standard().build();
                   return client.getBasePath();
                 });
-    assertThat(path, is(Config.DEFAULT_FALLBACK_HOST));
+    assertThat(path).isEqualTo(Config.DEFAULT_FALLBACK_HOST);
   }
 
   @Test
@@ -161,7 +159,7 @@ public class ClientBuilderTest {
                   final ApiClient client = ClientBuilder.standard().build();
                   return client.getBasePath();
                 });
-    assertThat(path, is("https://localhost:443"));
+    assertThat(path).isEqualTo("https://localhost:443");
   }
 
   @Test
@@ -173,7 +171,7 @@ public class ClientBuilderTest {
                   final ApiClient client = ClientBuilder.standard().build();
                   return client.getBasePath();
                 });
-    assertThat(path, is("http://localhost"));
+    assertThat(path).isEqualTo("http://localhost");
   }
 
   @Test
@@ -185,13 +183,13 @@ public class ClientBuilderTest {
                   final ApiClient client = ClientBuilder.standard().build();
                   return client.isVerifyingSsl();
                 });
-    assertThat(isVerifyingSsl, is(false));
+    assertThat(isVerifyingSsl).isFalse();
   }
 
   @Test
   public void testBasePathTrailingSlash() throws Exception {
     final ApiClient client = ClientBuilder.standard().setBasePath("http://localhost/").build();
-    assertThat(client.getBasePath(), is("http://localhost"));
+    assertThat(client.getBasePath()).isEqualTo("http://localhost");
   }
 
   @Test
@@ -203,7 +201,7 @@ public class ClientBuilderTest {
                   final ApiClient client = ClientBuilder.standard().build();
                   return client.isVerifyingSsl();
                 });
-    assertThat(isVerifyingSsl, is(true));
+    assertThat(isVerifyingSsl).isTrue();
   }
 
   @Test
@@ -245,7 +243,7 @@ public class ClientBuilderTest {
                   final ApiClient client = ClientBuilder.standard().build();
                   return client.getBasePath();
                 });
-    assertEquals(path, "http://home.dir.com");
+    assertThat("http://home.dir.com").isEqualTo(path);
   }
 
   @Test
@@ -266,7 +264,7 @@ public class ClientBuilderTest {
                       }.setBasePath(ipv4Host, port);
                   return builder.getBasePath();
                 });
-    assertEquals(path, "https://127.0.0.1:6443");
+    assertThat("https://127.0.0.1:6443").isEqualTo(path);
   }
 
   @Test
@@ -287,7 +285,7 @@ public class ClientBuilderTest {
                       }.setBasePath(ipv4Host, port);
                   return builder.getBasePath();
                 });
-    assertEquals(path, "https://[::1]:6443");
+    assertThat("https://[::1]:6443").isEqualTo(path);
   }
 
   @Test
@@ -300,21 +298,18 @@ public class ClientBuilderTest {
     KubeconfigAuthentication receivingAuthn =
         (KubeconfigAuthentication) builder.getAuthentication();
     builder.build();
-    assertEquals(
-        expectedPassphrase,
+    assertThat(
         ((ClientCertificateAuthentication) receivingAuthn.getDelegateAuthentication())
-            .getPassphrase());
+            .getPassphrase()).isEqualTo(expectedPassphrase);
   }
 
   @Test
   public void testDetectsServerNotSet() {
-    assertThrows(
-        "No server in kubeconfig",
-        IllegalArgumentException.class,
+    assertThatThrownBy(
         () -> {
           KubeConfig kubeConfigWithoutServer = mock(KubeConfig.class);
 
           ClientBuilder.kubeconfig(kubeConfigWithoutServer);
-        });
+        }).hasMessage("No server in kubeconfig").isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/util/src/test/java/io/kubernetes/client/util/ConfigTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/ConfigTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.util;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariable;
 
 import io.kubernetes.client.openapi.ApiClient;
@@ -29,21 +29,17 @@ public class ConfigTest {
   @Rule public TemporaryFolder folder = new TemporaryFolder();
 
   @Test
-  public void testDefaultClientNothingPresent() {
-    try {
-      String path =
-          withEnvironmentVariable("HOME", "/non-existent")
-              .and("HOMEDRIVE", null)
-              .and("USERPROFILE", null)
-              .execute(
-                  () -> {
-                    ApiClient client = Config.defaultClient();
-                    return client.getBasePath();
-                  });
-      assertEquals("http://localhost:8080", path);
-    } catch (Exception ex) {
-      fail("Unexpected exception: " + ex);
-    }
+  public void testDefaultClientNothingPresent() throws Exception {
+    String path =
+        withEnvironmentVariable("HOME", "/non-existent")
+            .and("HOMEDRIVE", null)
+            .and("USERPROFILE", null)
+            .execute(
+                () -> {
+                  ApiClient client = Config.defaultClient();
+                  return client.getBasePath();
+                });
+    assertThat(path).isEqualTo("http://localhost:8080");
   }
 
   public static String HOME_CONFIG =
@@ -94,56 +90,41 @@ public class ConfigTest {
   }
 
   @Test
-  public void testDefaultClientHomeDir() {
-    try {
-      String path =
-          withEnvironmentVariable("HOME", dir.getCanonicalPath())
-              .execute(
-                  () -> {
-                    ApiClient client = Config.defaultClient();
-                    return client.getBasePath();
-                  });
-      assertEquals("http://home.dir.com", path);
-    } catch (Exception ex) {
-      ex.printStackTrace();
-      fail("Unexpected exception: " + ex);
-    }
+  public void testDefaultClientHomeDir() throws Exception {
+    String path =
+        withEnvironmentVariable("HOME", dir.getCanonicalPath())
+            .execute(
+                () -> {
+                  ApiClient client = Config.defaultClient();
+                  return client.getBasePath();
+                });
+    assertThat(path).isEqualTo("http://home.dir.com");
   }
 
   @Test
-  public void testDefaultClientKubeConfig() {
-    try {
-      String path =
-          withEnvironmentVariable("KUBECONFIG", configFile.getCanonicalPath())
-              .execute(
-                  () -> {
-                    ApiClient client = Config.defaultClient();
-                    return client.getBasePath();
-                  });
-      assertEquals("http://kubeconfig.dir.com", path);
-    } catch (Exception ex) {
-      ex.printStackTrace();
-      fail("Unexpected exception: " + ex);
-    }
+  public void testDefaultClientKubeConfig() throws Exception {
+    String path =
+        withEnvironmentVariable("KUBECONFIG", configFile.getCanonicalPath())
+            .execute(
+                () -> {
+                  ApiClient client = Config.defaultClient();
+                  return client.getBasePath();
+                });
+    assertThat(path).isEqualTo("http://kubeconfig.dir.com");
   }
 
   @Test
-  public void testDefaultClientPrecedence() {
-    try {
-      String path =
-          withEnvironmentVariable("HOME", dir.getCanonicalPath())
-              .and("KUBECONFIG", configFile.getCanonicalPath())
-              .execute(
-                  () -> {
-                    ApiClient client = Config.defaultClient();
-                    return client.getBasePath();
-                  });
+  public void testDefaultClientPrecedence() throws Exception {
+    String path =
+        withEnvironmentVariable("HOME", dir.getCanonicalPath())
+            .and("KUBECONFIG", configFile.getCanonicalPath())
+            .execute(
+                () -> {
+                  ApiClient client = Config.defaultClient();
+                  return client.getBasePath();
+                });
 
-      // $KUBECONFIG should take precedence over $HOME/.kube/config
-      assertEquals("http://kubeconfig.dir.com", path);
-    } catch (Exception ex) {
-      ex.printStackTrace();
-      fail("Unexpected exception: " + ex);
-    }
+    // $KUBECONFIG should take precedence over $HOME/.kube/config
+    assertThat(path).isEqualTo("http://kubeconfig.dir.com");
   }
 }

--- a/util/src/test/java/io/kubernetes/client/util/FilePersisterTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/FilePersisterTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.Resources;
 import java.io.File;
@@ -47,9 +47,9 @@ public class FilePersisterTest {
 
     KubeConfig configOut = KubeConfig.loadKubeConfig(new FileReader(file));
 
-    assertEquals(config.getCurrentContext(), configOut.getCurrentContext());
-    assertEquals(config.getClusters(), configOut.getClusters());
-    assertEquals(config.getContexts(), configOut.getContexts());
-    assertEquals(config.getUsers(), configOut.getUsers());
+    assertThat(configOut.getCurrentContext()).isEqualTo(config.getCurrentContext());
+    assertThat(configOut.getClusters()).isEqualTo(config.getClusters());
+    assertThat(configOut.getContexts()).isEqualTo(config.getContexts());
+    assertThat(configOut.getUsers()).isEqualTo(config.getUsers());
   }
 }

--- a/util/src/test/java/io/kubernetes/client/util/ModelMapperTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/ModelMapperTest.java
@@ -12,8 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.apimachinery.GroupVersionKind;
 import io.kubernetes.client.openapi.models.V1CustomResourceDefinition;
@@ -26,11 +25,12 @@ public class ModelMapperTest {
   @Test
   public void testPrebuiltModelMapping() {
 
-    assertEquals(V1Pod.class, ModelMapper.getApiTypeClass("", "v1", "Pod"));
-    assertEquals(V1Deployment.class, ModelMapper.getApiTypeClass("", "v1", "Deployment"));
-    assertEquals(
-            V1CustomResourceDefinition.class,
-            ModelMapper.getApiTypeClass("", "v1", "CustomResourceDefinition"));
+    assertThat(ModelMapper.getApiTypeClass("", "v1", "Pod"))
+        .isEqualTo(V1Pod.class);
+    assertThat(ModelMapper.getApiTypeClass("", "v1", "Deployment"))
+        .isEqualTo(V1Deployment.class);
+    assertThat(ModelMapper.getApiTypeClass("", "v1", "CustomResourceDefinition"))
+        .isEqualTo(V1CustomResourceDefinition.class);
   }
 
   @Test
@@ -43,35 +43,33 @@ public class ModelMapperTest {
 
     ModelMapper.addModelMap("example.io", "v1", "Toss", objClass);
 
-    assertEquals(objClass, ModelMapper.getApiTypeClass("example.io/v1", "Toss"));
-    assertEquals(objClass, ModelMapper.getApiTypeClass("example.io", "v1", "Toss"));
+    assertThat(ModelMapper.getApiTypeClass("example.io/v1", "Toss"))
+        .isEqualTo(objClass);
+    assertThat(ModelMapper.getApiTypeClass("example.io", "v1", "Toss"))
+        .isEqualTo(objClass);
 
-    assertNull(ModelMapper.getApiTypeClass("example.io/V1", "Toss"));
-    assertNull(ModelMapper.getApiTypeClass("example.io", "V1", "Toss"));
+    assertThat(ModelMapper.getApiTypeClass("example.io/V1", "Toss")).isNull();
+    assertThat(ModelMapper.getApiTypeClass("example.io", "V1", "Toss")).isNull();
 
-    assertNull(ModelMapper.getApiTypeClass("example.io/v1", "Tofu"));
-    assertNull(ModelMapper.getApiTypeClass("example.io", "v1", "Tofu"));
+    assertThat(ModelMapper.getApiTypeClass("example.io/v1", "Tofu")).isNull();
+    assertThat(ModelMapper.getApiTypeClass("example.io", "v1", "Tofu")).isNull();
 
-    assertNull(ModelMapper.getApiTypeClass("v1", "Togu"));
+    assertThat(ModelMapper.getApiTypeClass("v1", "Togu")).isNull();
     ModelMapper.addModelMap("v1", "Togu", objClass);
-    assertEquals(objClass, ModelMapper.getApiTypeClass("", "v1", "Togu"));
-    assertEquals(objClass, ModelMapper.getApiTypeClass("v1", "Togu"));
+    assertThat(ModelMapper.getApiTypeClass("", "v1", "Togu"))
+        .isEqualTo(objClass);
+    assertThat(ModelMapper.getApiTypeClass("v1", "Togu"))
+        .isEqualTo(objClass);
   }
 
 
   @Test
   public void testPreBuiltGetGroupVersionKindByClass() {
-    assertEquals(
-            new GroupVersionKind("", "v1", "Pod"),
-            ModelMapper.preBuiltGetGroupVersionKindByClass(V1Pod.class).orElse(null));
-    assertEquals(
-            new GroupVersionKind("", "v1", "Pod"),
-            ModelMapper.preBuiltGetGroupVersionKindByClass(V1Pod.class).orElse(null));
-    assertEquals(
-            new GroupVersionKind("", "v1", "Deployment"),
-            ModelMapper.preBuiltGetGroupVersionKindByClass(V1Deployment.class).orElse(null));
-    assertEquals(
-            new GroupVersionKind("", "v1", "CustomResourceDefinition"),
-            ModelMapper.preBuiltGetGroupVersionKindByClass(V1CustomResourceDefinition.class).orElse(null));
+    assertThat(ModelMapper.preBuiltGetGroupVersionKindByClass(V1Pod.class))
+        .hasValue(new GroupVersionKind("", "v1", "Pod"));
+    assertThat(ModelMapper.preBuiltGetGroupVersionKindByClass(V1Deployment.class))
+        .hasValue(new GroupVersionKind("", "v1", "Deployment"));
+    assertThat(ModelMapper.preBuiltGetGroupVersionKindByClass(V1CustomResourceDefinition.class))
+        .hasValue(new GroupVersionKind("", "v1", "CustomResourceDefinition"));
   }
 }

--- a/util/src/test/java/io/kubernetes/client/util/PatchUtilsTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/PatchUtilsTest.java
@@ -21,7 +21,6 @@ import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Pod;
-import java.io.IOException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,7 +32,7 @@ public class PatchUtilsTest {
   @Rule public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
 
   @Before
-  public void setup() throws IOException {
+  public void setup() {
     client = new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
   }
 

--- a/util/src/test/java/io/kubernetes/client/util/PreconditionsTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/PreconditionsTest.java
@@ -13,9 +13,9 @@ limitations under the License.
 package io.kubernetes.client.util;
 
 import static io.kubernetes.client.util.Preconditions.precondition;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 public class PreconditionsTest {
@@ -31,6 +31,6 @@ public class PreconditionsTest {
   @Test
   public void testNonEmptyString() {
     String abc = precondition("abc", Strings::isNullOrEmpty, () -> "string can not be empty");
-    Assertions.assertThat(abc).isEqualTo("abc");
+    assertThat(abc).isEqualTo("abc");
   }
 }

--- a/util/src/test/java/io/kubernetes/client/util/RetryUtilsTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/RetryUtilsTest.java
@@ -12,8 +12,9 @@ limitations under the License.
 */
 package io.kubernetes.client.util;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
 
 import io.kubernetes.client.openapi.ApiException;
 import java.net.HttpURLConnection;
@@ -43,7 +44,7 @@ public class RetryUtilsTest {
             });
 
     Object actualReturn = RetryUtils.retryUponConflict(apiInvocation, 3);
-    assertEquals(expectedReturn, actualReturn);
+    assertThat(actualReturn).isEqualTo(expectedReturn);
   }
 
   @Test
@@ -60,13 +61,14 @@ public class RetryUtilsTest {
               return expectedReturn;
             });
 
-    assertThrows(ApiException.class, () -> RetryUtils.retryUponConflict(apiInvocation, 3));
+    assertThatThrownBy(() -> RetryUtils.retryUponConflict(apiInvocation, 3))
+        .isInstanceOf(ApiException.class);
   }
 
   @Test
   public void testRetryUponConflictShouldThrowNonConflictException() throws ApiException {
     when(apiInvocation.call()).thenThrow(IllegalArgumentException.class);
-    assertThrows(
-        IllegalArgumentException.class, () -> RetryUtils.retryUponConflict(apiInvocation, 3));
+    assertThatThrownBy(() -> RetryUtils.retryUponConflict(apiInvocation, 3))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/util/src/test/java/io/kubernetes/client/util/SSLUtilsTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/SSLUtilsTest.java
@@ -12,13 +12,12 @@ limitations under the License.
 */
 package io.kubernetes.client.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.Resources;
 import java.io.IOException;
 import java.net.URL;
 import java.security.GeneralSecurityException;
-import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import org.apache.commons.io.IOUtils;
@@ -43,30 +42,30 @@ public class SSLUtilsTest {
   @Test
   public void testLoadKeyRsaPkcs8() throws IOException, GeneralSecurityException {
     final PrivateKey privateKey = assertLoadDumpReloadKeyEquals(CLIENT_KEY_RSA_PKCS8);
-    assertEquals(RSA_ALGORITHM, privateKey.getAlgorithm());
+    assertThat(privateKey.getAlgorithm()).isEqualTo(RSA_ALGORITHM);
   }
 
   @Test
   public void testLoadKeyRsaPkcs1() throws IOException, GeneralSecurityException {
     final PrivateKey privateKey = assertLoadDumpReloadKeyEquals(CLIENT_KEY_RSA_PKCS1);
-    assertEquals(RSA_ALGORITHM, privateKey.getAlgorithm());
+    assertThat(privateKey.getAlgorithm()).isEqualTo(RSA_ALGORITHM);
   }
 
   @Test
   public void testLoadKeyEcdsaPkcs7() throws IOException, GeneralSecurityException {
     final PrivateKey privateKey = assertLoadDumpReloadKeyEquals(CLIENT_KEY_ECDSA_PKCS7);
-    assertEquals(ECDSA_ALGORITHM, privateKey.getAlgorithm());
+    assertThat(privateKey.getAlgorithm()).isEqualTo(ECDSA_ALGORITHM);
   }
 
   @Test
   public void testLoadKeyEcdsaPkcs8() throws IOException, GeneralSecurityException {
     final PrivateKey privateKey = assertLoadDumpReloadKeyEquals(CLIENT_KEY_ECDSA_PKCS8);
-    assertEquals(ECDSA_ALGORITHM, privateKey.getAlgorithm());
+    assertThat(privateKey.getAlgorithm()).isEqualTo(ECDSA_ALGORITHM);
   }
 
   @Test(expected = InvalidKeySpecException.class)
   public void testLoadKeyCertificateNotSupported()
-      throws IOException, InvalidKeySpecException, NoSuchAlgorithmException {
+      throws IOException, InvalidKeySpecException {
     final byte[] resourceBytes = getResourceBytes(CLIENT_CERT);
     SSLUtils.loadKey(resourceBytes);
   }
@@ -79,7 +78,7 @@ public class SSLUtilsTest {
     byte[] dumpedKey = SSLUtils.dumpKey(privateKey);
     final PrivateKey reloadedPrivateKey = SSLUtils.loadKey(dumpedKey);
 
-    assertEquals(privateKey, reloadedPrivateKey);
+    assertThat(reloadedPrivateKey).isEqualTo(privateKey);
 
     return privateKey;
   }

--- a/util/src/test/java/io/kubernetes/client/util/WatchTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/WatchTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
@@ -45,6 +45,6 @@ public class WatchTest {
     obj.add("object", status);
     String data = json.getGson().toJson(obj);
     Watch.Response<V1ConfigMap> response = watch.parseLine(data);
-    assertEquals(null, response.object);
+    assertThat(response.object).isEqualTo(null);
   }
 }

--- a/util/src/test/java/io/kubernetes/client/util/authenticators/GCPAuthenticatorTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/authenticators/GCPAuthenticatorTest.java
@@ -12,9 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.util.authenticators;
 
-import static org.assertj.core.api.Fail.fail;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -28,7 +26,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -68,19 +65,14 @@ public class GCPAuthenticatorTest {
   private final GCPAuthenticator gcpAuthenticator = new GCPAuthenticator(mockPB, mockGC);
 
   @Before
-  public void setup() {
+  public void setup() throws IOException {
     Process mockProcess = Mockito.mock(Process.class);
     Mockito.when(mockProcess.exitValue()).thenReturn(0);
     Mockito.when(mockProcess.getInputStream())
         .thenReturn(new ByteArrayInputStream(fakeExecResult.getBytes(StandardCharsets.UTF_8)));
-    try {
-      Mockito.when(mockPB.command(Mockito.anyList())).thenCallRealMethod();
-      Mockito.when(mockPB.start()).thenReturn(mockProcess);
-      Mockito.when(mockPB.command()).thenCallRealMethod();
-    } catch (IOException ex) {
-      ex.printStackTrace();
-      fail("Unexpected exception: " + ex);
-    }
+    Mockito.when(mockPB.command(Mockito.anyList())).thenCallRealMethod();
+    Mockito.when(mockPB.start()).thenReturn(mockProcess);
+    Mockito.when(mockPB.command()).thenCallRealMethod();
   }
 
   @Test
@@ -96,7 +88,7 @@ public class GCPAuthenticatorTest {
         };
     gcpAuthenticator.refresh(gcpConfig);
     List<String> executedCommand = mockPB.command();
-    MatcherAssert.assertThat(executedCommand, is(expectedCommand));
+    assertThat(executedCommand).isEqualTo(expectedCommand);
   }
 
   @Test
@@ -112,7 +104,7 @@ public class GCPAuthenticatorTest {
         };
     gcpAuthenticator.refresh(gcpConfig);
     List<String> executedCommand = mockPB.command();
-    MatcherAssert.assertThat(executedCommand, is(expectedCommand));
+    assertThat(executedCommand).isEqualTo(expectedCommand);
   }
 
   @Test
@@ -128,7 +120,7 @@ public class GCPAuthenticatorTest {
         };
     gcpAuthenticator.refresh(gcpConfig);
     List<String> executedCommand = mockPB.command();
-    MatcherAssert.assertThat(executedCommand, is(expectedCommand));
+    assertThat(executedCommand).isEqualTo(expectedCommand);
   }
 
   @Test
@@ -144,7 +136,7 @@ public class GCPAuthenticatorTest {
         };
     gcpAuthenticator.refresh(gcpConfig);
     List<String> executedCommand = mockPB.command();
-    MatcherAssert.assertThat(executedCommand, is(expectedCommand));
+    assertThat(executedCommand).isEqualTo(expectedCommand);
   }
 
   @Test
@@ -160,7 +152,7 @@ public class GCPAuthenticatorTest {
         };
     gcpAuthenticator.refresh(gcpConfig);
     List<String> executedCommand = mockPB.command();
-    MatcherAssert.assertThat(executedCommand, is(expectedCommand));
+    assertThat(executedCommand).isEqualTo(expectedCommand);
   }
 
   @Test
@@ -176,7 +168,7 @@ public class GCPAuthenticatorTest {
         };
     gcpAuthenticator.refresh(gcpConfig);
     List<String> executedCommand = mockPB.command();
-    MatcherAssert.assertThat(executedCommand, is(expectedCommand));
+    assertThat(executedCommand).isEqualTo(expectedCommand);
   }
 
   @Test
@@ -192,7 +184,7 @@ public class GCPAuthenticatorTest {
         };
     gcpAuthenticator.refresh(gcpConfig);
     List<String> executedCommand = mockPB.command();
-    MatcherAssert.assertThat(executedCommand, is(expectedCommand));
+    assertThat(executedCommand).isEqualTo(expectedCommand);
   }
 
   @Test
@@ -202,7 +194,7 @@ public class GCPAuthenticatorTest {
         .thenReturn(new AccessToken(fakeToken, fakeTokenExpiryDate));
     final Map<String, Object> config = new HashMap<String, Object>() {};
     final Map<String, Object> result = gcpAuthenticator.refresh(config);
-    assertEquals(fakeToken, result.get(GCPAuthenticator.ACCESS_TOKEN));
-    assertEquals(fakeTokenExpiryDate, result.get(GCPAuthenticator.EXPIRY));
+    assertThat(result).containsEntry(GCPAuthenticator.ACCESS_TOKEN, fakeToken);
+    assertThat(result).containsEntry(GCPAuthenticator.EXPIRY, fakeTokenExpiryDate);
   }
 }

--- a/util/src/test/java/io/kubernetes/client/util/credentials/AccessTokenAuthenticationTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/credentials/AccessTokenAuthenticationTest.java
@@ -13,8 +13,7 @@ limitations under the License.
 package io.kubernetes.client.util.credentials;
 
 import static io.kubernetes.client.util.TestUtils.getApiKeyAuthFromClient;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.openapi.ApiClient;
 import org.junit.Test;
@@ -25,8 +24,8 @@ public class AccessTokenAuthenticationTest {
   public void testTokenProvided() {
     final ApiClient client = new ApiClient();
     new AccessTokenAuthentication("token").provide(client);
-    assertThat(getApiKeyAuthFromClient(client).getApiKeyPrefix(), is("Bearer"));
-    assertThat(getApiKeyAuthFromClient(client).getApiKey(), is("token"));
+    assertThat(getApiKeyAuthFromClient(client).getApiKeyPrefix()).isEqualTo("Bearer");
+    assertThat(getApiKeyAuthFromClient(client).getApiKey()).isEqualTo("token");
   }
 
   @Test(expected = NullPointerException.class)

--- a/util/src/test/java/io/kubernetes/client/util/credentials/OpenIDConnectAuthenticationTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/credentials/OpenIDConnectAuthenticationTest.java
@@ -17,10 +17,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
@@ -33,7 +30,6 @@ import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
-import java.security.spec.InvalidKeySpecException;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.codec.binary.Base64;
@@ -62,7 +58,7 @@ public class OpenIDConnectAuthenticationTest {
 
   @Test
   public void testTokenExpiredNotExpired()
-      throws InvalidKeySpecException, NoSuchAlgorithmException, Exception {
+      throws NoSuchAlgorithmException, Exception {
     OpenIDConnectAuthenticator oidcAuth = new OpenIDConnectAuthenticator();
     Map<String, Object> config = new HashMap<String, Object>();
 
@@ -78,12 +74,12 @@ public class OpenIDConnectAuthenticationTest {
 
     config.put(OpenIDConnectAuthenticator.OIDC_ID_TOKEN, jwt);
 
-    assertFalse(oidcAuth.isExpired(config));
+    assertThat(oidcAuth.isExpired(config)).isFalse();
   }
 
   @Test
   public void testTokenExpiredHasExpired()
-      throws InvalidKeySpecException, NoSuchAlgorithmException, Exception {
+      throws NoSuchAlgorithmException, Exception {
     OpenIDConnectAuthenticator oidcAuth = new OpenIDConnectAuthenticator();
     Map<String, Object> config = new HashMap<String, Object>();
 
@@ -99,21 +95,20 @@ public class OpenIDConnectAuthenticationTest {
 
     config.put(OpenIDConnectAuthenticator.OIDC_ID_TOKEN, jwt);
 
-    assertTrue(oidcAuth.isExpired(config));
+    assertThat(oidcAuth.isExpired(config)).isTrue();
   }
 
-  public void testTokenExpiredNull()
-      throws InvalidKeySpecException, NoSuchAlgorithmException, Exception {
+  public void testTokenExpiredNull() {
     OpenIDConnectAuthenticator oidcAuth = new OpenIDConnectAuthenticator();
     Map<String, Object> config = new HashMap<String, Object>();
 
     // no id_token
 
-    assertTrue(oidcAuth.isExpired(config));
+    assertThat(oidcAuth.isExpired(config)).isTrue();
   }
 
   @Test
-  public void testLoadToken() throws InvalidKeySpecException, NoSuchAlgorithmException, Exception {
+  public void testLoadToken() throws NoSuchAlgorithmException, Exception {
     OpenIDConnectAuthenticator oidcAuth = new OpenIDConnectAuthenticator();
     Map<String, Object> config = new HashMap<String, Object>();
 
@@ -129,16 +124,15 @@ public class OpenIDConnectAuthenticationTest {
 
     config.put(OpenIDConnectAuthenticator.OIDC_ID_TOKEN, jwt);
 
-    assertEquals(oidcAuth.getToken(config), jwt);
+    assertThat(jwt).isEqualTo(oidcAuth.getToken(config));
   }
 
   @Test
-  public void testLoadNullToken()
-      throws InvalidKeySpecException, NoSuchAlgorithmException, Exception {
+  public void testLoadNullToken() {
     OpenIDConnectAuthenticator oidcAuth = new OpenIDConnectAuthenticator();
     Map<String, Object> config = new HashMap<String, Object>();
 
-    assertNull(oidcAuth.getToken(config));
+    assertThat(oidcAuth.getToken(config)).isNull();
   }
 
   @Test
@@ -196,8 +190,8 @@ public class OpenIDConnectAuthenticationTest {
 
     Map<String, Object> respMap = oidcAuth.refresh(config);
 
-    assertEquals(refreshedJWT, respMap.get(OpenIDConnectAuthenticator.OIDC_ID_TOKEN));
-    assertEquals("new_refresh_token", respMap.get(OpenIDConnectAuthenticator.OIDC_REFRESH_TOKEN));
+    assertThat(respMap).containsEntry(OpenIDConnectAuthenticator.OIDC_ID_TOKEN, refreshedJWT);
+    assertThat(respMap).containsEntry(OpenIDConnectAuthenticator.OIDC_REFRESH_TOKEN, "new_refresh_token");
   }
 
   @Test(expected = RuntimeException.class)

--- a/util/src/test/java/io/kubernetes/client/util/credentials/TokenFileAuthenticationTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/credentials/TokenFileAuthenticationTest.java
@@ -28,7 +28,6 @@ import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.Configuration;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import java.io.File;
-import java.io.IOException;
 import java.time.Instant;
 import org.junit.Before;
 import org.junit.Rule;
@@ -45,7 +44,7 @@ public class TokenFileAuthenticationTest {
   @Rule public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
 
   @Before
-  public void setup() throws IOException {
+  public void setup() {
     final ApiClient client = new ApiClient();
     client.setBasePath("http://localhost:" + wireMockRule.port());
     this.auth = new TokenFileAuthentication(SERVICEACCOUNT_TOKEN1_PATH);
@@ -54,7 +53,7 @@ public class TokenFileAuthenticationTest {
   }
 
   @Test
-  public void testTokenProvided() throws IOException, ApiException {
+  public void testTokenProvided() throws ApiException {
     stubFor(
         get(urlPathEqualTo("/api/v1/pods")).willReturn(okForContentType("application/json",
                 "{\"items\":[]}")));

--- a/util/src/test/java/io/kubernetes/client/util/credentials/UsernamePasswordAuthenticationTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/credentials/UsernamePasswordAuthenticationTest.java
@@ -13,8 +13,7 @@ limitations under the License.
 package io.kubernetes.client.util.credentials;
 
 import static io.kubernetes.client.util.TestUtils.getApiKeyAuthFromClient;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.openapi.ApiClient;
 import java.nio.charset.StandardCharsets;
@@ -32,9 +31,8 @@ public class UsernamePasswordAuthenticationTest {
   public void testUsernamePasswordProvided() {
     final ApiClient client = new ApiClient();
     new UsernamePasswordAuthentication(USERNAME, PASSWORD).provide(client);
-    assertThat(getApiKeyAuthFromClient(client).getApiKeyPrefix(), is("Basic"));
-    assertThat(
-        getApiKeyAuthFromClient(client).getApiKey(),
-        is(ByteString.of(USERNAME_PASSWORD_BYTES).base64()));
+    assertThat(getApiKeyAuthFromClient(client).getApiKeyPrefix()).isEqualTo("Basic");
+    assertThat(getApiKeyAuthFromClient(client).getApiKey())
+        .isEqualTo(ByteString.of(USERNAME_PASSWORD_BYTES).base64());
   }
 }

--- a/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesApiForCoreApiTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesApiForCoreApiTest.java
@@ -31,17 +31,15 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.kubernetes.client.common.KubernetesType;
 import io.kubernetes.client.custom.V1Patch;
 import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.JSON;
 import io.kubernetes.client.openapi.models.V1ListMeta;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -76,7 +74,7 @@ public class GenericKubernetesApiForCoreApiTest {
   private GenericKubernetesApi<V1Pod, V1PodList> podClient;
 
   @Before
-  public void setup() throws IOException {
+  public void setup() {
     ApiClient apiClient =
         new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
     apiClient.setHttpClient(
@@ -94,9 +92,9 @@ public class GenericKubernetesApiForCoreApiTest {
             .willReturn(aResponse().withStatus(200).withBody(json.serialize(status))));
 
     KubernetesApiResponse<V1Pod> deletePodResp = podClient.delete("default", "foo1", null);
-    assertTrue(deletePodResp.isSuccess());
-    assertEquals(status, deletePodResp.getStatus());
-    assertNull(deletePodResp.getObject());
+    assertThat(deletePodResp.isSuccess()).isTrue();
+    assertThat(deletePodResp.getStatus()).isEqualTo(status);
+    assertThat(deletePodResp.getObject()).isNull();
     verify(1, deleteRequestedFor(urlPathEqualTo("/api/v1/namespaces/default/pods/foo1")));
   }
 
@@ -111,11 +109,11 @@ public class GenericKubernetesApiForCoreApiTest {
     Future<KubernetesApiResponse<V1Pod>> deletePodFuture =
         podClient.deleteAsync("default", "foo1", null, callback);
     KubernetesApiResponse<V1Pod> deletePodResp = callback.waitForAndGetResponse();
-    assertTrue(deletePodResp.isSuccess());
-    assertEquals(status, deletePodResp.getStatus());
-    assertNull(deletePodResp.getObject());
-    assertTrue(deletePodFuture.isDone());
-    assertFalse(deletePodFuture.isCancelled());
+    assertThat(deletePodResp.isSuccess()).isTrue();
+    assertThat(deletePodResp.getStatus()).isEqualTo(status);
+    assertThat(deletePodResp.getObject()).isNull();
+    assertThat(deletePodFuture.isDone()).isTrue();
+    assertThat(deletePodFuture.isCancelled()).isFalse();
 
     verify(1, deleteRequestedFor(urlPathEqualTo("/api/v1/namespaces/default/pods/foo1")));
   }
@@ -130,9 +128,9 @@ public class GenericKubernetesApiForCoreApiTest {
             .willReturn(aResponse().withStatus(200).withBody(json.serialize(foo1))));
 
     KubernetesApiResponse<V1Pod> deletePodResp = podClient.delete("default", "foo1");
-    assertTrue(deletePodResp.isSuccess());
-    assertEquals(foo1, deletePodResp.getObject());
-    assertNull(deletePodResp.getStatus());
+    assertThat(deletePodResp.isSuccess()).isTrue();
+    assertThat(deletePodResp.getObject()).isEqualTo(foo1);
+    assertThat(deletePodResp.getStatus()).isNull();
     verify(1, deleteRequestedFor(urlPathEqualTo("/api/v1/namespaces/default/pods/foo1")));
   }
 
@@ -149,11 +147,11 @@ public class GenericKubernetesApiForCoreApiTest {
     Future<KubernetesApiResponse<V1Pod>> deletePodFuture =
         podClient.deleteAsync("default", "foo1", callback);
     KubernetesApiResponse<V1Pod> deletePodResp = callback.waitForAndGetResponse();
-    assertTrue(deletePodResp.isSuccess());
-    assertEquals(foo1, deletePodResp.getObject());
-    assertNull(deletePodResp.getStatus());
-    assertTrue(deletePodFuture.isDone());
-    assertFalse(deletePodFuture.isCancelled());
+    assertThat(deletePodResp.isSuccess()).isTrue();
+    assertThat(deletePodResp.getObject()).isEqualTo(foo1);
+    assertThat(deletePodResp.getStatus()).isNull();
+    assertThat(deletePodFuture.isDone()).isTrue();
+    assertThat(deletePodFuture.isCancelled()).isFalse();
     verify(1, deleteRequestedFor(urlPathEqualTo("/api/v1/namespaces/default/pods/foo1")));
   }
 
@@ -166,9 +164,9 @@ public class GenericKubernetesApiForCoreApiTest {
             .willReturn(aResponse().withStatus(403).withBody(json.serialize(status))));
 
     KubernetesApiResponse<V1Pod> deletePodResp = podClient.delete("default", "foo1");
-    assertFalse(deletePodResp.isSuccess());
-    assertEquals(status, deletePodResp.getStatus());
-    assertNull(deletePodResp.getObject());
+    assertThat(deletePodResp.isSuccess()).isFalse();
+    assertThat(deletePodResp.getStatus()).isEqualTo(status);
+    assertThat(deletePodResp.getObject()).isNull();
     verify(1, deleteRequestedFor(urlPathEqualTo("/api/v1/namespaces/default/pods/foo1")));
   }
 
@@ -184,11 +182,11 @@ public class GenericKubernetesApiForCoreApiTest {
     Future<KubernetesApiResponse<V1Pod>> deletePodFuture =
         podClient.deleteAsync("default", "foo1", callback);
     KubernetesApiResponse<V1Pod> deletePodResp = callback.waitForAndGetResponse();
-    assertFalse(deletePodResp.isSuccess());
-    assertEquals(status, deletePodResp.getStatus());
-    assertNull(deletePodResp.getObject());
-    assertTrue(deletePodFuture.isDone());
-    assertFalse(deletePodFuture.isCancelled());
+    assertThat(deletePodResp.isSuccess()).isFalse();
+    assertThat(deletePodResp.getStatus()).isEqualTo(status);
+    assertThat(deletePodResp.getObject()).isNull();
+    assertThat(deletePodFuture.isDone()).isTrue();
+    assertThat(deletePodFuture.isCancelled()).isFalse();
     verify(1, deleteRequestedFor(urlPathEqualTo("/api/v1/namespaces/default/pods/foo1")));
   }
 
@@ -200,9 +198,9 @@ public class GenericKubernetesApiForCoreApiTest {
         get(urlPathEqualTo("/api/v1/namespaces/default/pods"))
             .willReturn(aResponse().withStatus(200).withBody(json.serialize(podList))));
     KubernetesApiResponse<V1PodList> podListResp = podClient.list("default");
-    assertTrue(podListResp.isSuccess());
-    assertEquals(podList, podListResp.getObject());
-    assertNull(podListResp.getStatus());
+    assertThat(podListResp.isSuccess()).isTrue();
+    assertThat(podListResp.getObject()).isEqualTo(podList);
+    assertThat(podListResp.getStatus()).isNull();
     verify(1, getRequestedFor(urlPathEqualTo("/api/v1/namespaces/default/pods")));
   }
 
@@ -218,11 +216,11 @@ public class GenericKubernetesApiForCoreApiTest {
     Future<KubernetesApiResponse<V1PodList>> podListFuture =
         podClient.listAsync("default", callback);
     KubernetesApiResponse<V1PodList> podListResp = callback.waitForAndGetResponse();
-    assertTrue(podListResp.isSuccess());
-    assertEquals(podList, podListResp.getObject());
-    assertNull(podListResp.getStatus());
-    assertTrue(podListFuture.isDone());
-    assertFalse(podListFuture.isCancelled());
+    assertThat(podListResp.isSuccess()).isTrue();
+    assertThat(podListResp.getObject()).isEqualTo(podList);
+    assertThat(podListResp.getStatus()).isNull();
+    assertThat(podListFuture.isDone()).isTrue();
+    assertThat(podListFuture.isCancelled()).isFalse();
     verify(1, getRequestedFor(urlPathEqualTo("/api/v1/namespaces/default/pods")));
   }
 
@@ -234,9 +232,9 @@ public class GenericKubernetesApiForCoreApiTest {
         get(urlPathEqualTo("/api/v1/pods"))
             .willReturn(aResponse().withStatus(200).withBody(json.serialize(podList))));
     KubernetesApiResponse<V1PodList> podListResp = podClient.list();
-    assertTrue(podListResp.isSuccess());
-    assertEquals(podList, podListResp.getObject());
-    assertNull(podListResp.getStatus());
+    assertThat(podListResp.isSuccess()).isTrue();
+    assertThat(podListResp.getObject()).isEqualTo(podList);
+    assertThat(podListResp.getStatus()).isNull();
     verify(
         1,
         getRequestedFor(urlPathEqualTo("/api/v1/pods")).withQueryParam("watch", equalTo("false")));
@@ -256,20 +254,21 @@ public class GenericKubernetesApiForCoreApiTest {
 
     Future<KubernetesApiResponse<V1PodList>> podListFuture = podClient.listAsync(callback);
 
-    assertFalse(podListFuture.isDone());
-    assertFalse(podListFuture.isCancelled());
+    assertThat(podListFuture.isDone()).isFalse();
+    assertThat(podListFuture.isCancelled()).isFalse();
 
-    assertThrows(TimeoutException.class, () -> podListFuture.get(10, TimeUnit.MILLISECONDS));
+    assertThatThrownBy(() -> podListFuture.get(10, TimeUnit.MILLISECONDS))
+        .isInstanceOf(TimeoutException.class);
 
     waitForRequest.proceed();
 
     KubernetesApiResponse<V1PodList> podListResp = callback.waitForAndGetResponse();
-    assertTrue(podListResp.isSuccess());
-    assertEquals(podList, podListResp.getObject());
-    assertNull(podListResp.getStatus());
-    assertTrue(podListFuture.isDone());
-    assertFalse(podListFuture.isCancelled());
-    assertEquals(podListResp, podListFuture.get());
+    assertThat(podListResp.isSuccess()).isTrue();
+    assertThat(podListResp.getObject()).isEqualTo(podList);
+    assertThat(podListResp.getStatus()).isNull();
+    assertThat(podListFuture.isDone()).isTrue();
+    assertThat(podListFuture.isCancelled()).isFalse();
+    assertThat(podListFuture.get()).isEqualTo(podListResp);
     verify(
         1,
         getRequestedFor(urlPathEqualTo("/api/v1/pods")).withQueryParam("watch", equalTo("false")));
@@ -289,22 +288,23 @@ public class GenericKubernetesApiForCoreApiTest {
 
     Future<KubernetesApiResponse<V1PodList>> podListFuture = podClient.listAsync(callback);
 
-    assertFalse(podListFuture.isDone());
-    assertFalse(podListFuture.isCancelled());
+    assertThat(podListFuture.isDone()).isFalse();
+    assertThat(podListFuture.isCancelled()).isFalse();
 
     // cancel request
-    assertTrue(podListFuture.cancel(true));
+    assertThat(podListFuture.cancel(true)).isTrue();
 
-    assertTrue(podListFuture.isCancelled());
-    assertTrue(podListFuture.isDone());
+    assertThat(podListFuture.isCancelled()).isTrue();
+    assertThat(podListFuture.isDone()).isTrue();
 
     // unblock thread to clean up
     waitForRequest.proceed();
 
-    assertThrows(CancellationException.class, podListFuture::get);
-    assertThrows(CancellationException.class, () -> podListFuture.get(10, TimeUnit.MILLISECONDS));
+    assertThatThrownBy(podListFuture::get).isInstanceOf(CancellationException.class);
+    assertThatThrownBy(() -> podListFuture.get(10, TimeUnit.MILLISECONDS))
+        .isInstanceOf(CancellationException.class);
 
-    assertFalse(callback.hasBeenCalled());
+    assertThat(callback.hasBeenCalled()).isFalse();
 
     verify(
         exactly(0),
@@ -320,9 +320,9 @@ public class GenericKubernetesApiForCoreApiTest {
         post(urlEqualTo("/api/v1/namespaces/default/pods"))
             .willReturn(aResponse().withStatus(200).withBody(json.serialize(foo1))));
     KubernetesApiResponse<V1Pod> podListResp = podClient.create(foo1);
-    assertTrue(podListResp.isSuccess());
-    assertEquals(foo1, podListResp.getObject());
-    assertNull(podListResp.getStatus());
+    assertThat(podListResp.isSuccess()).isTrue();
+    assertThat(podListResp.getObject()).isEqualTo(foo1);
+    assertThat(podListResp.getStatus()).isNull();
     verify(1, postRequestedFor(urlPathEqualTo("/api/v1/namespaces/default/pods")));
   }
 
@@ -338,11 +338,11 @@ public class GenericKubernetesApiForCoreApiTest {
 
     Future<KubernetesApiResponse<V1Pod>> podListFuture = podClient.createAsync(foo1, callback);
     KubernetesApiResponse<V1Pod> podListResp = callback.waitForAndGetResponse();
-    assertTrue(podListResp.isSuccess());
-    assertEquals(foo1, podListResp.getObject());
-    assertNull(podListResp.getStatus());
-    assertTrue(podListFuture.isDone());
-    assertFalse(podListFuture.isCancelled());
+    assertThat(podListResp.isSuccess()).isTrue();
+    assertThat(podListResp.getObject()).isEqualTo(foo1);
+    assertThat(podListResp.getStatus()).isNull();
+    assertThat(podListFuture.isDone()).isTrue();
+    assertThat(podListFuture.isCancelled()).isFalse();
     verify(1, postRequestedFor(urlPathEqualTo("/api/v1/namespaces/default/pods")));
   }
 
@@ -355,9 +355,9 @@ public class GenericKubernetesApiForCoreApiTest {
         put(urlEqualTo("/api/v1/namespaces/default/pods/foo1"))
             .willReturn(aResponse().withStatus(200).withBody(json.serialize(foo1))));
     KubernetesApiResponse<V1Pod> podListResp = podClient.update(foo1);
-    assertTrue(podListResp.isSuccess());
-    assertEquals(foo1, podListResp.getObject());
-    assertNull(podListResp.getStatus());
+    assertThat(podListResp.isSuccess()).isTrue();
+    assertThat(podListResp.getObject()).isEqualTo(foo1);
+    assertThat(podListResp.getStatus()).isNull();
     verify(1, putRequestedFor(urlPathEqualTo("/api/v1/namespaces/default/pods/foo1")));
   }
 
@@ -373,11 +373,11 @@ public class GenericKubernetesApiForCoreApiTest {
 
     Future<KubernetesApiResponse<V1Pod>> podListFuture = podClient.updateAsync(foo1, callback);
     KubernetesApiResponse<V1Pod> podListResp = callback.waitForAndGetResponse();
-    assertTrue(podListResp.isSuccess());
-    assertEquals(foo1, podListResp.getObject());
-    assertNull(podListResp.getStatus());
-    assertTrue(podListFuture.isDone());
-    assertFalse(podListFuture.isCancelled());
+    assertThat(podListResp.isSuccess()).isTrue();
+    assertThat(podListResp.getObject()).isEqualTo(foo1);
+    assertThat(podListResp.getStatus()).isNull();
+    assertThat(podListFuture.isDone()).isTrue();
+    assertThat(podListFuture.isCancelled()).isFalse();
     verify(1, putRequestedFor(urlPathEqualTo("/api/v1/namespaces/default/pods/foo1")));
   }
 
@@ -393,9 +393,9 @@ public class GenericKubernetesApiForCoreApiTest {
     KubernetesApiResponse<V1Pod> podPatchResp =
         podClient.patch("default", "foo1", V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH, v1Patch);
 
-    assertTrue(podPatchResp.isSuccess());
-    assertEquals(foo1, podPatchResp.getObject());
-    assertNull(podPatchResp.getStatus());
+    assertThat(podPatchResp.isSuccess()).isTrue();
+    assertThat(podPatchResp.getObject()).isEqualTo(foo1);
+    assertThat(podPatchResp.getStatus()).isNull();
     verify(1, patchRequestedFor(urlPathEqualTo("/api/v1/namespaces/default/pods/foo1")));
   }
 
@@ -415,11 +415,11 @@ public class GenericKubernetesApiForCoreApiTest {
             "default", "foo1", V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH, v1Patch, callback);
     KubernetesApiResponse<V1Pod> podPatchResp = callback.waitForAndGetResponse();
 
-    assertTrue(podPatchResp.isSuccess());
-    assertEquals(foo1, podPatchResp.getObject());
-    assertNull(podPatchResp.getStatus());
-    assertTrue(podPatchFuture.isDone());
-    assertFalse(podPatchFuture.isCancelled());
+    assertThat(podPatchResp.isSuccess()).isTrue();
+    assertThat(podPatchResp.getObject()).isEqualTo(foo1);
+    assertThat(podPatchResp.getStatus()).isNull();
+    assertThat(podPatchFuture.isDone()).isTrue();
+    assertThat(podPatchFuture.isCancelled()).isFalse();
     verify(1, patchRequestedFor(urlPathEqualTo("/api/v1/namespaces/default/pods/foo1")));
   }
 
@@ -449,9 +449,9 @@ public class GenericKubernetesApiForCoreApiTest {
         rancherPodClient.patch(
             "default", "foo1", V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH, v1Patch);
 
-    assertTrue(podPatchResp.isSuccess());
-    assertEquals(foo1, podPatchResp.getObject());
-    assertNull(podPatchResp.getStatus());
+    assertThat(podPatchResp.isSuccess()).isTrue();
+    assertThat(podPatchResp.getObject()).isEqualTo(foo1);
+    assertThat(podPatchResp.getStatus()).isNull();
     verify(1, patchRequestedFor(urlPathEqualTo(prefix + "/api/v1/namespaces/default/pods/foo1")));
   }
 
@@ -483,11 +483,11 @@ public class GenericKubernetesApiForCoreApiTest {
             "default", "foo1", V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH, v1Patch, callback);
     KubernetesApiResponse<V1Pod> podPatchResp = callback.waitForAndGetResponse();
 
-    assertTrue(podPatchResp.isSuccess());
-    assertEquals(foo1, podPatchResp.getObject());
-    assertNull(podPatchResp.getStatus());
-    assertTrue(podPatchFuture.isDone());
-    assertFalse(podPatchFuture.isCancelled());
+    assertThat(podPatchResp.isSuccess()).isTrue();
+    assertThat(podPatchResp.getObject()).isEqualTo(foo1);
+    assertThat(podPatchResp.getStatus()).isNull();
+    assertThat(podPatchFuture.isDone()).isTrue();
+    assertThat(podPatchFuture.isCancelled()).isFalse();
     verify(1, patchRequestedFor(urlPathEqualTo(prefix + "/api/v1/namespaces/default/pods/foo1")));
   }
 
@@ -507,12 +507,11 @@ public class GenericKubernetesApiForCoreApiTest {
     podClient =
         new GenericKubernetesApi<>(V1Pod.class, V1PodList.class, "", "v1", "pods", apiClient);
     try {
-      KubernetesApiResponse<V1Pod> response = podClient.get("foo", "test");
-    } catch (Throwable t) {
-      assertTrue(t.getCause() instanceof SocketTimeoutException);
-      return;
+      podClient.get("foo", "test");
+      failBecauseExceptionWasNotThrown(IllegalStateException.class);
+    } catch (IllegalStateException e) {
+      assertThat(e).hasCauseInstanceOf(SocketTimeoutException.class);
     }
-    fail("no exception happened");
   }
 
   static class TestCallback<ApiType extends KubernetesType>

--- a/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesApiTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesApiTest.java
@@ -14,7 +14,8 @@ package io.kubernetes.client.util.generic;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.kubernetes.client.custom.V1Patch;
@@ -31,7 +32,7 @@ import io.kubernetes.client.util.ClientBuilder;
 import io.kubernetes.client.util.Watchable;
 import io.kubernetes.client.util.generic.options.GetOptions;
 import io.kubernetes.client.util.generic.options.ListOptions;
-import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.SocketTimeoutException;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
@@ -46,7 +47,7 @@ public class GenericKubernetesApiTest {
   private GenericKubernetesApi<V1Job, V1JobList> jobClient;
 
   @Before
-  public void setup() throws IOException {
+  public void setup() {
     ApiClient apiClient =
         new ClientBuilder().setBasePath("http://localhost:" + wireMockRule.port()).build();
     jobClient =
@@ -62,9 +63,9 @@ public class GenericKubernetesApiTest {
             .willReturn(aResponse().withStatus(200).withBody(json.serialize(status))));
 
     KubernetesApiResponse<V1Job> deleteJobResp = jobClient.delete("default", "foo1", null);
-    assertTrue(deleteJobResp.isSuccess());
-    assertEquals(status, deleteJobResp.getStatus());
-    assertNull(deleteJobResp.getObject());
+    assertThat(deleteJobResp.isSuccess()).isTrue();
+    assertThat(deleteJobResp.getStatus()).isEqualTo(status);
+    assertThat(deleteJobResp.getObject()).isNull();
     verify(1, deleteRequestedFor(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1")));
   }
 
@@ -78,9 +79,9 @@ public class GenericKubernetesApiTest {
             .willReturn(aResponse().withStatus(200).withBody(json.serialize(foo1))));
 
     KubernetesApiResponse<V1Job> deleteJobResp = jobClient.delete("default", "foo1");
-    assertTrue(deleteJobResp.isSuccess());
-    assertEquals(foo1, deleteJobResp.getObject());
-    assertNull(deleteJobResp.getStatus());
+    assertThat(deleteJobResp.isSuccess()).isTrue();
+    assertThat(deleteJobResp.getObject()).isEqualTo(foo1);
+    assertThat(deleteJobResp.getStatus()).isNull();
     verify(1, deleteRequestedFor(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1")));
   }
 
@@ -93,9 +94,9 @@ public class GenericKubernetesApiTest {
             .willReturn(aResponse().withStatus(403).withBody(json.serialize(status))));
 
     KubernetesApiResponse<V1Job> deleteJobResp = jobClient.delete("default", "foo1");
-    assertFalse(deleteJobResp.isSuccess());
-    assertEquals(status, deleteJobResp.getStatus());
-    assertNull(deleteJobResp.getObject());
+    assertThat(deleteJobResp.isSuccess()).isFalse();
+    assertThat(deleteJobResp.getStatus()).isEqualTo(status);
+    assertThat(deleteJobResp.getObject()).isNull();
     verify(1, deleteRequestedFor(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1")));
   }
 
@@ -107,9 +108,9 @@ public class GenericKubernetesApiTest {
         get(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs"))
             .willReturn(aResponse().withStatus(200).withBody(json.serialize(jobList))));
     KubernetesApiResponse<V1JobList> jobListResp = jobClient.list("default");
-    assertTrue(jobListResp.isSuccess());
-    assertEquals(jobList, jobListResp.getObject());
-    assertNull(jobListResp.getStatus());
+    assertThat(jobListResp.isSuccess()).isTrue();
+    assertThat(jobListResp.getObject()).isEqualTo(jobList);
+    assertThat(jobListResp.getStatus()).isNull();
     verify(1, getRequestedFor(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs")));
   }
 
@@ -128,9 +129,9 @@ public class GenericKubernetesApiTest {
 
     KubernetesApiResponse<V1JobList> jobListResp =
         pomClient.list("default", new ListOptions().isPartialObjectMetadataListRequest(true));
-    assertTrue(jobListResp.isSuccess());
-    assertEquals(jobList, jobListResp.getObject());
-    assertNull(jobListResp.getStatus());
+    assertThat(jobListResp.isSuccess()).isTrue();
+    assertThat(jobListResp.getObject()).isEqualTo(jobList);
+    assertThat(jobListResp.getStatus()).isNull();
     verify(
         1,
         getRequestedFor(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs"))
@@ -154,9 +155,9 @@ public class GenericKubernetesApiTest {
 
     KubernetesApiResponse<V1Job> jobResp =
         pomClient.get("default", "noxu", new GetOptions().isPartialObjectMetadataRequest(true));
-    assertTrue(jobResp.isSuccess());
-    assertEquals(job, jobResp.getObject());
-    assertNull(jobResp.getStatus());
+    assertThat(jobResp.isSuccess()).isTrue();
+    assertThat(jobResp.getObject()).isEqualTo(job);
+    assertThat(jobResp.getStatus()).isNull();
     verify(
         1,
         getRequestedFor(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs/noxu"))
@@ -174,9 +175,9 @@ public class GenericKubernetesApiTest {
         get(urlPathEqualTo("/apis/batch/v1/jobs"))
             .willReturn(aResponse().withStatus(200).withBody(json.serialize(jobList))));
     KubernetesApiResponse<V1JobList> jobListResp = jobClient.list();
-    assertTrue(jobListResp.isSuccess());
-    assertEquals(jobList, jobListResp.getObject());
-    assertNull(jobListResp.getStatus());
+    assertThat(jobListResp.isSuccess()).isTrue();
+    assertThat(jobListResp.getObject()).isEqualTo(jobList);
+    assertThat(jobListResp.getStatus()).isNull();
     verify(1, getRequestedFor(urlPathEqualTo("/apis/batch/v1/jobs")));
   }
 
@@ -189,9 +190,9 @@ public class GenericKubernetesApiTest {
         post(urlEqualTo("/apis/batch/v1/namespaces/default/jobs"))
             .willReturn(aResponse().withStatus(200).withBody(json.serialize(foo1))));
     KubernetesApiResponse<V1Job> jobListResp = jobClient.create(foo1);
-    assertTrue(jobListResp.isSuccess());
-    assertEquals(foo1, jobListResp.getObject());
-    assertNull(jobListResp.getStatus());
+    assertThat(jobListResp.isSuccess()).isTrue();
+    assertThat(jobListResp.getObject()).isEqualTo(foo1);
+    assertThat(jobListResp.getStatus()).isNull();
     verify(1, postRequestedFor(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs")));
   }
 
@@ -204,9 +205,9 @@ public class GenericKubernetesApiTest {
         put(urlEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1"))
             .willReturn(aResponse().withStatus(200).withBody(json.serialize(foo1))));
     KubernetesApiResponse<V1Job> jobListResp = jobClient.update(foo1);
-    assertTrue(jobListResp.isSuccess());
-    assertEquals(foo1, jobListResp.getObject());
-    assertNull(jobListResp.getStatus());
+    assertThat(jobListResp.isSuccess()).isTrue();
+    assertThat(jobListResp.getObject()).isEqualTo(foo1);
+    assertThat(jobListResp.getStatus()).isNull();
     verify(1, putRequestedFor(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1")));
   }
 
@@ -220,9 +221,9 @@ public class GenericKubernetesApiTest {
         patch(urlEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1/status"))
             .willReturn(aResponse().withStatus(200).withBody(new JSON().serialize(foo1))));
     KubernetesApiResponse<V1Job> jobListResp = jobClient.updateStatus(foo1, t -> t.getStatus());
-    assertTrue(jobListResp.isSuccess());
-    assertEquals(foo1, jobListResp.getObject());
-    assertNull(jobListResp.getStatus());
+    assertThat(jobListResp.isSuccess()).isTrue();
+    assertThat(jobListResp.getObject()).isEqualTo(foo1);
+    assertThat(jobListResp.getStatus()).isNull();
     verify(
         1, patchRequestedFor(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1/status")));
   }
@@ -239,9 +240,9 @@ public class GenericKubernetesApiTest {
     KubernetesApiResponse<V1Job> jobPatchResp =
         jobClient.patch("default", "foo1", V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH, v1Patch);
 
-    assertTrue(jobPatchResp.isSuccess());
-    assertEquals(foo1, jobPatchResp.getObject());
-    assertNull(jobPatchResp.getStatus());
+    assertThat(jobPatchResp.isSuccess()).isTrue();
+    assertThat(jobPatchResp.getObject()).isEqualTo(foo1);
+    assertThat(jobPatchResp.getStatus()).isNull();
     verify(1, patchRequestedFor(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1")));
   }
 
@@ -255,10 +256,10 @@ public class GenericKubernetesApiTest {
     KubernetesApiResponse<V1Job> jobPatchResp =
         jobClient.patch("default", "foo1", V1Patch.PATCH_FORMAT_STRATEGIC_MERGE_PATCH, v1Patch);
 
-    assertTrue(jobPatchResp.isSuccess());
-    assertNull(jobPatchResp.getObject());
-    assertEquals("Unexpected response body", jobPatchResp.getStatus().getMessage());
-    assertEquals(200, jobPatchResp.getStatus().getCode().intValue());
+    assertThat(jobPatchResp.isSuccess()).isTrue();
+    assertThat(jobPatchResp.getObject()).isNull();
+    assertThat(jobPatchResp.getStatus().getMessage()).isEqualTo("Unexpected response body");
+    assertThat(jobPatchResp.getStatus().getCode().intValue()).isEqualTo(200);
     verify(1, patchRequestedFor(urlPathEqualTo("/apis/batch/v1/namespaces/default/jobs/foo1")));
   }
 
@@ -292,11 +293,10 @@ public class GenericKubernetesApiTest {
     jobClient =
         new GenericKubernetesApi<>(V1Job.class, V1JobList.class, "batch", "v1", "jobs", apiClient);
     try {
-      KubernetesApiResponse<V1Job> response = jobClient.get("foo", "test");
-    } catch (Throwable t) {
-      assertTrue(t.getCause() instanceof SocketTimeoutException);
-      return;
+      jobClient.get("foo", "test");
+      failBecauseExceptionWasNotThrown(IllegalStateException.class);
+    } catch (IllegalStateException e) {
+      assertThat(e).hasCauseInstanceOf(SocketTimeoutException.class);
     }
-    fail("no exception happened");
   }
 }

--- a/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesGetApiTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesGetApiTest.java
@@ -14,8 +14,7 @@ package io.kubernetes.client.util.generic;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.kubernetes.client.openapi.ApiClient;
@@ -68,10 +67,10 @@ public class GenericKubernetesGetApiTest {
     KubernetesApiResponse<V1Job> jobResp = jobClient.get("default", "noxu");
     KubernetesApiResponse<FooCustomResource> fooResp = fooClient.get("default", "noxu");
 
-    assertEquals(job, jobResp.getObject());
-    assertEquals(foo, fooResp.getObject());
-    assertNull(jobResp.getStatus());
-    assertNull(fooResp.getStatus());
+    assertThat(jobResp.getObject()).isEqualTo(job);
+    assertThat(fooResp.getObject()).isEqualTo(foo);
+    assertThat(jobResp.getStatus()).isNull();
+    assertThat(fooResp.getStatus()).isNull();
   }
 
   @Test
@@ -88,9 +87,9 @@ public class GenericKubernetesGetApiTest {
     KubernetesApiResponse<V1Job> jobResp = jobClient.get("default", "noxu");
     KubernetesApiResponse<FooCustomResource> fooResp = fooClient.get("default", "noxu");
 
-    assertEquals(forbiddenStatus, jobResp.getStatus());
-    assertEquals(forbiddenStatus, fooResp.getStatus());
-    assertNull(jobResp.getObject());
-    assertNull(fooResp.getObject());
+    assertThat(jobResp.getStatus()).isEqualTo(forbiddenStatus);
+    assertThat(fooResp.getStatus()).isEqualTo(forbiddenStatus);
+    assertThat(jobResp.getObject()).isNull();
+    assertThat(fooResp.getObject()).isNull();
   }
 }

--- a/util/src/test/java/io/kubernetes/client/util/generic/dynamic/DynamicKubernetesTypeAdaptorFactoryTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/generic/dynamic/DynamicKubernetesTypeAdaptorFactoryTest.java
@@ -12,8 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.util.generic.dynamic;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.gson.Gson;
 import io.kubernetes.client.common.KubernetesListObject;
@@ -50,14 +49,14 @@ public class DynamicKubernetesTypeAdaptorFactoryTest {
   @Test
   public void testSingleDynamicObjectRoundTrip() {
     KubernetesObject dynamicObj = gson.fromJson(jsonContent, KubernetesObject.class);
-    assertTrue(dynamicObj instanceof DynamicKubernetesObject);
+    assertThat(dynamicObj instanceof DynamicKubernetesObject).isTrue();
 
-    assertEquals("v1", dynamicObj.getApiVersion());
-    assertEquals("Namespace", dynamicObj.getKind());
-    assertEquals(new V1ObjectMeta().name("foo"), dynamicObj.getMetadata());
+    assertThat(dynamicObj.getApiVersion()).isEqualTo("v1");
+    assertThat(dynamicObj.getKind()).isEqualTo("Namespace");
+    assertThat(dynamicObj.getMetadata()).isEqualTo(new V1ObjectMeta().name("foo"));
 
     String dumped = gson.toJson(dynamicObj);
-    assertEquals(jsonContent, dumped);
+    assertThat(dumped).isEqualTo(jsonContent);
   }
 
   @Test
@@ -73,12 +72,12 @@ public class DynamicKubernetesTypeAdaptorFactoryTest {
 
     KubernetesListObject dynamicListObj =
         gson.fromJson(listJsonContent, KubernetesListObject.class);
-    assertTrue(dynamicListObj instanceof DynamicKubernetesListObject);
+    assertThat(dynamicListObj instanceof DynamicKubernetesListObject).isTrue();
 
-    assertEquals(1, dynamicListObj.getItems().size());
+    assertThat(dynamicListObj.getItems()).hasSize(1);
 
     String dumped = gson.toJson(dynamicListObj);
-    assertEquals(listJsonContent, dumped);
+    assertThat(dumped).isEqualTo(listJsonContent);
   }
 
   // Registering the same factory twice is not a good idea, but we should not explode if it happens.
@@ -87,6 +86,6 @@ public class DynamicKubernetesTypeAdaptorFactoryTest {
   public void testMultipleRegistration() {
     Gson badGson = gson.newBuilder().registerTypeAdapterFactory(factory).create();
     Object x = badGson.fromJson("{}", Map.class);
-    assertEquals(Collections.emptyMap(), x);
+    assertThat(x).isEqualTo(Collections.emptyMap());
   }
 }

--- a/util/src/test/java/io/kubernetes/client/util/generic/dynamic/DynamicsTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/generic/dynamic/DynamicsTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.util.generic.dynamic;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.gson.JsonObject;
 import io.kubernetes.client.Resources;
@@ -40,9 +40,8 @@ public class DynamicsTest {
     String podJsonContent = new String(Files.readAllBytes(Paths.get(TEST_POD_JSON_FILE)));
     String convertedJsonContent = Dynamics.fromYamlToJson(podYamlContent);
 
-    assertEquals(
-        json.getGson().fromJson(podJsonContent, JsonObject.class),
-        json.getGson().fromJson(convertedJsonContent, JsonObject.class));
+    assertThat(json.getGson().fromJson(convertedJsonContent, JsonObject.class))
+        .isEqualTo(json.getGson().fromJson(podJsonContent, JsonObject.class));
   }
 
   @Test
@@ -51,7 +50,7 @@ public class DynamicsTest {
     String podJsonContent = new String(Files.readAllBytes(Paths.get(TEST_POD_JSON_FILE)));
     String convertedYamlContent = Dynamics.fromJsonToYaml(podJsonContent);
 
-    assertEquals(Yaml.load(podYamlContent), Yaml.load(convertedYamlContent));
+    assertThat(Yaml.load(convertedYamlContent)).isEqualTo(Yaml.load(podYamlContent));
   }
 
   @Test
@@ -59,8 +58,8 @@ public class DynamicsTest {
     String podJsonContent = new String(Files.readAllBytes(Paths.get(TEST_POD_JSON_FILE)));
     DynamicKubernetesObject obj = Dynamics.newFromJson(podJsonContent);
 
-    assertEquals(obj.getApiVersion(), "v1");
-    assertEquals(obj.getKind(), "Pod");
+    assertThat("v1").isEqualTo(obj.getApiVersion());
+    assertThat("Pod").isEqualTo(obj.getKind());
   }
 
   @Test
@@ -68,7 +67,7 @@ public class DynamicsTest {
     String podYamlContent = new String(Files.readAllBytes(Paths.get(TEST_POD_YAML_FILE)));
     DynamicKubernetesObject obj = Dynamics.newFromYaml(podYamlContent);
 
-    assertEquals(obj.getApiVersion(), "v1");
-    assertEquals(obj.getKind(), "Pod");
+    assertThat("v1").isEqualTo(obj.getApiVersion());
+    assertThat("Pod").isEqualTo(obj.getKind());
   }
 }

--- a/util/src/test/java/io/kubernetes/client/util/labels/LabelSelectorTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/labels/LabelSelectorTest.java
@@ -15,14 +15,14 @@ package io.kubernetes.client.util.labels;
 import static io.kubernetes.client.util.labels.EqualityMatcher.equal;
 import static io.kubernetes.client.util.labels.EqualityMatcher.notEqual;
 import static io.kubernetes.client.util.labels.SetMatcher.*;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.kubernetes.client.openapi.models.V1LabelSelector;
 import io.kubernetes.client.openapi.models.V1LabelSelectorRequirement;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class LabelSelectorTest {
@@ -30,178 +30,178 @@ public class LabelSelectorTest {
   @Test
   public void normalLabelSelectionEqualShouldWork() {
     LabelSelector labelSelector = LabelSelector.and(equal("foo", "v1"));
-    assertTrue(
+    assertThat(
         labelSelector.test(
             new HashMap<String, String>() {
               {
                 put("foo", "v1");
               }
-            }));
-    assertFalse(
+            })).isTrue();
+    assertThat(
         labelSelector.test(
             new HashMap<String, String>() {
               {
                 put("foo", "v2");
               }
-            }));
-    assertEquals("foo = v1", labelSelector.toString());
+            })).isFalse();
+    assertThat(labelSelector).hasToString("foo = v1");
   }
 
   @Test
   public void normalLabelSelectionNotEqualShouldWork() {
     LabelSelector labelSelector = LabelSelector.and(notEqual("foo", "v1"));
-    assertTrue(
+    assertThat(
         labelSelector.test(
             new HashMap<String, String>() {
               {
                 put("foo", "v2");
               }
-            }));
-    assertFalse(
+            })).isTrue();
+    assertThat(
         labelSelector.test(
             new HashMap<String, String>() {
               {
                 put("foo", "v1");
               }
-            }));
-    assertEquals("foo != v1", labelSelector.toString());
+            })).isFalse();
+    assertThat(labelSelector).hasToString("foo != v1");
   }
 
   @Test
   public void normalLabelSelectionInShouldWork() {
     LabelSelector labelSelector = LabelSelector.and(in("foo", "v1", "v2"));
-    assertTrue(
+    assertThat(
         labelSelector.test(
             new HashMap<String, String>() {
               {
                 put("foo", "v1");
               }
-            }));
-    assertTrue(
+            })).isTrue();
+    assertThat(
         labelSelector.test(
             new HashMap<String, String>() {
               {
                 put("foo", "v2");
               }
-            }));
-    assertFalse(
+            })).isTrue();
+    assertThat(
         labelSelector.test(
             new HashMap<String, String>() {
               {
                 put("foo", "v3");
               }
-            }));
-    assertEquals("foo in (v1,v2)", labelSelector.toString());
+            })).isFalse();
+    assertThat(labelSelector).hasToString("foo in (v1,v2)");
   }
 
   @Test
   public void normalLabelSelectionNotInShouldWork() {
     LabelSelector labelSelector = LabelSelector.and(notIn("foo", "v1", "v2"));
-    assertFalse(
+    assertThat(
         labelSelector.test(
             new HashMap<String, String>() {
               {
                 put("foo", "v1");
               }
-            }));
-    assertFalse(
+            })).isFalse();
+    assertThat(
         labelSelector.test(
             new HashMap<String, String>() {
               {
                 put("foo", "v2");
               }
-            }));
-    assertTrue(
+            })).isFalse();
+    assertThat(
         labelSelector.test(
             new HashMap<String, String>() {
               {
                 put("foo", "v3");
               }
-            }));
-    assertEquals("foo notin (v1,v2)", labelSelector.toString());
+            })).isTrue();
+    assertThat(labelSelector).hasToString("foo notin (v1,v2)");
   }
 
   @Test
   public void normalLabelSelectionConjuctionShouldWork() {
     LabelSelector labelSelector = LabelSelector.and(in("foo", "v1", "v2"), equal("fok", "v1"));
-    assertTrue(
+    assertThat(
         labelSelector.test(
             new HashMap<String, String>() {
               {
                 put("foo", "v1");
                 put("fok", "v1");
               }
-            }));
-    assertFalse(
+            })).isTrue();
+    assertThat(
         labelSelector.test(
             new HashMap<String, String>() {
               {
                 put("foo", "v2");
               }
-            }));
-    assertFalse(
+            })).isFalse();
+    assertThat(
         labelSelector.test(
             new HashMap<String, String>() {
               {
                 put("fok", "v1");
               }
-            }));
-    assertEquals("foo in (v1,v2),fok = v1", labelSelector.toString());
+            })).isFalse();
+    assertThat(labelSelector).hasToString("foo in (v1,v2),fok = v1");
   }
 
   @Test
   public void normalLabelSelectionExistsShouldWork() {
     LabelSelector labelSelector = LabelSelector.and(exists("foo"));
-    assertTrue(
+    assertThat(
         labelSelector.test(
             new HashMap<String, String>() {
               {
                 put("foo", "v1");
               }
-            }));
-    assertFalse(labelSelector.test(new HashMap<String, String>()));
-    assertFalse(
+            })).isTrue();
+    assertThat(labelSelector.test(new HashMap<String, String>())).isFalse();
+    assertThat(
         labelSelector.test(
             new HashMap<String, String>() {
               {
                 put("fok", "v1");
               }
-            }));
-    assertEquals("foo", labelSelector.toString());
+            })).isFalse();
+    assertThat(labelSelector).hasToString("foo");
   }
 
   @Test
   public void normalLabelSelectionNotExistsShouldWork() {
     LabelSelector labelSelector = LabelSelector.and(notExists("foo"));
-    assertFalse(
+    assertThat(
         labelSelector.test(
             new HashMap<String, String>() {
               {
                 put("foo", "v1");
               }
-            }));
-    assertTrue(labelSelector.test(new HashMap<String, String>()));
-    assertTrue(
+            })).isFalse();
+    assertThat(labelSelector.test(new HashMap<String, String>())).isTrue();
+    assertThat(
         labelSelector.test(
             new HashMap<String, String>() {
               {
                 put("fok", "v1");
               }
-            }));
-    assertEquals("!foo", labelSelector.toString());
+            })).isTrue();
+    assertThat(labelSelector).hasToString("!foo");
   }
 
   @Test
   public void emptyLabelSelectorShouldWork() {
     LabelSelector labelSelector = LabelSelector.empty();
-    assertTrue(
+    assertThat(
         labelSelector.test(
             new HashMap<String, String>() {
               {
                 put("foo", "v1");
               }
-            }));
-    assertEquals("", labelSelector.toString());
+            })).isTrue();
+    assertThat(labelSelector.toString()).isEmpty();
   }
 
   @Test
@@ -222,9 +222,9 @@ public class LabelSelectorTest {
             put("app2", "bar");
           }
         };
-    Assert.assertTrue(labelSelector.test(testSelector));
+    assertThat(labelSelector.test(testSelector)).isTrue();
     testSelector.remove("app1");
-    Assert.assertFalse(labelSelector.test(testSelector));
+    assertThat(labelSelector.test(testSelector)).isFalse();
   }
 
   @Test
@@ -274,7 +274,7 @@ public class LabelSelectorTest {
             put("key3", "");
           }
         };
-    Assert.assertTrue(labelSelector.test(testSelector));
+    assertThat(labelSelector.test(testSelector)).isTrue();
   }
 
   @Test
@@ -334,7 +334,7 @@ public class LabelSelectorTest {
             put("key3", "");
           }
         };
-    Assert.assertTrue(labelSelector.test(testSelector));
+    assertThat(labelSelector.test(testSelector)).isTrue();
   }
 
   @Test
@@ -356,6 +356,7 @@ public class LabelSelectorTest {
           }
         };
     V1LabelSelector v1LabelSelector = new V1LabelSelector().matchExpressions(exprs);
-    assertThrows(IllegalArgumentException.class, () -> LabelSelector.parse(v1LabelSelector));
+    assertThatThrownBy(() -> LabelSelector.parse(v1LabelSelector))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/util/src/test/java/io/kubernetes/client/util/labels/LabelsTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/labels/LabelsTest.java
@@ -12,7 +12,7 @@ limitations under the License.
 */
 package io.kubernetes.client.util.labels;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
@@ -26,7 +26,7 @@ public class LabelsTest {
   public void testAddLabels() {
     V1Pod pod = new V1Pod().metadata(new V1ObjectMeta());
     Labels.addLabels(pod, "foo", "bar");
-    assertEquals(pod.getMetadata().getLabels().get("foo"), "bar");
+    assertThat("bar").isEqualTo(pod.getMetadata().getLabels().get("foo"));
   }
 
   @Test
@@ -36,7 +36,7 @@ public class LabelsTest {
     newLabels.put("foo1", "bar1");
     newLabels.put("foo2", "bar2");
     Labels.addLabels(pod, newLabels);
-    assertEquals(pod.getMetadata().getLabels().get("foo1"), "bar1");
-    assertEquals(pod.getMetadata().getLabels().get("foo2"), "bar2");
+    assertThat("bar1").isEqualTo(pod.getMetadata().getLabels().get("foo1"));
+    assertThat("bar2").isEqualTo(pod.getMetadata().getLabels().get("foo2"));
   }
 }

--- a/util/src/test/java/io/kubernetes/client/util/taints/TaintsTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/taints/TaintsTest.java
@@ -13,9 +13,7 @@ limitations under the License.
 package io.kubernetes.client.util.taints;
 
 import static io.kubernetes.client.util.taints.Taints.taints;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kubernetes.client.openapi.models.V1Node;
 import org.junit.Test;
@@ -28,8 +26,8 @@ public class TaintsTest {
         .addTaint("key1", Taints.Effect.NO_SCHEDULE)
         .addTaint("key2", Taints.Effect.PREFER_NO_SCHEDULE);
 
-    assertNotNull(Taints.findTaint(node, "key1", Taints.Effect.NO_SCHEDULE));
-    assertNotNull(Taints.findTaint(node, "key2", Taints.Effect.PREFER_NO_SCHEDULE));
+    assertThat(Taints.findTaint(node, "key1", Taints.Effect.NO_SCHEDULE)).isNotNull();
+    assertThat(Taints.findTaint(node, "key2", Taints.Effect.PREFER_NO_SCHEDULE)).isNotNull();
   }
 
   @Test
@@ -51,12 +49,12 @@ public class TaintsTest {
         // Remove matching
         .removeTaint("key3", Taints.Effect.NO_EXECUTE);
 
-    assertNull(Taints.findTaint(node, "key1", Taints.Effect.NO_SCHEDULE));
-    assertNull(Taints.findTaint(node, "key1", Taints.Effect.PREFER_NO_SCHEDULE));
-    assertNull(Taints.findTaint(node, "key1", Taints.Effect.NO_EXECUTE));
-    assertNull(Taints.findTaint(node, "key3", Taints.Effect.NO_EXECUTE));
-    assertNotNull(Taints.findTaint(node, "key2", Taints.Effect.PREFER_NO_SCHEDULE));
-    assertNotNull(Taints.findTaint(node, "key3", Taints.Effect.NO_SCHEDULE));
+    assertThat(Taints.findTaint(node, "key1", Taints.Effect.NO_SCHEDULE)).isNull();
+    assertThat(Taints.findTaint(node, "key1", Taints.Effect.PREFER_NO_SCHEDULE)).isNull();
+    assertThat(Taints.findTaint(node, "key1", Taints.Effect.NO_EXECUTE)).isNull();
+    assertThat(Taints.findTaint(node, "key3", Taints.Effect.NO_EXECUTE)).isNull();
+    assertThat(Taints.findTaint(node, "key2", Taints.Effect.PREFER_NO_SCHEDULE)).isNotNull();
+    assertThat(Taints.findTaint(node, "key3", Taints.Effect.NO_SCHEDULE)).isNotNull();
   }
 
   @Test
@@ -64,6 +62,7 @@ public class TaintsTest {
     V1Node node = new V1Node();
     String effect = "NoExecute";
     taints(node).addTaint("key1", "value1", Taints.Effect.NO_EXECUTE);
-    assertEquals(effect, Taints.findTaint(node, "key1", Taints.Effect.NO_EXECUTE).getEffect());
+    assertThat(Taints.findTaint(node, "key1", Taints.Effect.NO_EXECUTE).getEffect())
+        .isEqualTo(effect);
   }
 }


### PR DESCRIPTION
This migrates all test assertions to AssertJ. For example, we no longer use assertions from JUnit (4) or hamcrest. As a result, this removes the dependency on hamcrest.

Notes:
 * There are a couple places where it seems we fail tests on an exception not raised on the test thread. I retained JUnit's `fail` function for that, with a TODO for once we move to jupiter.
 * There were a couple places we used hamcrest matchers in awaitility, so I used a normal predicate instead

On OpenRewrite:

The openrewrite recipes for `MigrateHamcrestToAssertJ` and `JUnitToAssertj` didn't affect many files.. I'm not sure why. I did most of this manually via IntelliJ regex replacements. Later, I cleaned up by running `UnnecessaryThrows` `RemoveUnusedImports` (then reverting the changes to main) and finally `Assertj` to polish existing and new usage. cc @timtebeek

e.g. This applies current AssertJ best practices.
```bash
./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-testing-frameworks:RELEASE -Drewrite.activeRecipes=org.openrewrite.java.testing.assertj.Assertj
```