### PR TITLE
openrewrite: apply Slf4jBestPractices

### DIFF
--- a/examples/examples-release-17/src/main/java/io/kubernetes/client/examples/ExpandedExample.java
+++ b/examples/examples-release-17/src/main/java/io/kubernetes/client/examples/ExpandedExample.java
@@ -73,7 +73,7 @@ public class ExpandedExample {
                   System.out.println("----- " + namespace + " -----");
                   getNamespacedPod(namespace).stream().forEach(System.out::println);
                 } catch (ApiException ex) {
-                  LOGGER.warn("Couldn't get the pods in namespace:" + namespace, ex);
+                  LOGGER.warn("Couldn't get the pods in namespace:{}", namespace, ex);
                 }
               });
 
@@ -242,7 +242,7 @@ public class ExpandedExample {
             appsV1Api.replaceNamespacedDeployment(
                 deploymentName, DEFAULT_NAME_SPACE, newDeploy, null, null, null, null);
           } catch (ApiException ex) {
-            LOGGER.warn("Scale the pod failed for Deployment:" + deploymentName, ex);
+            LOGGER.warn("Scale the pod failed for Deployment:{}", deploymentName, ex);
           }
         });
   }

--- a/examples/examples-release-18/src/main/java/io/kubernetes/client/examples/ExpandedExample.java
+++ b/examples/examples-release-18/src/main/java/io/kubernetes/client/examples/ExpandedExample.java
@@ -73,7 +73,7 @@ public class ExpandedExample {
                   System.out.println("----- " + namespace + " -----");
                   getNamespacedPod(namespace).stream().forEach(System.out::println);
                 } catch (ApiException ex) {
-                  LOGGER.warn("Couldn't get the pods in namespace:" + namespace, ex);
+                  LOGGER.warn("Couldn't get the pods in namespace:{}", namespace, ex);
                 }
               });
 
@@ -242,7 +242,7 @@ public class ExpandedExample {
             appsV1Api.replaceNamespacedDeployment(
                 deploymentName, DEFAULT_NAME_SPACE, newDeploy, null, null, null, null);
           } catch (ApiException ex) {
-            LOGGER.warn("Scale the pod failed for Deployment:" + deploymentName, ex);
+            LOGGER.warn("Scale the pod failed for Deployment:{}", deploymentName, ex);
           }
         });
   }

--- a/examples/examples-release-19/src/main/java/io/kubernetes/client/examples/ExpandedExample.java
+++ b/examples/examples-release-19/src/main/java/io/kubernetes/client/examples/ExpandedExample.java
@@ -73,7 +73,7 @@ public class ExpandedExample {
                   System.out.println("----- " + namespace + " -----");
                   getNamespacedPod(namespace).stream().forEach(System.out::println);
                 } catch (ApiException ex) {
-                  LOGGER.warn("Couldn't get the pods in namespace:" + namespace, ex);
+                  LOGGER.warn("Couldn't get the pods in namespace:{}", namespace, ex);
                 }
               });
 
@@ -245,7 +245,7 @@ public class ExpandedExample {
             appsV1Api.replaceNamespacedDeployment(
                 deploymentName, DEFAULT_NAME_SPACE, newDeploy, null, null, null, null);
           } catch (ApiException ex) {
-            LOGGER.warn("Scale the pod failed for Deployment:" + deploymentName, ex);
+            LOGGER.warn("Scale the pod failed for Deployment:{}", deploymentName, ex);
           }
         });
   }

--- a/examples/examples-release-20/src/main/java/io/kubernetes/client/examples/ExpandedExample.java
+++ b/examples/examples-release-20/src/main/java/io/kubernetes/client/examples/ExpandedExample.java
@@ -73,7 +73,7 @@ public class ExpandedExample {
                   System.out.println("----- " + namespace + " -----");
                   getNamespacedPod(namespace).stream().forEach(System.out::println);
                 } catch (ApiException ex) {
-                  LOGGER.warn("Couldn't get the pods in namespace:" + namespace, ex);
+                  LOGGER.warn("Couldn't get the pods in namespace:{}", namespace, ex);
                 }
               });
 
@@ -218,7 +218,7 @@ public class ExpandedExample {
             appsV1Api.replaceNamespacedDeployment(
                 deploymentName, DEFAULT_NAME_SPACE, newDeploy).execute();
           } catch (ApiException ex) {
-            LOGGER.warn("Scale the pod failed for Deployment:" + deploymentName, ex);
+            LOGGER.warn("Scale the pod failed for Deployment:{}", deploymentName, ex);
           }
         });
   }

--- a/examples/examples-release-latest/src/main/java/io/kubernetes/client/examples/ExpandedExample.java
+++ b/examples/examples-release-latest/src/main/java/io/kubernetes/client/examples/ExpandedExample.java
@@ -73,7 +73,7 @@ public class ExpandedExample {
                   System.out.println("----- " + namespace + " -----");
                   getNamespacedPod(namespace).stream().forEach(System.out::println);
                 } catch (ApiException ex) {
-                  LOGGER.warn("Couldn't get the pods in namespace:" + namespace, ex);
+                  LOGGER.warn("Couldn't get the pods in namespace:{}", namespace, ex);
                 }
               });
 
@@ -218,7 +218,7 @@ public class ExpandedExample {
             appsV1Api.replaceNamespacedDeployment(
                 deploymentName, DEFAULT_NAME_SPACE, newDeploy).execute();
           } catch (ApiException ex) {
-            LOGGER.warn("Scale the pod failed for Deployment:" + deploymentName, ex);
+            LOGGER.warn("Scale the pod failed for Deployment:{}", deploymentName, ex);
           }
         });
   }

--- a/extended/src/main/java/io/kubernetes/client/extended/controller/ControllerManager.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/controller/ControllerManager.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * factory.
  */
 public class ControllerManager implements Controller {
-  private static final Logger log = LoggerFactory.getLogger(DefaultController.class);
+  private static final Logger log = LoggerFactory.getLogger(ControllerManager.class);
   private Controller[] controllers;
   private ExecutorService controllerThreadPool;
   private SharedInformerFactory informerFactory;

--- a/spring-aot/src/main/java/io/kubernetes/client/spring/aot/KubernetesBeanFactoryInitializationAotProcessor.java
+++ b/spring-aot/src/main/java/io/kubernetes/client/spring/aot/KubernetesBeanFactoryInitializationAotProcessor.java
@@ -64,7 +64,7 @@ public class KubernetesBeanFactoryInitializationAotProcessor
             "io.kubernetes.client.util.Watch$Response" //
           };
       for (String className : classNames) {
-        LOGGER.info("registering " + className + " for reflection");
+        LOGGER.info("registering {} for reflection", className);
         hints.reflection().registerType(TypeReference.of(className), allMemberCategories);
       }
       registerForPackage("io.kubernetes", hints);
@@ -85,7 +85,7 @@ public class KubernetesBeanFactoryInitializationAotProcessor
     all.addAll(controllers);
     all.addAll(apiModels);
     for (Class<?> clazz : all) {
-      LOGGER.info("registering " + clazz.getName() + " for reflection");
+      LOGGER.info("registering {} for reflection", clazz.getName());
       hints.reflection().registerType(clazz, allMemberCategories);
     }
   }

--- a/spring/src/main/java/io/kubernetes/client/spring/extended/controller/config/KubernetesInformerAutoConfiguration.java
+++ b/spring/src/main/java/io/kubernetes/client/spring/extended/controller/config/KubernetesInformerAutoConfiguration.java
@@ -41,10 +41,7 @@ public class KubernetesInformerAutoConfiguration {
       ApiClient apiClient = ClientBuilder.defaultClient();
       return apiClient;
     } catch (Exception e) {
-      LOGGER.warn(
-          "Could not create a Kubernetes ApiClient from either a cluster or standard environment. "
-              + "Will return one that always connects to localhost:8080",
-          e);
+      LOGGER.warn("Could not create a Kubernetes ApiClient from either a cluster or standard environment. " + "Will return one that always connects to localhost:8080", e);
       return new ClientBuilder().build();
     }
   }

--- a/util/src/main/java/io/kubernetes/client/Copy.java
+++ b/util/src/main/java/io/kubernetes/client/Copy.java
@@ -185,7 +185,7 @@ public class Copy extends Exec {
           entry != null;
           entry = archive.getNextEntry()) {
         if (!archive.canReadEntryData(entry)) {
-          log.error("Can't read: " + entry);
+          log.error("Can't read: {}", entry);
           continue;
         }
         String normalName = FilenameUtils.normalize(entry.getName());

--- a/util/src/main/java/io/kubernetes/client/informer/cache/ReflectorRunnable.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/ReflectorRunnable.java
@@ -282,7 +282,7 @@ public class ReflectorRunnable<
 
   static <ApiType extends KubernetesObject> void defaultWatchErrorHandler(
       Class<ApiType> watchingApiTypeClass, Throwable t) {
-    log.error(String.format("%s#Reflector loop failed unexpectedly", watchingApiTypeClass), t);
+    log.error("{}#Reflector loop failed unexpectedly", watchingApiTypeClass, t);
   }
 
   private boolean isConnectException(Throwable t) {

--- a/util/src/main/java/io/kubernetes/client/util/ClientBuilder.java
+++ b/util/src/main/java/io/kubernetes/client/util/ClientBuilder.java
@@ -159,9 +159,7 @@ public class ClientBuilder {
       final String[] filePaths = kubeConfigEnv.split(File.pathSeparator);
       final String kubeConfigPath = filePaths[0];
       if (filePaths.length > 1) {
-        log.warn(
-            "Found multiple kubeconfigs files, $KUBECONFIG: " + kubeConfigEnv + " using first: {}",
-            kubeConfigPath);
+        log.warn("Found multiple kubeconfigs files, $KUBECONFIG: {} using first: {}", kubeConfigEnv, kubeConfigPath);
       }
 
       return kubeConfigPath;

--- a/util/src/main/java/io/kubernetes/client/util/KubeConfig.java
+++ b/util/src/main/java/io/kubernetes/client/util/KubeConfig.java
@@ -231,7 +231,7 @@ public class KubeConfig {
           credentials.put(CRED_TOKEN_KEY, auth.getToken(authConfig));
           return credentials;
         } else {
-          log.error("Unknown auth provider: " + name);
+          log.error("Unknown auth provider: {}", name);
         }
       }
     }
@@ -358,7 +358,7 @@ public class KubeConfig {
           Reader r = new InputStreamReader(is, StandardCharsets.UTF_8)) {
         root = JsonParser.parseReader(r);
       } catch (JsonParseException x) {
-        log.error("Failed to parse output of " + command, x);
+        log.error("Failed to parse output of {}", command, x);
         return null;
       }
       int r = proc.waitFor();
@@ -368,7 +368,7 @@ public class KubeConfig {
       }
       return root;
     } catch (IOException | InterruptedException x) {
-      log.error("Failed to run " + command, x);
+      log.error("Failed to run {}", command, x);
       return null;
     }
   }

--- a/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
+++ b/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
@@ -422,9 +422,7 @@ public class ModelMapper {
       preBuiltClassesByGVK.put(new GroupVersionKind(group, version, kind), clazz);
     }
     if (preBuiltClassesByGVK.size() == 0) {
-      logger.warn(
-          "No kubernetes api model classes found from classloader, "
-              + "this may break automatic api discovery");
+      logger.warn("No kubernetes api model classes found from classloader, " + "this may break automatic api discovery");
     }
   }
 

--- a/util/src/main/java/io/kubernetes/client/util/Yaml.java
+++ b/util/src/main/java/io/kubernetes/client/util/Yaml.java
@@ -178,7 +178,7 @@ public class Yaml {
         try {
           list.add(modelMapper((Map<String, Object>) object));
         } catch (ClassCastException ex) {
-          logger.error("Unexpected exception while casting: " + ex);
+          logger.error("Unexpected exception while casting: {}", ex);
         }
       }
     }

--- a/util/src/main/java/io/kubernetes/client/util/eks/HttpUtils.java
+++ b/util/src/main/java/io/kubernetes/client/util/eks/HttpUtils.java
@@ -92,7 +92,7 @@ public class HttpUtils {
             if ( headers != null ) {
                 log.debug("--------- Request headers ---------");
                 for ( String headerKey : headers.keySet() ) {
-                    log.debug(headerKey + ": " + headers.get(headerKey));
+                    log.debug("{}: {}", headerKey, headers.get(headerKey));
                     connection.setRequestProperty(headerKey, headers.get(headerKey));
                 }
             }


### PR DESCRIPTION
This fixes some practice not all of which easy to notice manually, notably use SLF4J parameters instead of string concatenation.

```bash
./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-logging-frameworks:RELEASE -Drewrite.activeRecipes=org.openrewrite.java.logging.slf4j.Slf4jBestPractices
```