### PR TITLE
Update google-java-format to LTS 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -521,7 +521,7 @@
             </format>
           </formats>
           <java>
-            <removeUnusedImports /> <!-- self-explanatory -->
+            <removeUnusedImports />
             <googleJavaFormat>
               <!-- Use the floor LTS Java version used in CI -->
               <version>1.17.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -523,7 +523,8 @@
           <java>
             <removeUnusedImports /> <!-- self-explanatory -->
             <googleJavaFormat>
-              <version>1.15.0</version>
+              <!-- Use the floor LTS Java version used in CI -->
+              <version>1.17.0</version>
             </googleJavaFormat>
           </java>
           <groovy>


### PR DESCRIPTION
This is a part of me trying to get us to the point we can build with JDK 21

Before, we have this error and now we don't
```bash
$ ./mvnw spotless:apply
--snip--
[ERROR] Failed to execute goal com.diffplug.spotless:spotless-maven-plugin:2.43.0:apply (default-cli) on project client-java-parent: Execution default-cli of goal com.diffplug.spotless:spotless-maven-plugin:2.43.0:apply failed: You are running Spotless on JVM 21. This requires google-java-format of at least 1.17.0 (you are using 1.15.0).
```