### PR TITLE
Resolve indirect dep CVE from adal4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,13 @@
         <version>1.6.7</version>
         <optional>true</optional>
       </dependency>
+      <!-- override the version in adal4j which has a CVE -->
+      <dependency>
+        <groupId>net.minidev</groupId>
+        <artifactId>json-smart</artifactId>
+        <version>2.5.0</version>
+        <optional>true</optional>
+      </dependency>
       <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-sts</artifactId>


### PR DESCRIPTION
adal4j is an optional dependency. This means that for a project to use it, they must declare their own dependency. As such, it doesn't always show up in CVE reports as we do not require this dependency.

However, some will detect it and I also notice IntelliJ will. After updating its indirect dep, IntelliJ's detector is no longer aware of any CVE related to this. 

Hopefully, this buys time, and removes any short term action about adal4j except deleting the code that uses it.

See #3169