### PR TITLE
Fix CVEs brought in by accidental spring boot version override

### DIFF
--- a/spring-aot/pom.xml
+++ b/spring-aot/pom.xml
@@ -13,7 +13,6 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <properties>
-        <spring.boot.version>3.0.0</spring.boot.version>
         <!-- Spring Boot 3.x is minimum JRE 17 -->
         <java.version>17</java.version>
     </properties>


### PR DESCRIPTION
We accidentally masked the parent definition of spring-boot version and in doing so pin older dependencies than we meant to. This was detected by `trivy repo .`.