### PR TITLE
Update devcontainer to use Java 17 (required for Spring >= 6)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# Update the VARIANT arg in devcontainer.json to pick a Java version >= 11
-ARG VARIANT=11
+# Update the VARIANT arg in devcontainer.json to pick a Java version >= 17
+ARG VARIANT=17
 FROM openjdk:${VARIANT}-jdk-buster
 
 # Options for setup script

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,8 +3,8 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			// Update the VARIANT arg to pick a Java version >= 11
-			"VARIANT": "11",
+			// Update the VARIANT arg to pick a Java version >= 17
+			"VARIANT": "17",
 			// Options to install Maven or Gradle
 			"INSTALL_MAVEN": "true",
 			"MAVEN_VERSION": "3.6.3",


### PR DESCRIPTION
Commit 544f434a94a1412b9f2f2df29cfac3e6c8208a93 upgraded Spring to version 6.0.11.

According to https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions , Spring >= 6 requires Java 17.

The devcontainer is still using Java 11, which causes errors when compiling the project in a devcontainer.

This PR sets the Java version in the devcontainer to 17, after which the project compiles without errors.