### PR TITLE
build(deps): bump org.apache.commons:commons-compress

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <gsonfire.version>1.9.0</gsonfire.version>
     <apache.commons.lang3.version>3.14.0</apache.commons.lang3.version>
     <apache.commons.collections4.version>4.4</apache.commons.collections4.version>
-    <apache.commons.compress>1.25.0</apache.commons.compress>
+    <apache.commons.compress>1.26.0</apache.commons.compress>
     <apache.commons.io>2.15.1</apache.commons.io>
     <common.codec.version>1.16.1</common.codec.version>
     <spring.boot.version>3.2.2</spring.boot.version>


### PR DESCRIPTION
Bumps org.apache.commons:commons-compress from 1.25.0 to 1.26.0.

---
updated-dependencies:
- dependency-name: org.apache.commons:commons-compress dependency-type: direct:production update-type: version-update:semver-minor ...