### PR TITLE
Update maven.yml for legacy branch

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,8 +27,8 @@ jobs:
     strategy:
       matrix:
         # Test against the LTS Java versions. TODO: add JDK18 when it becomes available.
-        java: [ 8.0.x, 11.0.x, 17.0.x ]
-        os: [ macos-latest, windows-latest, ubuntu-latest ]
+        java: [ 8.0.x ]
+        os: [ windows-latest, ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
MacOS + GitHub Actions no longer supports Java8