### PR TITLE
fix: AuthenticationRefresher wrapper solution

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/ClientBuilder.java
+++ b/util/src/main/java/io/kubernetes/client/util/ClientBuilder.java
@@ -467,12 +467,14 @@ public class ClientBuilder {
 
       // When authenticationRefreshSeconds is set, wrap the Authentication
       // object in an AuthenticationRefresher. It is important that we do this
-      // after the passphrase code above is done munging around with the
-      // internals of KubeConfigAuthentication
+      // after the passphrase code
       if (authenticationRefreshSeconds != null) {
         if (authentication instanceof AuthenticationRefresher) {
-          throw new IllegalStateException(
-              "AuthenticationRefresher already exists in the chain");
+          // If we're already wrapped in a AuthenticationRefresher, stop it
+          AuthenticationRefresher refresher = (AuthenticationRefresher) authentication;
+          refresher.stop();
+          // Unwrap the delegate authentication, so we can rewrap it
+          authentication = refresher.getDelegateAuthentication();
         }
         authentication = new AuthenticationRefresher(authentication, authenticationRefreshSeconds.toSeconds());
       }

--- a/util/src/main/java/io/kubernetes/client/util/ClientBuilder.java
+++ b/util/src/main/java/io/kubernetes/client/util/ClientBuilder.java
@@ -470,6 +470,10 @@ public class ClientBuilder {
       // after the passphrase code above is done munging around with the
       // internals of KubeConfigAuthentication
       if (authenticationRefreshSeconds != null) {
+        if (authentication instanceof AuthenticationRefresher) {
+          throw new IllegalStateException(
+              "AuthenticationRefresher already exists in the chain");
+        }
         authentication = new AuthenticationRefresher(authentication, authenticationRefreshSeconds.toSeconds());
       }
 

--- a/util/src/main/java/io/kubernetes/client/util/credentials/AuthenticationRefresher.java
+++ b/util/src/main/java/io/kubernetes/client/util/credentials/AuthenticationRefresher.java
@@ -1,0 +1,66 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.util.credentials;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.kubernetes.client.openapi.ApiClient;
+
+/**
+ * Wraps an existing {@link Authentication} and refreshes it every
+ * expirationSeconds.
+ *
+ * Can be used with ClientBuilder as such:
+ *
+ * <pre>
+ * ClientBuilder.standard()
+ *         .withAuthentication(new AuthenticationRefresher(new KubeconfigAuthentication(), 60))
+ *         .build();
+ * </pre>
+ */
+public class AuthenticationRefresher implements Authentication {
+
+    private static final Logger log = LoggerFactory.getLogger(AuthenticationRefresher.class);
+
+    private final Authentication delegateAuthentication;
+    private final Long expirationSeconds;
+
+    public AuthenticationRefresher(Authentication delegateAuthentication, long expirationSeconds) {
+        this.delegateAuthentication = delegateAuthentication;
+        this.expirationSeconds = expirationSeconds;
+        log.debug("AuthenticationRefresher initialized with expirationSeconds: " + expirationSeconds);
+    }
+
+    /**
+     * Calls delegateAuthentication every expirationSeconds
+     */
+    @Override
+    public void provide(ApiClient client) {
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+        executor.scheduleAtFixedRate(new Runnable() {
+            @Override
+            public void run() {
+                log.debug("Refreshing authentication");
+                delegateAuthentication.provide(client);
+            }
+        }, expirationSeconds, expirationSeconds, java.util.concurrent.TimeUnit.SECONDS);
+
+        // Run it now, synchronously.
+        log.debug("Invoking authentication");
+        delegateAuthentication.provide(client);
+    }
+}

--- a/util/src/test/java/io/kubernetes/client/util/ClientBuilderTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/ClientBuilderTest.java
@@ -17,20 +17,24 @@ import static io.kubernetes.client.util.Config.ENV_SERVICE_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.kubernetes.client.Resources;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.util.credentials.Authentication;
 import io.kubernetes.client.util.credentials.ClientCertificateAuthentication;
 import io.kubernetes.client.util.credentials.KubeconfigAuthentication;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
@@ -216,6 +220,19 @@ class ClientBuilderTest {
     final Authentication provider = mock(Authentication.class);
     final ApiClient client = ClientBuilder.standard().setAuthentication(provider).build();
     verify(provider).provide(client);
+  }
+
+  @Test
+  void credentialProviderWrappedWithRefresher() throws IOException, InterruptedException {
+    final Authentication provider = mock(Authentication.class);
+    final ApiClient client = ClientBuilder.standard()
+        .setAuthentication(provider)
+        .setAuthenticationRefreshSeconds(Duration.ofSeconds(2))
+        .build();
+
+    Thread.sleep(3000);
+
+    verify(provider, times(2)).provide(client);
   }
 
   /**

--- a/util/src/test/java/io/kubernetes/client/util/credentials/AuthenticationRefresherTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/credentials/AuthenticationRefresherTest.java
@@ -1,0 +1,52 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.util.credentials;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.util.ClientBuilder;
+
+public class AuthenticationRefresherTest {
+
+    @Test
+    void credentialProviderWrapperInvoked() throws IOException {
+        final Authentication provider = mock(Authentication.class);
+        final Authentication wrapper = new AuthenticationRefresher(provider, 15);
+
+        final ApiClient client = ClientBuilder.standard().setAuthentication(wrapper).build();
+
+        verify(provider).provide(client);
+    }
+
+    @Test
+    void credentialProviderTimerInvoked() throws Exception {
+        final Authentication provider = mock(Authentication.class);
+        final Authentication wrapper = new AuthenticationRefresher(provider, 2);
+
+        final ApiClient client = ClientBuilder.standard().setAuthentication(wrapper).build();
+
+        Thread.sleep(3000);
+
+        // verify provider mock called 2 times
+        verify(provider, times(2)).provide(client);
+
+    }
+
+}

--- a/util/src/test/java/io/kubernetes/client/util/credentials/AuthenticationRefresherTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/credentials/AuthenticationRefresherTest.java
@@ -80,8 +80,7 @@ public class AuthenticationRefresherTest {
         ClientBuilder.standard().setAuthentication(wrapper).build();
         wrapper.stop();
 
-        assertFalse(wrapper.isRunning(), "After our unused ApiClient returned from .build() is garbage collected, the refresher should stop.");
+        assertFalse(wrapper.isRunning(), "Wrapper should be stopped.");
         verify(mockProvider, times(1)).provide(any(ApiClient.class));
     }
-
 }


### PR DESCRIPTION
This fixes/relates to #2438 and #290

This commit introduces the AuthenticationRefresher as an implementation of Authentication. It's purpose is to warp another Authentication instance and refresh it very n seconds by calling `provide` on the wrapped Authentication object.

This code is intedned to be used a solution to issue #2438.

Any Authentication object that provides credentials, that must be refreshed, to the ApiClient do not have a way to do so.

There are two ways to use the AuthenticationRefresher with ClientBuilder. The first option is to use the
ClientBuilder.setAuthentication(...) method. An Authentication instance can be wrapped in an AuthenticationRefresher and passed into the setAuthentication method. For example,

```
ClientBuilder.standard().setAuthentication(
  //wrap an auth and refresh it every 15 minutes (900s)
  new Authentication(someDelegateAuthenticationInstance, 900)
);
```

This is integrated up into the ClientBuilder.build() method by adding a new authenticationRefreshSeconds field and getter/setter pair. If a refresh interval is set, the Authentication object used by ClientBuilder will be wrapped with an AuthenticationRefresher.