### PR TITLE
Fixed memory leak in cache indices when item is deleted

### DIFF
--- a/util/src/main/java/io/kubernetes/client/informer/cache/Cache.java
+++ b/util/src/main/java/io/kubernetes/client/informer/cache/Cache.java
@@ -365,6 +365,9 @@ public class Cache<ApiType extends KubernetesObject> implements Indexer<ApiType>
         Set<String> indexSet = index.get(indexValue);
         if (indexSet != null) {
           indexSet.remove(key);
+          if (indexSet.isEmpty()) {
+            index.remove(indexValue);
+          }
         }
       }
     }


### PR DESCRIPTION
**Fix to the issue**:  #3510 

Memory leak in Cache indices when item is deleted #3510 
