### PR TITLE
Update pom.xml - com.bucket4j migration

### DIFF
--- a/extended/pom.xml
+++ b/extended/pom.xml
@@ -39,7 +39,7 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.vladimir-bukhtoyarov</groupId>
+            <groupId>com.bucket4j</groupId>
             <artifactId>bucket4j-core</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
         <version>0.9.6</version>
       </dependency>
       <dependency>
-        <groupId>com.github.vladimir-bukhtoyarov</groupId>
+        <groupId>com.bucket4j</groupId>
         <artifactId>bucket4j-core</artifactId>
         <version>${bucket4j.version}</version>
       </dependency>


### PR DESCRIPTION
The groupId `com.github.vladimir-bukhtoyarov` has migrated to `com.bucket4j` see https://mvnrepository.com/artifact/com.github.vladimir-bukhtoyarov/bucket4j-core/8.0.1

Note:
I have not upgraded the version (there are newer versions). This is to allow this to be a like-for-like replacement.

Once this migration is made, dependabot will be able to see the newer versions and propose future upgrades.