### PR TITLE
Move `optional` tags to module POMs

### DIFF
--- a/extended/pom.xml
+++ b/extended/pom.xml
@@ -35,6 +35,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <optional>${prometheus.client.optional}</optional>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,15 @@
     <prometheus.client.version>0.16.0</prometheus.client.version>
     <reflections.version>0.10.2</reflections.version>
 
+    <!-- The `optional` tag in `dependencyManagement` is not inherited; see
+    https://issues.apache.org/jira/browse/MNG-5227 and
+    https://issues.apache.org/jira/browse/MNG-5632. Therefore, we specify
+    optional dependencies here to manage them in a single location. -->
+    <prometheus.client.optional>true</prometheus.client.optional>
+    <com.amazonaws.aws-java-sdk-sts.optional>true</com.amazonaws.aws-java-sdk-sts.optional>
+    <com.google.auth.google-auth-library-oauth2-http.optional>true</com.google.auth.google-auth-library-oauth2-http.optional>
+    <org.springframework.boot.spring-boot-actuator.optional>true</org.springframework.boot.spring-boot-actuator.optional>
+
     <e2e.skip>true</e2e.skip>
 
     <gpg.keyname>48540ECBBF00A28EACCF04E720FD12AFB0C9EBA9</gpg.keyname>
@@ -144,7 +153,6 @@
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-sts</artifactId>
         <version>1.12.760</version>
-        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>
@@ -180,19 +188,16 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-actuator</artifactId>
         <version>${spring.boot.version}</version>
-        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>io.prometheus</groupId>
         <artifactId>simpleclient</artifactId>
         <version>${prometheus.client.version}</version>
-        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>io.prometheus</groupId>
         <artifactId>simpleclient_httpserver</artifactId>
         <version>${prometheus.client.version}</version>
-        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>
@@ -248,13 +253,6 @@
         <groupId>com.google.auth</groupId>
         <artifactId>google-auth-library-oauth2-http</artifactId>
         <version>1.24.0</version>
-        <optional>true</optional>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>2.17.2</version>
-        <optional>true</optional>
       </dependency>
 
       <!-- tests -->

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -29,7 +29,11 @@
       <artifactId>client-java-extended</artifactId>
       <version>${project.version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient</artifactId>
+      <optional>${prometheus.client.optional}</optional>
+    </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
@@ -41,6 +45,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-actuator</artifactId>
+      <optional>${org.springframework.boot.spring-boot-actuator.optional}</optional>
     </dependency>
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -14,10 +14,12 @@
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
+            <optional>${prometheus.client.optional}</optional>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient_httpserver</artifactId>
+            <optional>${prometheus.client.optional}</optional>
         </dependency>
         <dependency>
             <groupId>io.kubernetes</groupId>
@@ -60,6 +62,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sts</artifactId>
+            <optional>${com.amazonaws.aws-java-sdk-sts.optional}</optional>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -81,7 +84,7 @@
         <dependency>
             <groupId>com.google.auth</groupId>
             <artifactId>google-auth-library-oauth2-http</artifactId>
-            <optional>true</optional>
+            <optional>${com.google.auth.google-auth-library-oauth2-http.optional}</optional>
         </dependency>
         <!-- test dependencies -->
         <dependency>


### PR DESCRIPTION
This PR moves `optional` tags to module POMs since they are not inherited in `dependencyManagement`. See https://github.com/kubernetes-client/java/issues/3533 for more details.

Resolves https://github.com/kubernetes-client/java/issues/3533.