### PR TITLE
Migrate deprecated Bucket4J class usage to Bucket class to unblock upgrade

### DIFF
--- a/extended/src/main/java/io/kubernetes/client/extended/event/legacy/EventSpamFilter.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/event/legacy/EventSpamFilter.java
@@ -15,7 +15,7 @@ package io.kubernetes.client.extended.event.legacy;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.github.bucket4j.Bandwidth;
-import io.github.bucket4j.Bucket4j;
+import io.github.bucket4j.Bucket;
 import io.github.bucket4j.Refill;
 import io.github.bucket4j.local.LocalBucket;
 import io.github.bucket4j.local.SynchronizationStrategy;
@@ -65,7 +65,7 @@ public class EventSpamFilter {
 
   private class SpamRecord {
     private LocalBucket tokenBucket =
-        Bucket4j.builder()
+        Bucket.builder()
             .addLimit(
                 Bandwidth.classic(
                     capacity, Refill.greedy(refillingTokensPerPeriod, refillingPeriod)))

--- a/extended/src/main/java/io/kubernetes/client/extended/workqueue/ratelimiter/BucketRateLimiter.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/workqueue/ratelimiter/BucketRateLimiter.java
@@ -14,7 +14,6 @@ package io.kubernetes.client.extended.workqueue.ratelimiter;
 
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
-import io.github.bucket4j.Bucket4j;
 import io.github.bucket4j.Refill;
 import io.github.bucket4j.local.SynchronizationStrategy;
 import java.time.Duration;
@@ -32,7 +31,7 @@ public class BucketRateLimiter<T> implements RateLimiter<T> {
     Bandwidth bandwidth =
         Bandwidth.classic(capacity, Refill.greedy(tokensGeneratedInPeriod, period));
     this.bucket =
-        Bucket4j.builder()
+        Bucket.builder()
             .addLimit(bandwidth)
             .withSynchronizationStrategy(SynchronizationStrategy.SYNCHRONIZED)
             .build();

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <caffeine.version>2.9.3</caffeine.version>
     <protobuf.version>4.27.2</protobuf.version>
     <junit-jupiter.version>5.10.3</junit-jupiter.version>
-    <bucket4j.version>8.0.1</bucket4j.version>
+    <bucket4j.version>8.10.1</bucket4j.version>
     <bouncycastle.version>1.78.1</bouncycastle.version>
     <gson.version>2.11.0</gson.version>
     <jackson.version>2.17.2</jackson.version>


### PR DESCRIPTION
Migrate `@deprecated` `Bucket4J` class usage to `Bucket` class to unblock dependabot upgrade of bucket4j from `8.0.1` to `8.10.1`. 

I include the upgrade of the Bucket4J library as proposed by dependabot to demonstrate that it all works together.
Tested locally.