### PR TITLE
Add params to publish-gen-image.sh

### DIFF
--- a/client-java-contrib/publish-gen-image.sh
+++ b/client-java-contrib/publish-gen-image.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
-GEN_IMAGE_NAME=docker.pkg.github.com/kubernetes-client/java/crd-model-gen
-GEN_IMAGE_VERSION=v2.0.0
+# User-overridable variables
+IMAGE_REPOSITORY=${IMAGE_REPOSITORY:-docker.pkg.github.com}
+IMAGE_NAME=${IMAGE_NAME:-kubernetes-client/java/crd-model-gen}
+IMAGE_VERSION=${IMAGE_VERSION:-v1.0.0}
 
-docker build -t ${GEN_IMAGE_NAME}:${GEN_IMAGE_VERSION} .
-docker push ${GEN_IMAGE_NAME}:${GEN_IMAGE_VERSION}
+IMAGE=${IMAGE_REPOSITORY}/${IMAGE_NAME}:${IMAGE_VERSION}
+BUILD_DIR="$(dirname $0)"
+docker build -t ${IMAGE} ${BUILD_DIR}
+docker push ${IMAGE}

--- a/scripts/publish-crd-model-gen-image.sh
+++ b/scripts/publish-crd-model-gen-image.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 
-IMAGE_REPOSITORY=docker.pkg.github.com
-IMAGE_NAME=kubernetes-client/java/crd-model-gen
-IMAGE_VERSION=v1.0.0
-IMAGE=${IMAGE_REPOSITORY}/${IMAGE_NAME}:${IMAGE_VERSION}
+export IMAGE_REPOSITORY=docker.pkg.github.com
+export IMAGE_NAME=kubernetes-client/java/crd-model-gen
+export IMAGE_VERSION=v1.0.0
 
-docker build -t ${IMAGE} client-java-contrib/
-
-docker push ${IMAGE}
+bash "$(dirname $0)/../client-java-contrib/publish-gen-image.sh"


### PR DESCRIPTION
This change makes it convenient to publish a copy of crd-model-gen to a private container registry.

Refactor client-java-contrib/publish-gen-image.sh to accept parameters via environment variables. At the same time, refactor scripts/publish-crd-model-gen-image.sh to remove duplicated logic. This also serves as an example of how to invoke publish-gen-image.sh.

In case there are existing workflows that depend on these two scripts, I have not renamed either of them, and they have the same behavior when no environment variables are provided.