### PR TITLE
Bump protobuf to remediate CVE-2024-7254

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <snakeyaml.version>2.2</snakeyaml.version>
     <slf4j.version>2.0.13</slf4j.version>
     <caffeine.version>2.9.3</caffeine.version>
-    <protobuf.version>4.27.1</protobuf.version>
+    <protobuf.version>4.27.5</protobuf.version>
     <junit-jupiter.version>5.10.2</junit-jupiter.version>
     <bucket4j.version>8.10.1</bucket4j.version>
     <bouncycastle.version>1.78.1</bouncycastle.version>


### PR DESCRIPTION
Bump protobuf to [4.27.5](https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java/4.27.5) to remediate CVE-2024-7254