### PR TITLE
Shutdown original queue before override

### DIFF
--- a/extended/src/main/java/io/kubernetes/client/extended/controller/builder/DefaultControllerBuilder.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/controller/builder/DefaultControllerBuilder.java
@@ -104,6 +104,9 @@ public class DefaultControllerBuilder {
    * @return the controller builder
    */
   public DefaultControllerBuilder withWorkQueue(RateLimitingQueue<Request> workQueue) {
+    if (this.workQueue != null && !this.workQueue.isShuttingDown()){
+      this.workQueue.shutDown();
+    }
     this.workQueue = workQueue;
     return this;
   }


### PR DESCRIPTION
When overriding the workQueue for the controller, the original queue must be shut down to avoid thread leakage. If the original queue is not shut down here, it will remain active even after the controller is shut down. This is because the controller's queue has been replaced by the newly created queue.

Related Issue: https://github.com/kubernetes-client/java/issues/3738