### PR TITLE
Modify ModelMapper to return DynamicKubernetesObject

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
+++ b/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
@@ -19,6 +19,7 @@ import io.kubernetes.client.common.KubernetesListObject;
 import io.kubernetes.client.common.KubernetesObject;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.util.exception.IncompleteDiscoveryException;
+import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
 import java.io.File;
 
 import java.io.IOException;
@@ -215,8 +216,15 @@ public class ModelMapper {
     if (clazz != null) {
       return clazz;
     }
-    return preBuiltGetApiTypeClass(group, version, kind);
+
+    clazz = preBuiltGetApiTypeClass(group, version, kind);
+
+    if (clazz != null) {
+      return clazz;
+    }
+    return DynamicKubernetesObject.class;
   }
+
 
   /**
    * Gets the GVK by the given model class.

--- a/util/src/test/java/io/kubernetes/client/util/ModelMapperTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/ModelMapperTest.java
@@ -18,6 +18,8 @@ import io.kubernetes.client.apimachinery.GroupVersionKind;
 import io.kubernetes.client.openapi.models.V1CustomResourceDefinition;
 import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject;
+
 import org.junit.jupiter.api.Test;
 
 class ModelMapperTest {
@@ -35,41 +37,52 @@ class ModelMapperTest {
 
   @Test
   void addingModel() {
-    Class objClass =
-            new Object() {
-              {
-              }
-            }.getClass();
+    Class<?> objClass = new Object() {}.getClass();
+
+    assertThat(ModelMapper.getApiTypeClass("example.io/V1", "Toss"))
+            .isEqualTo(DynamicKubernetesObject.class);
 
     ModelMapper.addModelMap("example.io", "v1", "Toss", objClass);
 
     assertThat(ModelMapper.getApiTypeClass("example.io/v1", "Toss"))
-        .isEqualTo(objClass);
+            .isEqualTo(objClass);
     assertThat(ModelMapper.getApiTypeClass("example.io", "v1", "Toss"))
-        .isEqualTo(objClass);
+            .isEqualTo(objClass);
 
-    assertThat(ModelMapper.getApiTypeClass("example.io/V1", "Toss")).isNull();
-    assertThat(ModelMapper.getApiTypeClass("example.io", "V1", "Toss")).isNull();
+    assertThat(ModelMapper.getApiTypeClass("example.io/V1", "Toss"))
+            .isEqualTo(DynamicKubernetesObject.class);
+    assertThat(ModelMapper.getApiTypeClass("example.io", "V1", "Toss"))
+            .isEqualTo(DynamicKubernetesObject.class);
 
-    assertThat(ModelMapper.getApiTypeClass("example.io/v1", "Tofu")).isNull();
-    assertThat(ModelMapper.getApiTypeClass("example.io", "v1", "Tofu")).isNull();
+    assertThat(ModelMapper.getApiTypeClass("example.io/v1", "Tofu"))
+            .isEqualTo(DynamicKubernetesObject.class);
+    assertThat(ModelMapper.getApiTypeClass("example.io", "v1", "Tofu"))
+            .isEqualTo(DynamicKubernetesObject.class);
 
-    assertThat(ModelMapper.getApiTypeClass("v1", "Togu")).isNull();
-    ModelMapper.addModelMap("v1", "Togu", objClass);
-    assertThat(ModelMapper.getApiTypeClass("", "v1", "Togu"))
-        .isEqualTo(objClass);
     assertThat(ModelMapper.getApiTypeClass("v1", "Togu"))
-        .isEqualTo(objClass);
+            .isEqualTo(DynamicKubernetesObject.class);
+
+    ModelMapper.addModelMap("", "v1", "Togu", objClass);
+
+    assertThat(ModelMapper.getApiTypeClass("", "v1", "Togu"))
+            .isEqualTo(objClass);
+    assertThat(ModelMapper.getApiTypeClass("v1", "Togu"))
+            .isEqualTo(objClass);
   }
 
+  @Test
+  void getApiTypeClassReturnsDynamicKubernetesObjectWhenClassNotFound() {
+    assertThat(ModelMapper.getApiTypeClass("unknown.group", "v1", "UnknownKind"))
+            .isEqualTo(DynamicKubernetesObject.class);
+  }
 
   @Test
   void preBuiltGetGroupVersionKindByClass() {
-    assertThat(ModelMapper.preBuiltGetGroupVersionKindByClass(V1Pod.class))
-        .hasValue(new GroupVersionKind("", "v1", "Pod"));
     assertThat(ModelMapper.preBuiltGetGroupVersionKindByClass(V1Deployment.class))
-        .hasValue(new GroupVersionKind("", "v1", "Deployment"));
+            .hasValue(new GroupVersionKind("", "v1", "Deployment"));
+    assertThat(ModelMapper.preBuiltGetGroupVersionKindByClass(V1Pod.class))
+            .hasValue(new GroupVersionKind("", "v1", "Pod"));
     assertThat(ModelMapper.preBuiltGetGroupVersionKindByClass(V1CustomResourceDefinition.class))
-        .hasValue(new GroupVersionKind("", "v1", "CustomResourceDefinition"));
+            .hasValue(new GroupVersionKind("", "v1", "CustomResourceDefinition"));
   }
 }


### PR DESCRIPTION
I solved the issue [https://github.com/kubernetes-client/java/issues/3336](https://github.com/kubernetes-client/java/issues/3336) by modifying the `getApiTypeClass` method in `ModelMapper.java` to return `DynamicKubernetesObject.class` when a specific class for a given `GroupVersionKind` is not found. This change enables the Kubernetes Java client to handle YAML resources of any type without differentiating between specific `kind` values. 

By defaulting to a dynamic Kubernetes object, the client can now load unstructured YAML, extract the necessary `apiVersion` and `kind`, map it to a generic handler, and interact with the Kubernetes API accordingly. This approach allows for the submission and management of any YAML resource, enhancing the client's flexibility and resolving the issue of handling resources without prior knowledge of their types. 

@brendandburns  @yue9944882 

/lgtm

