### PR TITLE
Refactor: Merge TokenFile auth with refresh auth

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/credentials/TokenFileAuthentication.java
+++ b/util/src/main/java/io/kubernetes/client/util/credentials/TokenFileAuthentication.java
@@ -12,63 +12,32 @@ limitations under the License.
 */
 package io.kubernetes.client.util.credentials;
 
-import io.kubernetes.client.openapi.ApiClient;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.time.Instant;
-import okhttp3.Interceptor;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
+import java.time.Duration;
 
 // TODO: prefer OpenAPI backed Auentication once it is available. see details in
 // https://github.com/OpenAPITools/openapi-generator/pull/6036. currently, the
 // workaround is to hijack the http request.
-public class TokenFileAuthentication implements Authentication, Interceptor {
-  private String file;
-  private String token;
-  private Instant expiry;
-
+public class TokenFileAuthentication extends RefreshAuthentication {
   public TokenFileAuthentication(String file) {
-    this.expiry = Instant.MIN;
-    this.file = file;
+    this(file, Duration.ofMinutes(1));
   }
 
-  private String getToken() {
-    if (Instant.now().isAfter(this.expiry)) {
-      try {
-        this.token =
-            new String(Files.readAllBytes(Paths.get(this.file)), Charset.defaultCharset()).trim();
-        expiry = Instant.now().plusSeconds(60);
-      } catch (IOException ie) {
-        throw new RuntimeException("Cannot read file: " + this.file);
-      }
+  public TokenFileAuthentication(String file, Duration refreshPeriod) {
+    super(() -> {
+      return getToken(file);
+    }, refreshPeriod);
+  }
+
+  private static String getToken(String file) {
+    try {
+      return new String(Files.readAllBytes(Paths.get(file)), Charset.defaultCharset()).trim();
+    } catch (IOException e) {
+      throw new RuntimeException("Cannot read file: " + file);
     }
-
-    return this.token;
   }
 
-  public void setExpiry(Instant expiry) {
-    this.expiry = expiry;
-  }
-
-  public void setFile(String file) {
-    this.file = file;
-  }
-
-  @Override
-  public void provide(ApiClient client) {
-    OkHttpClient withInterceptor = client.getHttpClient().newBuilder().addInterceptor(this).build();
-    client.setHttpClient(withInterceptor);
-  }
-
-  @Override
-  public Response intercept(Interceptor.Chain chain) throws IOException {
-    Request request = chain.request();
-    Request newRequest;
-    newRequest = request.newBuilder().header("Authorization", "Bearer " + getToken()).build();
-    return chain.proceed(newRequest);
-  }
 }

--- a/util/src/main/java/io/kubernetes/client/util/exception/TokenAquisitionException.java
+++ b/util/src/main/java/io/kubernetes/client/util/exception/TokenAquisitionException.java
@@ -1,0 +1,19 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.util.exception;
+
+public class TokenAquisitionException extends RuntimeException {
+    public TokenAquisitionException(Exception exception) {
+        super(exception);
+    }
+}


### PR DESCRIPTION
This pull request addresses the TODO comment:

> // TODO: Merge this with TokenFileAuthentication.

It simplifies the TokenFileAuthentication by taking RefreshAuthentication as the parent class