### PR TITLE
Release-22: Bump the latest pom version to 22.0.1-SNAPSHOT

### DIFF
--- a/client-java-contrib/admissionreview/pom.xml
+++ b/client-java-contrib/admissionreview/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>io.kubernetes</groupId>
         <artifactId>client-java-parent</artifactId>
-        <version>22.0.0-SNAPSHOT</version>
+        <version>22.0.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
-    <version>22.0.0-SNAPSHOT</version>
+    <version>22.0.1-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/client-java-contrib/cert-manager/pom.xml
+++ b/client-java-contrib/cert-manager/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>io.kubernetes</groupId>
         <artifactId>client-java-parent</artifactId>
-        <version>22.0.0-SNAPSHOT</version>
+        <version>22.0.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <!-- the version tracks the release version of the CRDs in the upstream cert-manager project -->
-    <version>22.0.0-SNAPSHOT</version>
+    <version>22.0.1-SNAPSHOT</version>
     <dependencies>
         <dependency>
             <groupId>io.kubernetes</groupId>

--- a/client-java-contrib/prometheus-operator/pom.xml
+++ b/client-java-contrib/prometheus-operator/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>client-java-parent</artifactId>
         <groupId>io.kubernetes</groupId>
-        <version>22.0.0-SNAPSHOT</version>
+        <version>22.0.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>client-java-prometheus-operator-models</artifactId>
-    <version>22.0.0-SNAPSHOT</version>
+    <version>22.0.1-SNAPSHOT</version>
     <dependencies>
         <dependency>
             <groupId>io.kubernetes</groupId>

--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>client-java-parent</artifactId>
         <groupId>io.kubernetes</groupId>
-        <version>22.0.0-SNAPSHOT</version>
+        <version>22.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/examples-release-latest/pom.xml
+++ b/examples/examples-release-latest/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>io.kubernetes</groupId>
 		<artifactId>client-java-examples-parent</artifactId>
-		<version>22.0.0-SNAPSHOT</version>
+		<version>22.0.1-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>io.kubernetes</groupId>
 		<artifactId>client-java-parent</artifactId>
-		<version>22.0.0-SNAPSHOT</version>
+		<version>22.0.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
-	<version>22.0.0-SNAPSHOT</version>
+	<version>22.0.1-SNAPSHOT</version>
 
 	<artifactId>client-java-examples-parent</artifactId>
 	<packaging>pom</packaging>

--- a/extended/pom.xml
+++ b/extended/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>client-java-parent</artifactId>
         <groupId>io.kubernetes</groupId>
-        <version>22.0.0-SNAPSHOT</version>
+        <version>22.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fluent-gen/pom.xml
+++ b/fluent-gen/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>io.kubernetes</groupId>
     <artifactId>client-java-parent</artifactId>
-    <version>22.0.0-SNAPSHOT</version>
+    <version>22.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/fluent/pom.xml
+++ b/fluent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.kubernetes</groupId>
         <artifactId>client-java-parent</artifactId>
-        <version>22.0.0-SNAPSHOT</version>
+        <version>22.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>io.kubernetes</groupId>
     <artifactId>client-java-parent</artifactId>
-    <version>22.0.0-SNAPSHOT</version>
+    <version>22.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>client-java-parent</artifactId>
   <groupId>io.kubernetes</groupId>
-  <version>22.0.0-SNAPSHOT</version>
+  <version>22.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Kubernetes Client API</name>
   <url>https://github.com/kubernetes-client/java</url>

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>io.kubernetes</groupId>
     <artifactId>client-java-parent</artifactId>
-    <version>22.0.0-SNAPSHOT</version>
+    <version>22.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/spring-aot/pom.xml
+++ b/spring-aot/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>client-java-parent</artifactId>
         <groupId>io.kubernetes</groupId>
-        <version>22.0.0-SNAPSHOT</version>
+        <version>22.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <properties>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>client-java-parent</artifactId>
     <groupId>io.kubernetes</groupId>
-    <version>22.0.0-SNAPSHOT</version>
+    <version>22.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.kubernetes</groupId>
         <artifactId>client-java-parent</artifactId>
-        <version>22.0.0-SNAPSHOT</version>
+        <version>22.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>


### PR DESCRIPTION
Previously we have cut a `22.0.0` release from `release-22` branch, however the pom version was expected to be bumped to `22.0.1-SNAPSHOT` after the release. It should be automatically done via the release plugin but due to the workflow permission we lost the commit. This PR syncs the commit on the release branch.