### PR TITLE
Bump master java8 22.0.0-legacy

### DIFF
--- a/client-java-contrib/admissionreview/pom.xml
+++ b/client-java-contrib/admissionreview/pom.xml
@@ -7,10 +7,10 @@
     <parent>
         <groupId>io.kubernetes</groupId>
         <artifactId>client-java-parent</artifactId>
-        <version>21.0.0-legacy-SNAPSHOT</version>
+        <version>22.0.0-legacy-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
-    <version>21.0.0-legacy-SNAPSHOT</version>
+    <version>22.0.0-legacy-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/client-java-contrib/cert-manager/pom.xml
+++ b/client-java-contrib/cert-manager/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>io.kubernetes</groupId>
         <artifactId>client-java-parent</artifactId>
-        <version>21.0.0-legacy-SNAPSHOT</version>
+        <version>22.0.0-legacy-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <!-- the version tracks the release version of the CRDs in the upstream cert-manager project -->
-    <version>21.0.0-legacy-SNAPSHOT</version>
+    <version>22.0.0-legacy-SNAPSHOT</version>
     <dependencies>
         <dependency>
             <groupId>io.kubernetes</groupId>

--- a/client-java-contrib/prometheus-operator/pom.xml
+++ b/client-java-contrib/prometheus-operator/pom.xml
@@ -3,13 +3,13 @@
     <parent>
         <artifactId>client-java-parent</artifactId>
         <groupId>io.kubernetes</groupId>
-        <version>21.0.0-legacy-SNAPSHOT</version>
+        <version>22.0.0-legacy-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>client-java-prometheus-operator-models</artifactId>
-    <version>21.0.0-legacy-SNAPSHOT</version>
+    <version>22.0.0-legacy-SNAPSHOT</version>
     <dependencies>
         <dependency>
             <groupId>io.kubernetes</groupId>

--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>client-java-parent</artifactId>
         <groupId>io.kubernetes</groupId>
-        <version>21.0.0-legacy-SNAPSHOT</version>
+        <version>22.0.0-legacy-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/examples-release-16/pom.xml
+++ b/examples/examples-release-16/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>io.kubernetes</groupId>
 		<artifactId>client-java-examples-parent</artifactId>
-		<version>21.0.0-legacy-SNAPSHOT</version>
+		<version>22.0.0-legacy-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/examples/examples-release-17/pom.xml
+++ b/examples/examples-release-17/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>io.kubernetes</groupId>
 		<artifactId>client-java-examples-parent</artifactId>
-		<version>21.0.0-legacy-SNAPSHOT</version>
+		<version>22.0.0-legacy-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/examples/examples-release-18/pom.xml
+++ b/examples/examples-release-18/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>io.kubernetes</groupId>
 		<artifactId>client-java-examples-parent</artifactId>
-		<version>21.0.0-legacy-SNAPSHOT</version>
+		<version>22.0.0-legacy-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/examples/examples-release-19/pom.xml
+++ b/examples/examples-release-19/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>io.kubernetes</groupId>
 		<artifactId>client-java-examples-parent</artifactId>
-		<version>21.0.0-legacy-SNAPSHOT</version>
+		<version>22.0.0-legacy-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>io.kubernetes</groupId>
 		<artifactId>client-java-parent</artifactId>
-		<version>21.0.0-legacy-SNAPSHOT</version>
+		<version>22.0.0-legacy-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
-	<version>21.0.0-legacy-SNAPSHOT</version>
+	<version>22.0.0-legacy-SNAPSHOT</version>
 
 	<artifactId>client-java-examples-parent</artifactId>
 	<packaging>pom</packaging>

--- a/extended/pom.xml
+++ b/extended/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>client-java-parent</artifactId>
         <groupId>io.kubernetes</groupId>
-        <version>21.0.0-legacy-SNAPSHOT</version>
+        <version>22.0.0-legacy-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fluent-gen/pom.xml
+++ b/fluent-gen/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>io.kubernetes</groupId>
     <artifactId>client-java-parent</artifactId>
-    <version>21.0.0-legacy-SNAPSHOT</version>
+    <version>22.0.0-legacy-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/fluent/pom.xml
+++ b/fluent/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.kubernetes</groupId>
         <artifactId>client-java-parent</artifactId>
-        <version>21.0.0-legacy-SNAPSHOT</version>
+        <version>22.0.0-legacy-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>io.kubernetes</groupId>
     <artifactId>client-java-parent</artifactId>
-    <version>21.0.0-legacy-SNAPSHOT</version>
+    <version>22.0.0-legacy-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiClient.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiClient.java
@@ -108,7 +108,7 @@ public class ApiClient {
         json = new JSON();
 
         // Set default User-Agent.
-        setUserAgent("Kubernetes Java Client/21.0.0-legacy-SNAPSHOT");
+        setUserAgent("Kubernetes Java Client/22.0.0-legacy-SNAPSHOT");
 
         authentications = new HashMap<String, Authentication>();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>client-java-parent</artifactId>
   <groupId>io.kubernetes</groupId>
-  <version>21.0.0-legacy-SNAPSHOT</version>
+  <version>22.0.0-legacy-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Kubernetes Client API</name>
   <url>https://github.com/kubernetes-client/java</url>

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>io.kubernetes</groupId>
 		<artifactId>client-java-parent</artifactId>
-		<version>21.0.0-legacy-SNAPSHOT</version>
+		<version>22.0.0-legacy-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-aot/pom.xml
+++ b/spring-aot/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>client-java-parent</artifactId>
         <groupId>io.kubernetes</groupId>
-        <version>21.0.0-legacy-SNAPSHOT</version>
+        <version>22.0.0-legacy-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <properties>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <artifactId>client-java-parent</artifactId>
     <groupId>io.kubernetes</groupId>
-    <version>21.0.0-legacy-SNAPSHOT</version>
+    <version>22.0.0-legacy-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.kubernetes</groupId>
         <artifactId>client-java-parent</artifactId>
-        <version>21.0.0-legacy-SNAPSHOT</version>
+        <version>22.0.0-legacy-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <dependencies>


### PR DESCRIPTION
This PR bumps the root pom version on master-java8 which is the master branch for legacy support to 22.0.0-*.

As follow-up, I will cut another release branch for 22.0.x-legacy, probably named `release-legacy-22-fix` as the current content on `release-legacy-22` branch is not correct