### PR TITLE
Revert "build(deps): bump org.apache.felix:maven-bundle-plugin" from master-java8 branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -361,7 +361,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>6.0.0</version>
+          <version>5.1.9</version>
           <extensions>true</extensions>
         </plugin>
         <plugin>


### PR DESCRIPTION
org.apache.felix:maven-bundle-plugin 6.x is not compatible with java8 hence reverting it

> https://experienceleaguecommunities.adobe.com/t5/adobe-experience-manager/build-fails-aqute-bnd-osgi-analyzer-has-been-compiled-by-a-more/m-p/723973