### PR TITLE
Branch(master-java8): Remove "JSON.java" from openapi gen ignore file

### DIFF
--- a/kubernetes/.openapi-generator-ignore
+++ b/kubernetes/.openapi-generator-ignore
@@ -5,6 +5,3 @@
 git_push.sh
 README.md
 pom.xml
-
-# Remove when changes in kubernetes-client/java#366,#240 make into upstream openapi-generator
-src/main/java/io/kubernetes/client/openapi/JSON.java


### PR DESCRIPTION
So that it can be re-generated/refreshed by openapi model generation workflow