### PR TITLE
Added SSL reloading mechanism

### DIFF
--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -43,9 +43,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${slf4j.version}</version>
+            <groupId>io.github.hakky54</groupId>
+            <artifactId>logcaptor</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -67,10 +66,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <skipTests>${e2e.skip}</skipTests>
-                    <systemPropertyVariables>
-                        <org.slf4j.simpleLogger.defaultLogLevel>DEBUG</org.slf4j.simpleLogger.defaultLogLevel>
-                        <org.slf4j.simpleLogger.showDateTime>true</org.slf4j.simpleLogger.showDateTime>
-                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/e2e/src/test/java/io/kubernetes/client/e2e/ssl/SSLTest.java
+++ b/e2e/src/test/java/io/kubernetes/client/e2e/ssl/SSLTest.java
@@ -1,0 +1,95 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.e2e.ssl;
+
+import io.kubernetes.client.informer.SharedIndexInformer;
+import io.kubernetes.client.informer.SharedInformerFactory;
+import io.kubernetes.client.informer.cache.Lister;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.models.V1Namespace;
+import io.kubernetes.client.openapi.models.V1NamespaceList;
+import io.kubernetes.client.util.ClientBuilder;
+import io.kubernetes.client.util.generic.GenericKubernetesApi;
+import nl.altindag.log.LogCaptor;
+import nl.altindag.log.model.LogEvent;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+class SSLTest {
+
+    @Test
+    void buildClientWithReloadableSslConfiguration() throws Exception {
+        LogCaptor logCaptor = LogCaptor.forRoot();
+
+        ApiClient apiClient = ClientBuilder.defaultClient();
+        apiClient.setSslCaCert(null);
+
+        SharedInformerFactory informerFactory = new SharedInformerFactory(apiClient);
+
+        GenericKubernetesApi<V1Namespace, V1NamespaceList> api =
+                new GenericKubernetesApi<>(
+                        V1Namespace.class,
+                        V1NamespaceList.class,
+                        "",
+                        "v1",
+                        "namespaces",
+                        apiClient);
+
+        SharedIndexInformer<V1Namespace> nsInformer = informerFactory.sharedIndexInformerFor(api, V1Namespace.class, 0);
+        Lister<V1Namespace> nsLister = new Lister<>(nsInformer.getIndexer());
+
+        try {
+            informerFactory.startAllRegisteredInformers();
+
+            await().untilAsserted(() -> {
+                nsInformer.hasSynced();
+                Optional<Throwable> certificateNotFoundException = getCertificateNotFoundException(logCaptor);
+                assertThat(certificateNotFoundException).isPresent();
+            });
+
+            logCaptor.clearLogs();
+
+            // apiClient.setSslCaCert() should be called with the new certificates to make the test passing
+            // because the certificate is not easily obtained during the test apiClient.setVerifyingSsl
+            // is being called to also trigger the reloading mechanism of the ssl configuration.
+            apiClient.setVerifyingSsl(false);
+
+            await()
+                    .untilAsserted(
+                            () -> {
+                                assertThat(nsInformer.hasSynced()).isTrue();
+                                assertThat(nsLister.list()).isNotEmpty();
+                                Optional<Throwable> certificateNotFoundException = getCertificateNotFoundException(logCaptor);
+                                assertThat(certificateNotFoundException).isEmpty();
+                            });
+        } finally {
+            informerFactory.stopAllRegisteredInformers(true);
+            logCaptor.close();
+        }
+    }
+
+    private static Optional<Throwable> getCertificateNotFoundException(LogCaptor logCaptor) {
+        return logCaptor.getLogEvents().stream()
+                .map(LogEvent::getThrowable)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .filter(exception -> exception.getMessage().contains("unable to find valid certification path to requested target"))
+                .findAny();
+    }
+
+
+}

--- a/e2e/src/test/java/io/kubernetes/client/e2e/ssl/SSLTest.java
+++ b/e2e/src/test/java/io/kubernetes/client/e2e/ssl/SSLTest.java
@@ -43,16 +43,7 @@ class SSLTest {
         apiClient.setSslCaCert(null);
 
         SharedInformerFactory informerFactory = new SharedInformerFactory(apiClient);
-
-        GenericKubernetesApi<V1Namespace, V1NamespaceList> api =
-                new GenericKubernetesApi<>(
-                        V1Namespace.class,
-                        V1NamespaceList.class,
-                        "",
-                        "v1",
-                        "namespaces",
-                        apiClient);
-
+        GenericKubernetesApi<V1Namespace, V1NamespaceList> api = new GenericKubernetesApi<>(V1Namespace.class, V1NamespaceList.class, "", "v1", "namespaces", apiClient);
         SharedIndexInformer<V1Namespace> nsInformer = informerFactory.sharedIndexInformerFor(api, V1Namespace.class, 0);
         Lister<V1Namespace> nsLister = new Lister<>(nsInformer.getIndexer());
 

--- a/e2e/src/test/java/io/kubernetes/client/e2e/ssl/SSLTest.java
+++ b/e2e/src/test/java/io/kubernetes/client/e2e/ssl/SSLTest.java
@@ -37,6 +37,9 @@ class SSLTest {
 
     @Test
     void buildClientWithReloadableSslConfiguration() throws Exception {
+        LogCaptor logCaptorForJdkSecurityEvents = LogCaptor.forName("jdk.event.security");
+        logCaptorForJdkSecurityEvents.disableLogs();
+
         LogCaptor logCaptor = LogCaptor.forRoot();
 
         ApiClient apiClient = ClientBuilder.defaultClient();
@@ -70,6 +73,7 @@ class SSLTest {
             });
         } finally {
             informerFactory.stopAllRegisteredInformers(true);
+            logCaptorForJdkSecurityEvents.resetLogLevel();
             logCaptor.close();
         }
     }

--- a/e2e/src/test/java/io/kubernetes/client/e2e/ssl/SSLTest.java
+++ b/e2e/src/test/java/io/kubernetes/client/e2e/ssl/SSLTest.java
@@ -71,14 +71,12 @@ class SSLTest {
             assertThat(certificateAuthorityData).isPresent();
             apiClient.setSslCaCert(new ByteArrayInputStream(certificateAuthorityData.get()));
 
-            await()
-                    .untilAsserted(
-                            () -> {
-                                assertThat(nsInformer.hasSynced()).isTrue();
-                                assertThat(nsLister.list()).isNotEmpty();
-                                Optional<Throwable> certificateNotFoundException = getCertificateNotFoundException(logCaptor);
-                                assertThat(certificateNotFoundException).isEmpty();
-                            });
+            await().untilAsserted(() -> {
+                assertThat(nsInformer.hasSynced()).isTrue();
+                assertThat(nsLister.list()).isNotEmpty();
+                Optional<Throwable> certificateNotFoundException = getCertificateNotFoundException(logCaptor);
+                assertThat(certificateNotFoundException).isEmpty();
+            });
         } finally {
             informerFactory.stopAllRegisteredInformers(true);
             logCaptor.close();

--- a/e2e/src/test/java/io/kubernetes/client/e2e/util/TestUtils.java
+++ b/e2e/src/test/java/io/kubernetes/client/e2e/util/TestUtils.java
@@ -1,0 +1,88 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package io.kubernetes.client.e2e.util;
+
+import io.kubernetes.client.util.KubeConfig;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Optional;
+
+import static io.kubernetes.client.util.KubeConfig.*;
+
+public class TestUtils {
+
+    public static Optional<KubeConfig> getKubeConfig() {
+        return findConfigInHomeDir().flatMap(TestUtils::getKubeConfig);
+    }
+
+    public static Optional<KubeConfig> getKubeConfig(File configInHomeDir) {
+        try (InputStream inputStream = Files.newInputStream(configInHomeDir.toPath());
+             InputStreamReader inputStreamReader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
+             BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
+
+            KubeConfig kubeConfig = KubeConfig.loadKubeConfig(bufferedReader);
+            return Optional.of(kubeConfig);
+        } catch (IOException e) {
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<File> findConfigInHomeDir() {
+        final File homeDir = findHomeDir();
+        if (homeDir != null) {
+            final File config = new File(new File(homeDir, KUBEDIR), KUBECONFIG);
+            if (config.exists()) {
+                return Optional.of(config);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static File findHomeDir() {
+        final String envHome = System.getenv(ENV_HOME);
+        if (envHome != null && envHome.length() > 0) {
+            final File config = new File(envHome);
+            if (config.exists()) {
+                return config;
+            }
+        }
+        if (System.getProperty("os.name").toLowerCase().startsWith("windows")) {
+            String homeDrive = System.getenv("HOMEDRIVE");
+            String homePath = System.getenv("HOMEPATH");
+            if (homeDrive != null
+                    && homeDrive.length() > 0
+                    && homePath != null
+                    && homePath.length() > 0) {
+                File homeDir = new File(new File(homeDrive), homePath);
+                if (homeDir.exists()) {
+                    return homeDir;
+                }
+            }
+            String userProfile = System.getenv("USERPROFILE");
+            if (userProfile != null && userProfile.length() > 0) {
+                File profileDir = new File(userProfile);
+                if (profileDir.exists()) {
+                    return profileDir;
+                }
+            }
+        }
+        return null;
+    }
+
+}

--- a/kubernetes/pom.xml
+++ b/kubernetes/pom.xml
@@ -182,6 +182,10 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.github.hakky54</groupId>
+      <artifactId>sslcontext-kickstart</artifactId>
+    </dependency>
 
     <!-- test dependencies -->
     <dependency>

--- a/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiClient.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiClient.java
@@ -81,7 +81,7 @@ public class ApiClient {
     private InputStream sslCaCert;
     private boolean verifyingSsl;
     private KeyManager[] keyManagers;
-    private SSLFactory baseSslFactory;
+    private SSLFactory sslFactory;
 
     private OkHttpClient httpClient;
     private JSON json;
@@ -1467,19 +1467,19 @@ public class ApiClient {
      * verifyingSsl and sslCaCert.
      */
     private void applySslSettings() {
-        if (baseSslFactory != null) {
+        if (sslFactory != null) {
             reloadSslSettings();
             return;
         }
 
-        baseSslFactory = createSslFactoryBuilder()
+        sslFactory = createSslFactoryBuilder()
                 .withSwappableIdentityMaterial()
                 .withSwappableTrustMaterial()
                 .build();
 
         httpClient = httpClient.newBuilder()
-                        .sslSocketFactory(baseSslFactory.getSslSocketFactory(), baseSslFactory.getTrustManager().orElseThrow())
-                        .hostnameVerifier(baseSslFactory.getHostnameVerifier())
+                        .sslSocketFactory(sslFactory.getSslSocketFactory(), sslFactory.getTrustManager().orElseThrow())
+                        .hostnameVerifier(sslFactory.getHostnameVerifier())
                         .build();
     }
 
@@ -1508,7 +1508,7 @@ public class ApiClient {
 
     private void reloadSslSettings() {
         SSLFactory updatedSslFactory = createSslFactoryBuilder().build();
-        SSLFactoryUtils.reload(baseSslFactory, updatedSslFactory);
+        SSLFactoryUtils.reload(sslFactory, updatedSslFactory);
     }
 
     /**

--- a/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiClient.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiClient.java
@@ -1500,7 +1500,7 @@ public class ApiClient {
             sslFactoryBuilder.withHostnameVerifier(OkHostnameVerifier.INSTANCE);
         }
 
-        if (keyManagers != null && keyManagers.length > 0) {
+        if (keyManagers != null && keyManagers.length > 0 && keyManagers[0] instanceof X509KeyManager) {
             sslFactoryBuilder.withIdentityMaterial(KeyManagerUtils.wrapIfNeeded((X509KeyManager) keyManagers[0]));
         }
         return sslFactoryBuilder;

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
     <spring.version>6.2.2</spring.version>
     <prometheus.client.version>0.16.0</prometheus.client.version>
     <reflections.version>0.10.2</reflections.version>
+    <sslcontext-kickstart.version>9.0.0</sslcontext-kickstart.version>
 
     <!-- The `optional` tag in `dependencyManagement` is not inherited; see
     https://issues.apache.org/jira/browse/MNG-5227 and
@@ -258,6 +259,11 @@
         <groupId>com.google.auth</groupId>
         <artifactId>google-auth-library-oauth2-http</artifactId>
         <version>1.32.0</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.hakky54</groupId>
+        <artifactId>sslcontext-kickstart</artifactId>
+        <version>${sslcontext-kickstart.version}</version>
       </dependency>
 
       <!-- tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
     <prometheus.client.version>0.16.0</prometheus.client.version>
     <reflections.version>0.10.2</reflections.version>
     <sslcontext-kickstart.version>9.0.0</sslcontext-kickstart.version>
+    <logcaptor.version>2.10.1</logcaptor.version>
 
     <!-- The `optional` tag in `dependencyManagement` is not inherited; see
     https://issues.apache.org/jira/browse/MNG-5227 and
@@ -336,6 +337,12 @@
         <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
         <version>4.2.2</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.github.hakky54</groupId>
+        <artifactId>logcaptor</artifactId>
+        <version>${logcaptor.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
This PR resolves the following issue: https://github.com/kubernetes-client/java/issues/3809 

It uses my own ssl library which can be find here: https://github.com/Hakky54/sslcontext-kickstart
It has a built in reloading mechanism which is thread safe.

The client module will create an initial  ssl configuration as base sslfactory alongside with the client. If set cacerts, setkeymanager method is being called when the the library user has new ssl material then the reload mechanism will be executed. It will use the existing http client bowever it will reload the internal ssl properties.