### PR TITLE
Chore: Re-run spotless formatter

### DIFF
--- a/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesListApiTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/generic/GenericKubernetesListApiTest.java
@@ -1,3 +1,15 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package io.kubernetes.client.util.generic;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;


### PR DESCRIPTION
Somehow the source code on master branch failed formatter check after merging in the folowing PR:


https://github.com/kubernetes-client/java/pull/3930

This PR straights the format.