### PR TITLE
ApiClient: support deserializing from InputStream instead of String to bypass 2GB Java String limit

### DIFF
--- a/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiClient.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiClient.java
@@ -38,7 +38,6 @@ import java.security.SecureRandom;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
 import java.text.DateFormat;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -46,13 +45,11 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import io.kubernetes.client.openapi.auth.Authentication;
 import io.kubernetes.client.openapi.auth.HttpBasicAuth;
-import io.kubernetes.client.openapi.auth.HttpBearerAuth;
 import io.kubernetes.client.openapi.auth.ApiKeyAuth;
 
 /**
@@ -886,17 +883,8 @@ public class ApiClient {
             return (T) downloadFileFromResponse(response);
         }
 
-        String respBody;
-        try {
-            if (response.body() != null)
-                respBody = response.body().string();
-            else
-                respBody = null;
-        } catch (IOException e) {
-            throw new ApiException(e);
-        }
-
-        if (respBody == null || "".equals(respBody)) {
+        ResponseBody respBody = response.body();
+        if (respBody == null) {
             return null;
         }
 
@@ -905,17 +893,25 @@ public class ApiClient {
             // ensuring a default content type
             contentType = "application/json";
         }
-        if (isJsonMime(contentType)) {
-            return JSON.deserialize(respBody, returnType);
-        } else if (returnType.equals(String.class)) {
-            // Expecting string, return the raw response body.
-            return (T) respBody;
-        } else {
-            throw new ApiException(
-                    "Content type \"" + contentType + "\" is not supported for type: " + returnType,
-                    response.code(),
-                    response.headers().toMultimap(),
-                    respBody);
+        try {
+            if (isJsonMime(contentType)) {
+                return JSON.deserialize(respBody.byteStream(), returnType);
+            } else if (returnType.equals(String.class)) {
+                String respBodyString = respBody.string();
+                if (respBodyString.isEmpty()) {
+                    return null;
+                }
+                // Expecting string, return the raw response body.
+                return (T) respBodyString;
+            } else {
+                throw new ApiException(
+                        "Content type \"" + contentType + "\" is not supported for type: " + returnType,
+                        response.code(),
+                        response.headers().toMultimap(),
+                        response.body().string());
+            }
+        } catch (IOException e) {
+            throw new ApiException(e);
         }
     }
 

--- a/kubernetes/src/main/java/io/kubernetes/client/openapi/JSON.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/openapi/JSON.java
@@ -29,8 +29,11 @@ import io.kubernetes.client.openapi.models.V1Status;
 import okio.ByteString;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.time.LocalDate;
@@ -805,6 +808,28 @@ public class JSON {
                 return (T) body;
             } else {
                 throw (e);
+            }
+        }
+    }
+
+    /**
+     * Deserialize the given JSON InputStream to a Java object.
+     *
+     * @param <T> Type
+     * @param inputStream The JSON InputStream
+     * @param returnType The type to deserialize into
+     * @return The deserialized Java object
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T deserialize(InputStream inputStream, Type returnType) throws IOException {
+        try (InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
+            if (isLenientOnJson) {
+                // see https://google-gson.googlecode.com/svn/trunk/gson/docs/javadocs/com/google/gson/stream/JsonReader.html#setLenient(boolean)
+                JsonReader jsonReader = new JsonReader(reader);
+                jsonReader.setLenient(true);
+                return gson.fromJson(jsonReader, returnType);
+            } else {
+                return gson.fromJson(reader, returnType);
             }
         }
     }

--- a/kubernetes/src/test/java/io/kubernetes/client/openapi/JSONTest.java
+++ b/kubernetes/src/test/java/io/kubernetes/client/openapi/JSONTest.java
@@ -14,8 +14,11 @@ package io.kubernetes.client.openapi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 
 import com.google.gson.Gson;
@@ -107,5 +110,14 @@ class JSONTest {
     Gson gson = new Gson();
     JsonReader jsonReader = new JsonReader(new StringReader("{\"foo\":\"bar\"}"));
     new V1ListMeta.CustomTypeAdapterFactory().create(gson, TypeToken.get(V1ListMeta.class)).read(jsonReader);
+  }
+
+  @Test
+  void inputStream() throws IOException {
+    String timeStr = "\"2018-04-03T11:32:26.123Z\"";
+    OffsetDateTime dateTime = JSON.deserialize(new ByteArrayInputStream(timeStr.getBytes(StandardCharsets.UTF_8)), OffsetDateTime.class);
+    String serializedStr = JSON.serialize(dateTime);
+    String expectedStr = "\"2018-04-03T11:32:26.123000Z\"";
+    assertThat(serializedStr).isEqualTo(expectedStr);
   }
 }


### PR DESCRIPTION
Fixes issue https://github.com/kubernetes-client/java/issues/4020 .

Makes two changes:
1. In `ApiClient`, if we are deserializing JSON, get the response body as an `InputStream` instead of `String` for deserialization.
2. Adds a new `deserialize()` method in `JSON.java` which accepts `InputStream`.

These two changes enable the `ApiClient` to bypass the 2GB `String` length limit in Java and deserialize large responses greater than 2GB into Java objects.