### PR TITLE
Use patch cmd instead of `git apply` for conflict toleration

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -80,8 +80,8 @@ jobs:
       - name: Apply Manual Diffs
         if: ${{ github.event.inputs.skip_patches != 'true' }}
         run: |
-          ls scripts/patches/*.diff | xargs git apply
-          git add .
+          ls scripts/patches/*.diff | xargs -I {} patch -i {}
+          git add *.java
           git commit -s -m 'Applied patches under scripts/patches/*.diff'
       - name: Generate Fluent
         run: |


### PR DESCRIPTION
Use patch command instead of `git apply` to avoid the git conflict in the GH action for model generation:

> https://github.com/kubernetes-client/java/actions/runs/14861796504

```
bcd074aaeab5:java $ ls scripts/patches/*.diff | xargs  -I {}  patch -i {}
patching file 'kubernetes/src/main/java/io/kubernetes/client/openapi/JSON.java'
patching file 'kubernetes/src/main/java/io/kubernetes/client/openapi/models/V1ListMeta.java'
patching file 'kubernetes/src/main/java/io/kubernetes/client/openapi/models/V1Secret.java'
patching file 'kubernetes/src/main/java/io/kubernetes/client/openapi/models/V1Status.java'
bcd074aaeab5:java$ git add *.java
...
```

cc @brendandburns 