### PR TITLE
Generate workflow: Adding -p0 param for stripping prefix for patch cmd

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Apply Manual Diffs
         if: ${{ github.event.inputs.skip_patches != 'true' }}
         run: |
-          ls scripts/patches/*.diff | xargs -I {} patch -i {}
+          ls scripts/patches/*.diff | xargs -I {} patch -p0 -i {}
           git add *.java
           git commit -s -m 'Applied patches under scripts/patches/*.diff'
       - name: Generate Fluent


### PR DESCRIPTION
Fixes the github action failure:

> https://github.com/kubernetes-client/java/actions/runs/14987439252/job/42103899250

By adding `-p0` to the command:

```
File to patch: 
Skip this patch? [y] 
Skipping patch.
2 out of 2 hunks ignored
can't find file to patch at input line 15
Perhaps you should have used the -p or --strip option?
The text leading up to this was:
```