### PR TITLE
Fix patch workflow - fix linux patch command compatibility

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Apply Manual Diffs
         if: ${{ github.event.inputs.skip_patches != 'true' }}
         run: |
-          ls scripts/patches/*.diff | xargs -I {} patch -p0 -i {}
+          ls scripts/patches/*.diff | xargs -I {} bash -xc 'patch -p1 < "{}"'
           git add *.java
           git commit -s -m 'Applied patches under scripts/patches/*.diff'
       - name: Generate Fluent


### PR DESCRIPTION
This PR fixes the linux compatibility for `patch` command as github workflow is linux-based... My previous PRs are tested in mac environment so it didn't reproduce the interactive error from the last generate workflow:

```
Run ls scripts/patches/*.diff | xargs -I {} patch -p0 -i {}
  ls scripts/patches/*.diff | xargs -I {} patch -p0 -i {}
  git add *.java
  git commit -s -m 'Applied patches under scripts/patches/*.diff'
  shell: /usr/bin/bash -e {0}
  env:
    JAVA_HOME: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.15-6/x64
    JAVA_HOME_17_X64: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.15-6/x64
    BRANCH: automated-generate-0b1f95cb
    PROJECT_VERSION: [2](https://github.com/yue9944882/java/actions/runs/15144087833/job/42575359321#step:9:2)4.0.0-SNAPSHOT
can't find file to patch at input line 14
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|From eeb5069c974d[3](https://github.com/yue9944882/java/actions/runs/15144087833/job/42575359321#step:9:3)146495f8a9dc52653f029d3cc2d Mon Sep 17 00:00:00 2001
|From: Min Jin <minkimzz@amazon.com>
|Date: Tue, [4](https://github.com/yue9944882/java/actions/runs/15144087833/job/42575359321#step:9:4) Feb 2025 11:59:25 -0800
|Subject: [PATCH] manually apply JSON patch
|
|---
| .../io/kubernetes/client/openapi/JSON.java    | 3[6](https://github.com/yue9944882/java/actions/runs/15144087833/job/42575359321#step:9:6) ++++++++++++++++---
| 1 file changed, 32 insertions(+), 4 deletions(-)
|
|diff --git a/kubernetes/src/main/java/io/kubernetes/client/openapi/JSON.java b/kubernetes/src/main/java/io/kubernetes/client/openapi/JSON.java
|index dda3ec[7](https://github.com/yue9944882/java/actions/runs/15144087833/job/42575359321#step:9:7)08..fe902b293 100644
|--- a/kubernetes/src/main/java/io/kubernetes/client/openapi/JSON.java
|+++ b/kubernetes/src/main/java/io/kubernetes/client/openapi/JSON.java
--------------------------
File to patch: 
Skip this patch? [y] 
Skipping patch.
```

Successfully run in my fork repo:

> https://github.com/yue9944882/java/actions/runs/15145131606/job/42578868105
