### PR TITLE
Use PAT_TOKEN instead of GH_TOKEN to automate PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           source_branch: automated-release-${{ github.event.inputs.releaseVersion }}
           destination_branch: ${{ github.ref_name }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PAT_TOKEN }}
           pr_title: "Automated Release: ${{ github.event.inputs.releaseVersion }}"
       - name: Publish Release
         if: ${{ github.event.inputs.dry-run != 'true' }}


### PR DESCRIPTION
Currently it's a pain to manually release new versions. The following is an example of what we manually did for releasing 24.0.0: > https://github.com/kubernetes-client/java/issues/4054#issuecomment-2898658603

```
1.33 Model regeneration PR: https://github.com/kubernetes-client/java/pull/4056

Cut release branch release-24

1.33 Model regeneration PR for legacy branch: https://github.com/kubernetes-client/java/pull/4059

Cut release branch release-legacy-24

Run release workflow for release-24: https://github.com/yue9944882/java/actions/runs/15217107346

Run release workflow for release-legacy-24: https://github.com/yue9944882/java/actions/runs/15218963083

Release 24.0.0 PR: https://github.com/kubernetes-client/java/pull/4062

Release 24.0.0-legacy PR: https://github.com/kubernetes-client/java/pull/4063

Publish 24.0.0 tag

Publish 24.0.0-legacy tag
```

This is due to the default github action token losing the access for creating pull requests via the workflow. As a workaround, this PR allows the release job to use `PAT_TOKEN` which is my personal account's token that only contains PR creation permission so the release process can be automated again.

/cc @brendandburns  
