### PR TITLE
Switch to PAT_TOKEN for git branch push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
           echo "${{ github.event.inputs.nextDevelopmentVersion }}" | perl -ne 'die unless m/^\d+\.\d+\.\d+-SNAPSHOT$/'
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
       - name: Check Actor
         run: |
           # Release actor should be in the OWNER list


### PR DESCRIPTION
> https://github.com/kubernetes-client/java/actions/runs/15476712105/job/43573728659

The github action lost permission to push branch after maven release even though the maven release was successful. Looks like the permission got tighten again recently because we didn't have this error when publishing 24.0.0.. This PR proposes to use PAT_TOKEN which has the repo write permission to automate the version release process.

> remote: Permission to kubernetes-client/java.git denied to github-actions[bot].
> fatal: unable to access 'https://github.com/kubernetes-client/java.git/': The requested URL returned error: 403

We need to choose a poison between having a long manual release process and the risk of increasing the permission for github action..

/cc @brendandburns 
