### PR TITLE
Use PAT_TOKEN for model-generate workflow

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout Java
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
@@ -110,7 +112,7 @@ jobs:
         with:
           source_branch: ${{ env.BRANCH }}
           destination_branch: ${{ github.ref_name }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PAT_TOKEN }}
           pr_title: "Automated Generate from openapi ${{ github.event.inputs.kubernetesBranch }}"
 
 


### PR DESCRIPTION
Previously we have refactored the version-release workflow to onboard to PAT_TOKEN, this PR applies the same change to model generation PR so the model generation workflow can also be fully automated. An example workflow execution see: 

> Workflow: https://github.com/yue9944882/java/actions/runs/15719884145
> PR: https://github.com/yue9944882/java/pull/125