### PR TITLE
Add ApiClient in ClientBuilder

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/ClientBuilder.java
+++ b/util/src/main/java/io/kubernetes/client/util/ClientBuilder.java
@@ -73,6 +73,7 @@ public class ClientBuilder {
   // time to refresh exec based credentials
   // TODO: Read the expiration from the credential itself
   private Duration execCredentialRefreshPeriod = null;
+  private ApiClient apiClient = null;
 
   /**
    * Creates an {@link ApiClient} by calling {@link #standard()} and {@link #build()}.
@@ -435,8 +436,17 @@ public class ClientBuilder {
     return this;
   }
 
+  public ApiClient getApiClient() {
+    return this.apiClient;
+  }
+
+  public ClientBuilder setApiClient(ApiClient apiClient) {
+    this.apiClient = apiClient;
+    return this;
+  }
+
   public ApiClient build() {
-    final ApiClient client = new ApiClient();
+    final ApiClient client = this.apiClient == null ? new ApiClient() : this.apiClient;
 
     client.setHttpClient(
         client


### PR DESCRIPTION
Since the ApiClient has another constructor: apiClient(OkHttpClient). It's useful to allowing user customize the argument. OkHttp also recommend user to reuse the client instance(to sharing the internal dispatchers and connection pool).