### PR TITLE
fix(feat): arbitrary file access during archive extraction zipslip 

### DIFF
--- a/util/src/main/java/io/kubernetes/client/Copy.java
+++ b/util/src/main/java/io/kubernetes/client/Copy.java
@@ -193,6 +193,12 @@ public class Copy extends Exec {
           throw new IOException("Invalid entry: " + entry.getName());
         }
         File f = new File(destination.toFile(), normalName);
+        // Prevent Zip Slip: ensure the file is within the destination directory
+        Path destDirPath = destination.toAbsolutePath().normalize();
+        Path filePath = f.toPath().toAbsolutePath().normalize();
+        if (!filePath.startsWith(destDirPath)) {
+          throw new IOException("Entry is outside of the target dir: " + entry.getName());
+        }
         if (entry.isDirectory()) {
           if (!f.isDirectory() && !f.mkdirs()) {
             throw new IOException("create directory failed: " + f);


### PR DESCRIPTION
fix the vulnerability, we must ensure that the output file path constructed from the archive entry is strictly within the intended destination directory. This is best achieved by normalizing the full output path and then checking that it starts with the normalized destination directory path. If the check fails, we should throw an exception and skip extraction for that entry.

Specifically, in `copyDirectoryFromPodAsync`, after constructing `File f = new File(destination.toFile(), normalName);`, we should:
- Normalize both `f.toPath()` and `destination.toAbsolutePath().normalize()`.
- Check that `f.toPath().normalize().startsWith(destination.toAbsolutePath().normalize())`.
- If not, throw an exception or skip the entry.

This change should be made in the region of lines 195–196, before any file system operations are performed. No new methods are needed, but we should use the existing `java.nio.file.Path` API for normalization and prefix checking.