### PR TITLE
refactor: use StandardCharsets

### DIFF
--- a/util/src/main/java/io/kubernetes/client/Exec.java
+++ b/util/src/main/java/io/kubernetes/client/Exec.java
@@ -35,6 +35,7 @@ import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
 import java.net.URLEncoder;
+import java.nio.charsets.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -438,7 +439,7 @@ public class Exec {
       String[] encodedCommand = new String[command.length];
       for (int i = 0; i < command.length; i++) {
         try {
-          encodedCommand[i] = URLEncoder.encode(command[i], "UTF-8");
+          encodedCommand[i] = URLEncoder.encode(command[i], StandardCharsets.UTF_8);
         } catch (UnsupportedEncodingException ex) {
           throw new RuntimeException("some thing wrong happend: " + ex.getMessage());
         }
@@ -614,7 +615,7 @@ public class Exec {
     public void resize(int width, int height) throws IOException {
       OutputStream resizeStream = getResizeStream();
       String resize = "{ \"width\": " + width + ", \"height\": " + height + " }\n";
-      resizeStream.write(resize.getBytes("UTF-8"));
+      resizeStream.write(resize.getBytes(StandardCharsets.UTF_8));
       resizeStream.flush();
     }
 

--- a/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
+++ b/util/src/main/java/io/kubernetes/client/util/ModelMapper.java
@@ -27,6 +27,7 @@ import java.net.JarURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charsets.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -491,7 +492,7 @@ public class ModelMapper {
   }
 
   private static void processJarPackage(URL packageURL, String packageName, String pkg, ArrayList<String> names) throws IOException {
-    String jarFileName = URLDecoder.decode(packageURL.getFile(), "UTF-8");
+    String jarFileName = URLDecoder.decode(packageURL.getFile(), StandardCharsets.UTF_8);
     JarFile jf = null;
     // jar: client in repository; nested: client in a fat jar
     if (jarFileName.startsWith("jar:") || jarFileName.startsWith("nested:")) {

--- a/util/src/main/java/io/kubernetes/client/util/authenticators/OpenIDConnectAuthenticator.java
+++ b/util/src/main/java/io/kubernetes/client/util/authenticators/OpenIDConnectAuthenticator.java
@@ -216,7 +216,7 @@ public class OpenIDConnectAuthenticator implements Authenticator {
       String urlData =
           new StringBuilder()
               .append("refresh_token=")
-              .append(URLEncoder.encode(refreshToken, "UTF-8"))
+              .append(URLEncoder.encode(refreshToken, StandardCharsets.UTF_8))
               .append("&grant_type=refresh_token")
               .toString();
       OutputStream ou = https.getOutputStream();

--- a/util/src/test/java/io/kubernetes/client/ExecTest.java
+++ b/util/src/test/java/io/kubernetes/client/ExecTest.java
@@ -172,7 +172,7 @@ class ExecTest {
     process.resize(100, 100);
     process.destroy();
 
-    String out = bos.toString("UTF-8");
+    String out = bos.toString(StandardCharsets.UTF_8);
     assertThat(out).isEqualTo("{ \"width\": 100, \"height\": 100 }\n");
   }
 

--- a/util/src/test/java/io/kubernetes/client/WebsocketStreamHandlerTest.java
+++ b/util/src/test/java/io/kubernetes/client/WebsocketStreamHandlerTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
+import java.nio.charsets.StandardCharsets;
 import okhttp3.Request;
 import okhttp3.WebSocket;
 import okio.ByteString;
@@ -68,7 +69,7 @@ class WebsocketStreamHandlerTest {
 
     OutputStream outputStream = handler.getOutputStream(testStreamId);
 
-    byte[] bytes = "This is a test string".getBytes("UTF-8");
+    byte[] bytes = "This is a test string".getBytes(StandardCharsets.UTF_8);
     byte[] output = new byte[bytes.length + 1];
     output[0] = 0;
     for (int i = 0; i < bytes.length; i++) {


### PR DESCRIPTION
Since Java 11, there's `URLEncoder.encode(String s, Charset charset)`