### PR TITLE
Replace deprecated nexusUrl with the new endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -332,12 +332,12 @@
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
       <layout>default</layout>
     </snapshotRepository>
     <repository>
       <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+      <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
       <layout>default</layout>
     </repository>
   </distributionManagement>
@@ -455,12 +455,21 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.8.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>ossrh</publishingServerId>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
         <extensions>true</extensions>
         <configuration>
           <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <nexusUrl>https://ossrh-staging-api.central.sonatype.com/</nexusUrl>
           <autoReleaseAfterClose>true</autoReleaseAfterClose>
         </configuration>
       </plugin>


### PR DESCRIPTION
Maven central has officially deprecated the legacy nexus publish endpoint `oss.sonatype.org` according to:

> https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuring-the-repository

This PR update the endpoint to fix the release job failure for 1.34 release.