### PR TITLE
fix feat `TrustManager` that accepts all certificates

### DIFF
--- a/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiClient.java
+++ b/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiClient.java
@@ -1496,28 +1496,9 @@ public class ApiClient {
             TrustManager[] trustManagers;
             HostnameVerifier hostnameVerifier;
             if (!verifyingSsl) {
-                trustManagers = new TrustManager[]{
-                        new X509TrustManager() {
-                            @Override
-                            public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
-                            }
-
-                            @Override
-                            public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
-                            }
-
-                            @Override
-                            public java.security.cert.X509Certificate[] getAcceptedIssuers() {
-                                return new java.security.cert.X509Certificate[]{};
-                            }
-                        }
-                };
-                hostnameVerifier = new HostnameVerifier() {
-                    @Override
-                    public boolean verify(String hostname, SSLSession session) {
-                        return true;
-                    }
-                };
+                throw new IllegalStateException(
+                    "Disabling SSL verification is insecure and no longer supported. " +
+                    "Please provide a trusted CA certificate via sslCaCert.");
             } else {
                 TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
 


### PR DESCRIPTION
https://github.com/kubernetes-client/java/blob/c14bb93680786910ecb01bce1a428a3654ee4544/kubernetes/src/main/java/io/kubernetes/client/openapi/ApiClient.java#L1499-L1520

To address this vulnerability, we must remove the custom `TrustManager` and `HostnameVerifier` that accept all certificates.  
- If the intention is to allow self-signed certificates in some cases, explicit trusted certificates should be loaded from a secure location into a `KeyStore`, as demonstrated in the good example in the background.  
- The `TrustManager` should be initialized via a `TrustManagerFactory` with a `KeyStore` containing only the explicitly trusted certificates.
- Hostname verification should *not* be disabled; use the standard verifier unless on localhost for very specific reasons.
- Changes are required within the `applySslSettings()` method:  
  - Remove (or replace) the block starting on line 1498 that creates an insecure `TrustManager` and `HostnameVerifier`.
  - Instead, if `verifyingSsl` is `false`, throw an exception or require the user to provide a trusted CA cert, as in the `else` branch. This eliminates the insecure option entirely.


### References
[Security with HTTPS and SSL](https://developer.android.com/training/articles/security-ssl)