### PR TITLE
Update style format workflow to use Java 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - name: Verify Format and License
         run: ./mvnw spotless:check
   build:


### PR DESCRIPTION
The newer version of Spotless requires at least Java 17.