### PR TITLE
Use PAT_TOKEN to publish release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,5 +94,5 @@ jobs:
         if: ${{ github.event.inputs.dry-run != 'true' }}
         uses: ncipollo/release-action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN }}
           tag: v${{ github.event.inputs.releaseVersion }}


### PR DESCRIPTION
This PR fixes the permission issue in the repo's release workflow so that we don't need to create release manually.

```
Run ncipollo/release-action@v1
  with:
    token: ***
    tag: v25.0.0-legacy
    generateReleaseNotes: false
    immutableCreate: false
    makeLatest: legacy
    omitBody: false
    omitBodyDuringUpdate: false
    omitDraftDuringUpdate: false
    omitName: false
    omitNameDuringUpdate: false
    omitPrereleaseDuringUpdate: false
    removeArtifacts: false
    replacesArtifacts: true
    skipIfReleaseExists: false
    updateOnlyUnreleased: false
  env:
    JAVA_HOME: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.17-10/x64
    JAVA_HOME_17_X64: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.17-10/x64
Error: Error 403: Resource not accessible by integration - https://docs.github.com/rest/releases/releases#create-a-release
```