### PR TITLE
Clarify dependencyManagement usage for shared dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,14 @@
       <organizationUrl>https://kubernetes.io</organizationUrl>
     </developer>
   </developers>
+  <!--
+  NOTE:
+    Dependencies declared in dependencyManagement may appear unused in individual
+    modules, but are required to provide versions for child modules that declare
+    dependencies without explicit versions. Do not remove entries without verifying
+    all module POMs.
+-->
+
 
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
### Summary
While investigating removal of unused dependencies from the parent POM, I found
that several entries are required to supply versions for child modules that
declare dependencies without explicit versions.

This PR adds documentation to prevent accidental removal that would break
multi-module builds.

### Verification
- mvn dependency:analyze across multiple modules
- mvn clean verify