### PR TITLE
feat(util): add ServerSideApply for declarative resource management

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/ServerSideApply.java
+++ b/util/src/main/java/io/kubernetes/client/util/ServerSideApply.java
@@ -34,10 +34,10 @@ import java.util.Objects;
  * <pre>{@code
  * // Simple server-side apply
  * V1Pod appliedPod = ServerSideApply.apply(
- *     apiClient, 
- *     V1Pod.class, 
- *     V1PodList.class, 
- *     deployment, 
+ *     apiClient,
+ *     V1Pod.class,
+ *     V1PodList.class,
+ *     deployment,
  *     "my-field-manager"
  * );
  *
@@ -363,14 +363,14 @@ public class ServerSideApply {
             }
             return pluralize(kind);
         }
-        
+
         /**
          * Simple pluralization for Kubernetes resource kinds.
          */
         private String pluralize(String kind) {
             String lower = kind.toLowerCase();
             // Special cases for Kubernetes kinds
-            if (lower.endsWith("s") || lower.endsWith("x") || lower.endsWith("z") 
+            if (lower.endsWith("s") || lower.endsWith("x") || lower.endsWith("z")
                     || lower.endsWith("ch") || lower.endsWith("sh")) {
                 return lower + "es";
             }

--- a/util/src/test/java/io/kubernetes/client/util/ServerSideApplyTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/ServerSideApplyTest.java
@@ -232,7 +232,7 @@ class ServerSideApplyTest {
     @Test
     void apply_nullApi_throwsNullPointerException() {
         V1Pod pod = createPod("test-pod", "default");
-        assertThatThrownBy(() -> 
+        assertThatThrownBy(() ->
                 ServerSideApply.apply((GenericKubernetesApi<V1Pod, V1PodList>) null, pod, "test-manager"))
                 .isInstanceOf(NullPointerException.class);
     }
@@ -288,7 +288,7 @@ class ServerSideApplyTest {
     void builder_missingApiTypeClass_throwsNullPointerException() {
         V1Pod pod = createPod("test-pod", "default");
 
-        assertThatThrownBy(() -> 
+        assertThatThrownBy(() ->
                 ServerSideApply.<V1Pod, V1PodList>builder(apiClient)
                         .apiListTypeClass(V1PodList.class)
                         .resource(pod)
@@ -302,7 +302,7 @@ class ServerSideApplyTest {
     void builder_missingApiListTypeClass_throwsNullPointerException() {
         V1Pod pod = createPod("test-pod", "default");
 
-        assertThatThrownBy(() -> 
+        assertThatThrownBy(() ->
                 ServerSideApply.<V1Pod, V1PodList>builder(apiClient)
                         .apiTypeClass(V1Pod.class)
                         .resource(pod)
@@ -314,7 +314,7 @@ class ServerSideApplyTest {
 
     @Test
     void builder_missingResource_throwsNullPointerException() {
-        assertThatThrownBy(() -> 
+        assertThatThrownBy(() ->
                 ServerSideApply.<V1Pod, V1PodList>builder(apiClient)
                         .apiTypeClass(V1Pod.class)
                         .apiListTypeClass(V1PodList.class)


### PR DESCRIPTION
Add a utility class that provides fabric8-style server-side apply operations. Features include:
- Static apply() methods with GenericKubernetesApi
- Builder pattern for fluent configuration
- Support for fieldManager to track field ownership
- forceConflicts option to take ownership of conflicting fields
- dryRun mode for validation without persistence
- Works with both namespaced and cluster-scoped resources

Also adds comprehensive unit tests covering apply operations, builder pattern, error handling, and parameter validation.