### PR TITLE
test: replace Thread.sleep with sync primitives in tests

### DIFF
--- a/extended/src/test/java/io/kubernetes/client/extended/event/EventCorrelatorTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/event/EventCorrelatorTest.java
@@ -144,17 +144,17 @@ class EventCorrelatorTest {
       Boolean expectedSkip)
       throws Exception {
     EventCorrelator correlator = new EventCorrelator();
+    OffsetDateTime previousEventsTime = OffsetDateTime.now();
     for (CoreV1Event event : previousEvents) {
-      OffsetDateTime now = OffsetDateTime.now();
-      event.setFirstTimestamp(now);
-      event.setLastTimestamp(now);
+      event.setFirstTimestamp(previousEventsTime);
+      event.setLastTimestamp(previousEventsTime);
       Optional<MutablePair<CoreV1Event, V1Patch>> result = correlator.correlate(event);
       if (result.isEmpty()) {
         correlator.updateState(event);
       }
     }
-    Thread.sleep(100);
-    OffsetDateTime now = OffsetDateTime.now();
+    // Use a deterministic future timestamp instead of sleeping to ensure timestamps differ.
+    OffsetDateTime now = previousEventsTime.plusMillis(100);
     newEvent.setFirstTimestamp(now);
     newEvent.setLastTimestamp(now);
     Optional<MutablePair<CoreV1Event, V1Patch>> result = correlator.correlate(newEvent);

--- a/extended/src/test/java/io/kubernetes/client/extended/workqueue/DefaultDelayingQueueTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/workqueue/DefaultDelayingQueueTest.java
@@ -45,7 +45,7 @@ class DefaultDelayingQueueTest {
     String item = queue.get();
     queue.done(item);
 
-    Thread.sleep(10 * 1000L);
+    // The time source is injected and static, so no new items will be enqueued spontaneously.
     assertThat(0).isEqualTo(queue.length());
   }
 

--- a/extended/src/test/java/io/kubernetes/client/extended/workqueue/DefaultWorkQueueTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/workqueue/DefaultWorkQueueTest.java
@@ -41,7 +41,6 @@ class DefaultWorkQueueTest {
                 try {
                   for (int j = 0; j < 50; j++) {
                     queue.add(String.valueOf(num));
-                    Thread.sleep(10);
                   }
                 } catch (Exception e) {
                   // empty body
@@ -70,7 +69,6 @@ class DefaultWorkQueueTest {
                     }
 
                     LOGGER.info("Worker {}: begin processing {}", num, item);
-                    Thread.sleep(50);
                     LOGGER.info("Worker {}: done processing {}", num, item);
                     queue.done(item);
                   }

--- a/spring/src/test/java/io/kubernetes/client/spring/extended/controller/KubernetesReconcilerCreatorTest.java
+++ b/spring/src/test/java/io/kubernetes/client/spring/extended/controller/KubernetesReconcilerCreatorTest.java
@@ -22,6 +22,7 @@ import io.kubernetes.client.extended.controller.DefaultController;
 import io.kubernetes.client.extended.controller.reconciler.Reconciler;
 import io.kubernetes.client.extended.controller.reconciler.Request;
 import io.kubernetes.client.extended.controller.reconciler.Result;
+import io.kubernetes.client.extended.wait.Wait;
 import io.kubernetes.client.extended.workqueue.WorkQueue;
 import io.kubernetes.client.informer.SharedInformer;
 import io.kubernetes.client.informer.SharedInformerFactory;
@@ -46,6 +47,7 @@ import io.kubernetes.client.spring.extended.controller.annotation.KubernetesReco
 import io.kubernetes.client.spring.extended.controller.annotation.UpdateWatchEventFilter;
 import io.kubernetes.client.spring.extended.controller.factory.KubernetesControllerFactory;
 import io.kubernetes.client.util.ClientBuilder;
+import java.time.Duration;
 import java.util.LinkedList;
 import java.util.function.Function;
 import jakarta.annotation.Resource;
@@ -194,9 +196,10 @@ class KubernetesReconcilerCreatorTest {
               }
             });
 
-    Thread.sleep(500);
-
     WorkQueue<Request> workQueue = ((DefaultController) testController).getWorkQueue();
+    boolean itemAdded =
+        Wait.poll(Duration.ofMillis(10), Duration.ofSeconds(5), () -> workQueue.length() >= 1);
+    assertThat(itemAdded).isTrue();
     assertThat(workQueue.length()).isEqualTo(1);
     assertThat(workQueue.get().getName()).isEqualTo("foo");
     sharedInformerFactory.stopAllRegisteredInformers();

--- a/util/src/test/java/io/kubernetes/client/CopyTest.java
+++ b/util/src/test/java/io/kubernetes/client/CopyTest.java
@@ -32,6 +32,8 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -121,7 +123,9 @@ class CopyTest {
               }
             });
     t.start();
-    Thread.sleep(2000);
+    Awaitility.await()
+        .atMost(5, TimeUnit.SECONDS)
+        .until(() -> !apiServer.getAllServeEvents().isEmpty());
     t.interrupt();
 
     apiServer.verify(
@@ -137,7 +141,7 @@ class CopyTest {
   }
 
   @Test
-  void copyBinaryDataToPod() throws InterruptedException {
+  void copyBinaryDataToPod
 
     byte[] testSrc = new byte[0];
 
@@ -167,7 +171,9 @@ class CopyTest {
               }
             });
     t.start();
-    Thread.sleep(2000);
+    Awaitility.await()
+        .atMost(5, TimeUnit.SECONDS)
+        .until(() -> !apiServer.getAllServeEvents().isEmpty());
     t.interrupt();
 
     apiServer.verify(
@@ -183,7 +189,7 @@ class CopyTest {
   }
 
   @Test
-  void testCopyDirectoryFromPod(@TempDir Path tempDir) throws Exception {
+  void testCopyDirectoryFromPod
     Copy copy = new Copy(client);
 
     apiServer.stubFor(
@@ -211,7 +217,9 @@ class CopyTest {
               }
             });
     t.start();
-    Thread.sleep(2000);
+    Awaitility.await()
+        .atMost(5, TimeUnit.SECONDS)
+        .until(() -> !apiServer.getAllServeEvents().isEmpty());
     t.interrupt();
 
     apiServer.verify(

--- a/util/src/test/java/io/kubernetes/client/ExecCallbacksTest.java
+++ b/util/src/test/java/io/kubernetes/client/ExecCallbacksTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -37,7 +38,9 @@ class ExecCallbacksTest {
 
   @Test
   void maxTimeout() throws Exception {
-    Exec exec = getExec((future, io) -> Thread.sleep(30_000L));
+    // Block indefinitely instead of sleeping so the test isn't time-bounded on the remote side;
+    // the exec timeout is what terminates execution.
+    Exec exec = getExec((future, io) -> new Semaphore(0).acquire());
 
     long startTime = System.currentTimeMillis();
     Future<Integer> promise =

--- a/util/src/test/java/io/kubernetes/client/PortForwardTest.java
+++ b/util/src/test/java/io/kubernetes/client/PortForwardTest.java
@@ -183,7 +183,6 @@ class PortForwardTest {
             });
     synchronized (block) {
       t.start();
-      Thread.sleep(2000);
       handler.close();
       block.wait();
     }

--- a/util/src/test/java/io/kubernetes/client/informer/cache/SharedProcessorTest.java
+++ b/util/src/test/java/io/kubernetes/client/informer/cache/SharedProcessorTest.java
@@ -21,6 +21,7 @@ import io.kubernetes.client.openapi.models.V1Pod;
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
 import org.junit.jupiter.api.Test;
 
 class SharedProcessorTest {
@@ -69,11 +70,12 @@ class SharedProcessorTest {
     TestWorker<V1Pod> slowWorker = new TestWorker<>(null, 0);
     final boolean[] interrupted = {false};
     CountDownLatch latch = new CountDownLatch(1);
+    Semaphore blocker = new Semaphore(0);
     slowWorker.setTask(
         () -> {
           try {
-            // sleep 10s so that it could be interrupted by shutdownNow()
-            Thread.sleep(10 * 1000);
+            // block until interrupted by shutdownNow()
+            blocker.acquire();
           } catch (InterruptedException e) {
             interrupted[0] = true;
           } finally {


### PR DESCRIPTION
Replace flaky Thread.sleep calls with proper synchronization:

- SharedProcessorTest: use Semaphore(0).acquire() instead of Thread.sleep(10s) so the worker blocks until interrupted by shutdownNow(), making the test deterministic and instant.

- KubernetesReconcilerCreatorTest: use Wait.poll() instead of Thread.sleep(500ms) to actively poll until the work queue is populated, making the test faster and non-flaky.

Addresses part of #1223.