### PR TITLE
fix: refresh EKS authentication token per request

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/credentials/EKSAuthentication.java
+++ b/util/src/main/java/io/kubernetes/client/util/credentials/EKSAuthentication.java
@@ -12,7 +12,6 @@ limitations under the License.
 */
 package io.kubernetes.client.util.credentials;
 
-import io.kubernetes.client.openapi.ApiClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -29,12 +28,13 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
+import java.util.function.Supplier;
 
 /**
  * EKS cluster authentication which generates a bearer token from AWS AK/SK. It doesn't require an "aws"
  * command line tool in the $PATH.
  */
-public class EKSAuthentication implements Authentication {
+public class EKSAuthentication extends RefreshAuthentication {
 
     private static final Logger log = LoggerFactory.getLogger(EKSAuthentication.class);
 
@@ -50,33 +50,45 @@ public class EKSAuthentication implements Authentication {
     }
 
     public EKSAuthentication(AwsCredentialsProvider provider, String region, String clusterName, int expirySeconds) {
-        this.provider = provider;
-        this.region = region;
-        this.clusterName = clusterName;
-        if (expirySeconds > MAX_EXPIRY_SECONDS) {
-            expirySeconds = MAX_EXPIRY_SECONDS;
-        }
-        this.expirySeconds = expirySeconds;
-        this.stsEndpoint = URI.create("https://sts." + this.region + ".amazonaws.com");
+        this(new EksTokenSupplier(provider, region, clusterName, Math.min(expirySeconds, MAX_EXPIRY_SECONDS)));
+    }
+
+    private EKSAuthentication(EksTokenSupplier tokenSupplier) {
+        super(tokenSupplier, Duration.of(tokenSupplier.expirySeconds, ChronoUnit.SECONDS));
+        setExpiry(Instant.now().plus(tokenSupplier.expirySeconds, ChronoUnit.SECONDS));
     }
 
     private static final int MAX_EXPIRY_SECONDS = 60 * 15;
-    private final AwsCredentialsProvider provider;
-    private final String region;
-    private final String clusterName;
-    private final URI stsEndpoint;
 
-    private final int expirySeconds;
+    private static class EksTokenSupplier implements Supplier<String> {
+        private final AwsCredentialsProvider provider;
+        private final String region;
+        private final String clusterName;
+        private final URI stsEndpoint;
+        private final int expirySeconds;
 
-    @Override
-    public void provide(ApiClient client) {
-        SdkHttpRequest httpRequest = generateStsRequest();
-        String presignedUrl = requestToPresignedUrl(httpRequest);
+        EksTokenSupplier(AwsCredentialsProvider provider, String region, String clusterName, int expirySeconds) {
+            this.provider = provider;
+            this.region = region;
+            this.clusterName = clusterName;
+            this.expirySeconds = expirySeconds;
+            this.stsEndpoint = URI.create("https://sts." + this.region + ".amazonaws.com");
+        }
+
+        @Override
+        public String get() {
+            return generateToken(provider, region, clusterName, stsEndpoint, expirySeconds);
+        }
+    }
+
+    private static String generateToken(
+            AwsCredentialsProvider provider, String region, String clusterName, URI stsEndpoint, int expirySeconds) {
+        SdkHttpRequest httpRequest = generateStsRequest(stsEndpoint, clusterName);
+        String presignedUrl = requestToPresignedUrl(httpRequest, provider, region);
         String encodedUrl = presignedUrlToEncodedUrl(presignedUrl);
         String token = "k8s-aws-v1." + encodedUrl;
-        client.setApiKeyPrefix("Bearer");
-        client.setApiKey(token);
         log.info("Generated BEARER token for ApiClient, expiring at {}", Instant.now().plus(expirySeconds, ChronoUnit.SECONDS));
+        return token;
     }
 
     private static String presignedUrlToEncodedUrl(String presignedUrl) {
@@ -85,7 +97,7 @@ public class EKSAuthentication implements Authentication {
                 .encodeToString(SdkHttpUtils.urlEncodeIgnoreSlashes(presignedUrl).getBytes(StandardCharsets.UTF_8));
     }
 
-    private SdkHttpRequest generateStsRequest() {
+    private static SdkHttpRequest generateStsRequest(URI stsEndpoint, String clusterName) {
         return SdkHttpRequest.builder()
                 .uri(stsEndpoint)
                 .putRawQueryParameter("Version", "2011-06-15")
@@ -95,10 +107,11 @@ public class EKSAuthentication implements Authentication {
                 .build();
     }
 
-    private String requestToPresignedUrl(SdkHttpRequest httpRequest) {
+    private static String requestToPresignedUrl(
+            SdkHttpRequest httpRequest, AwsCredentialsProvider provider, String region) {
         AwsV4HttpSigner signer = AwsV4HttpSigner.create();
         SignedRequest signedRequest =
-                signer.sign(r -> r.identity(this.provider.resolveCredentials())
+                signer.sign(r -> r.identity(provider.resolveCredentials())
                         .request(httpRequest)
                         .putProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, "sts")
                         .putProperty(AwsV4HttpSigner.REGION_NAME, region)

--- a/util/src/test/java/io/kubernetes/client/util/credentials/EKSAuthenticationTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/credentials/EKSAuthenticationTest.java
@@ -13,6 +13,7 @@ limitations under the License.
 package io.kubernetes.client.util.credentials;
 
 import io.kubernetes.client.openapi.ApiClient;
+import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -20,7 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -33,6 +34,9 @@ class EKSAuthenticationTest {
     @Mock
     private ApiClient apiClient;
 
+    @Mock
+    private OkHttpClient httpClient;
+
     private String region = "us-west-2";
 
     private String clusterName = "test-2";
@@ -40,9 +44,10 @@ class EKSAuthenticationTest {
   @Test
   void provideApiClient() {
         when(provider.resolveCredentials()).thenReturn(AwsSessionCredentials.create("ak", "sk", "session"));
+        when(apiClient.getHttpClient()).thenReturn(httpClient);
+        when(httpClient.newBuilder()).thenReturn(new OkHttpClient.Builder());
         EKSAuthentication authentication = new EKSAuthentication(provider, region, clusterName);
         authentication.provide(apiClient);
-        verify(apiClient).setApiKey(anyString());
-        verify(apiClient).setApiKeyPrefix(anyString());
+        verify(apiClient).setHttpClient(any(OkHttpClient.class));
     }
 }


### PR DESCRIPTION
Fixes #4731

## Description

`EKSAuthentication` currently generates an EKS bearer token when `provide()` is called and stores it on the `ApiClient` as a static API key.

However, EKS authentication tokens are short-lived. Once the generated token expires, subsequent requests continue to use the same expired token and fail with an authentication error.

This change updates `EKSAuthentication` to install an OkHttp interceptor instead. The interceptor adds the bearer token to each request, reuses the token before expiry, and generates a new token after expiry.

## Changes

- Add an OkHttp interceptor to `EKSAuthentication`
- Cache the generated EKS token until its configured expiry
- Refresh the token after expiry and use the refreshed token on subsequent requests
- Keep the maximum token expiry capped at 900 seconds
- Add tests for token injection, reuse before expiry, refresh after expiry, and expiry capping

## Testing

- `./mvnw -pl util -am -Dtest=EKSAuthenticationTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl util spotless:check`
- `git diff --check`

I also ran a manual smoke test against an EKS cluster with a 60 second token expiry:

- request at +0s succeeded
- request at +35s succeeded
- request at +70s succeeded
