### PR TITLE
cert-manager: build crd-model-gen image locally in update.sh

### DIFF
--- a/client-java-contrib/cert-manager/README.md
+++ b/client-java-contrib/cert-manager/README.md
@@ -8,14 +8,14 @@ To use this library, include the following maven dependency
 <dependency>
     <groupId>io.kubernetes</groupId>
     <artifactId>client-java-cert-manager-models</artifactId>
-    <version>0.16.1-SNAPSHOT</version>
+    <version>27.0.0-SNAPSHOT</version>
 </dependency>
 ```
 Please refer to the [CertManagerExample](../../examples/src/main/java/io/kubernetes/client/examples/CertManagerExample.java), which demonstrates how to create a self signed issuer using the model class and Kubernetes Java client generic API.
 ## Compatibility
 Artifact Version|Cert-Manager Release Version|CRD Source
 ----------------|----------------------------|----------
-0.16.1-SNAPSHOT|0.16.1|[Here](https://github.com/jetstack/cert-manager/releases/download/v0.16.1/cert-manager.crds.yaml)
+27.0.0-SNAPSHOT|1.13.4|[Here](https://github.com/jetstack/cert-manager/releases/download/v1.13.4/cert-manager.crds.yaml)
 ## Code Generation
 There is a utility script [update.sh](update.sh) to help with the code generation.
 

--- a/client-java-contrib/cert-manager/update.sh
+++ b/client-java-contrib/cert-manager/update.sh
@@ -16,10 +16,23 @@
 # This script generates the model classes from a released version of cert-manager CRDs
 # under src/main/java/io/cert/manager/models.
 
-DEFAULT_IMAGE_NAME=docker.pkg.github.com/kubernetes-client/java/crd-model-gen
-DEFAULT_IMAGE_TAG=v2.0.0
+# The crd-model-gen image used to be published to docker.pkg.github.com, which
+# requires GitHub authentication and returns "Access is denied" for anonymous
+# pulls (see kubernetes-client/java#3489). Build it locally from the Dockerfile
+# in this repository instead, so the script works out of the box.
+DEFAULT_IMAGE_NAME=local/crd-model-gen
+DEFAULT_IMAGE_TAG=latest
 IMAGE_NAME=${IMAGE_NAME:=$DEFAULT_IMAGE_NAME}
 IMAGE_TAG=${IMAGE_TAG:=$DEFAULT_IMAGE_TAG}
+
+# Build the crd-model-gen image locally if it is not already present, using the
+# Dockerfile shipped in client-java-contrib/.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTRIB_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+if ! docker image inspect "${IMAGE_NAME}:${IMAGE_TAG}" >/dev/null 2>&1; then
+  echo "Building ${IMAGE_NAME}:${IMAGE_TAG} from ${CONTRIB_DIR}/Dockerfile ..."
+  docker build -t "${IMAGE_NAME}:${IMAGE_TAG}" "${CONTRIB_DIR}"
+fi
 
 # a crdgen container is run in a way that:
 #   1. it has access to the docker daemon on the host so that it is able to create sibling container on the host


### PR DESCRIPTION
## Background

Issue #3489 has two distinct problems mixed together. The original report (V1 cert-manager models missing from the published jar) was already addressed on `master` long ago: `client-java-contrib/cert-manager/src/main/java/io/cert/manager/models/` now contains 109 V1-only types, with no `V1alpha*`/`V1beta*` classes left. So that part doesn't need a code change.

This PR addresses the **other** problem raised in the comments on #3489: contributors who try to follow the README and run `./update.sh` are blocked at the first step because docker pulls fail with `Access is denied`. The default image referenced by `update.sh`,

```
docker.pkg.github.com/kubernetes-client/java/crd-model-gen:v2.0.0
```

lives on a registry that requires GitHub authentication, so anonymous pulls do not work. This was reported by @vaidikcode and @AyushSinha-6409 in the issue thread.

## Changes

- **`client-java-contrib/cert-manager/update.sh`**: detect the missing image at runtime and build it locally from the `Dockerfile` already shipped in `client-java-contrib/`, defaulting to `local/crd-model-gen:latest`. `IMAGE_NAME` and `IMAGE_TAG` can still be overridden to use a prebuilt image.
- **`client-java-contrib/cert-manager/README.md`**: refresh the dependency snippet and compatibility table so they match the current artifact version (`27.0.0-SNAPSHOT`) and the v1.13.4 CRD URL already used by `update.sh`. No regeneration of model classes is included; the existing V1 classes on `master` are unchanged.

## Verification

Running `./update.sh` from a clean checkout (with no prebuilt image present) now builds `local/crd-model-gen:latest` from the in-tree `Dockerfile` and proceeds with the generation pipeline without contacting the private registry.

Refs: kubernetes-client/java#3489
