### PR TITLE
fix: generate valid EKS authentication token payload

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/credentials/EKSAuthentication.java
+++ b/util/src/main/java/io/kubernetes/client/util/credentials/EKSAuthentication.java
@@ -94,12 +94,13 @@ public class EKSAuthentication extends RefreshAuthentication {
     private static String presignedUrlToEncodedUrl(String presignedUrl) {
         return Base64.getUrlEncoder()
                 .withoutPadding()
-                .encodeToString(SdkHttpUtils.urlEncodeIgnoreSlashes(presignedUrl).getBytes(StandardCharsets.UTF_8));
+                .encodeToString(presignedUrl.getBytes(StandardCharsets.UTF_8));
     }
 
     private static SdkHttpRequest generateStsRequest(URI stsEndpoint, String clusterName) {
         return SdkHttpRequest.builder()
                 .uri(stsEndpoint)
+                .encodedPath("/")
                 .putRawQueryParameter("Version", "2011-06-15")
                 .putRawQueryParameter("Action", "GetCallerIdentity")
                 .method(SdkHttpMethod.GET)

--- a/util/src/main/java/io/kubernetes/client/util/credentials/EKSAuthentication.java
+++ b/util/src/main/java/io/kubernetes/client/util/credentials/EKSAuthentication.java
@@ -12,7 +12,6 @@ limitations under the License.
 */
 package io.kubernetes.client.util.credentials;
 
-import io.kubernetes.client.openapi.ApiClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -29,12 +28,13 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
+import java.util.function.Supplier;
 
 /**
  * EKS cluster authentication which generates a bearer token from AWS AK/SK. It doesn't require an "aws"
  * command line tool in the $PATH.
  */
-public class EKSAuthentication implements Authentication {
+public class EKSAuthentication extends RefreshAuthentication {
 
     private static final Logger log = LoggerFactory.getLogger(EKSAuthentication.class);
 
@@ -50,33 +50,45 @@ public class EKSAuthentication implements Authentication {
     }
 
     public EKSAuthentication(AwsCredentialsProvider provider, String region, String clusterName, int expirySeconds) {
-        this.provider = provider;
-        this.region = region;
-        this.clusterName = clusterName;
-        if (expirySeconds > MAX_EXPIRY_SECONDS) {
-            expirySeconds = MAX_EXPIRY_SECONDS;
-        }
-        this.expirySeconds = expirySeconds;
-        this.stsEndpoint = URI.create("https://sts." + this.region + ".amazonaws.com");
+        this(new EksTokenSupplier(provider, region, clusterName, Math.min(expirySeconds, MAX_EXPIRY_SECONDS)));
+    }
+
+    private EKSAuthentication(EksTokenSupplier tokenSupplier) {
+        super(tokenSupplier, Duration.of(tokenSupplier.expirySeconds, ChronoUnit.SECONDS));
+        setExpiry(Instant.now().plus(tokenSupplier.expirySeconds, ChronoUnit.SECONDS));
     }
 
     private static final int MAX_EXPIRY_SECONDS = 60 * 15;
-    private final AwsCredentialsProvider provider;
-    private final String region;
-    private final String clusterName;
-    private final URI stsEndpoint;
 
-    private final int expirySeconds;
+    private static class EksTokenSupplier implements Supplier<String> {
+        private final AwsCredentialsProvider provider;
+        private final String region;
+        private final String clusterName;
+        private final URI stsEndpoint;
+        private final int expirySeconds;
 
-    @Override
-    public void provide(ApiClient client) {
-        SdkHttpRequest httpRequest = generateStsRequest();
-        String presignedUrl = requestToPresignedUrl(httpRequest);
+        EksTokenSupplier(AwsCredentialsProvider provider, String region, String clusterName, int expirySeconds) {
+            this.provider = provider;
+            this.region = region;
+            this.clusterName = clusterName;
+            this.expirySeconds = expirySeconds;
+            this.stsEndpoint = URI.create("https://sts." + this.region + ".amazonaws.com");
+        }
+
+        @Override
+        public String get() {
+            return generateToken(provider, region, clusterName, stsEndpoint, expirySeconds);
+        }
+    }
+
+    private static String generateToken(
+            AwsCredentialsProvider provider, String region, String clusterName, URI stsEndpoint, int expirySeconds) {
+        SdkHttpRequest httpRequest = generateStsRequest(stsEndpoint, clusterName);
+        String presignedUrl = requestToPresignedUrl(httpRequest, provider, region);
         String encodedUrl = presignedUrlToEncodedUrl(presignedUrl);
         String token = "k8s-aws-v1." + encodedUrl;
-        client.setApiKeyPrefix("Bearer");
-        client.setApiKey(token);
         log.info("Generated BEARER token for ApiClient, expiring at {}", Instant.now().plus(expirySeconds, ChronoUnit.SECONDS));
+        return token;
     }
 
     private static String presignedUrlToEncodedUrl(String presignedUrl) {
@@ -85,7 +97,7 @@ public class EKSAuthentication implements Authentication {
                 .encodeToString(SdkHttpUtils.urlEncodeIgnoreSlashes(presignedUrl).getBytes(StandardCharsets.UTF_8));
     }
 
-    private SdkHttpRequest generateStsRequest() {
+    private static SdkHttpRequest generateStsRequest(URI stsEndpoint, String clusterName) {
         return SdkHttpRequest.builder()
                 .uri(stsEndpoint)
                 .putRawQueryParameter("Version", "2011-06-15")
@@ -95,10 +107,11 @@ public class EKSAuthentication implements Authentication {
                 .build();
     }
 
-    private String requestToPresignedUrl(SdkHttpRequest httpRequest) {
+    private static String requestToPresignedUrl(
+            SdkHttpRequest httpRequest, AwsCredentialsProvider provider, String region) {
         AwsV4HttpSigner signer = AwsV4HttpSigner.create();
         SignedRequest signedRequest =
-                signer.sign(r -> r.identity(this.provider.resolveCredentials())
+                signer.sign(r -> r.identity(provider.resolveCredentials())
                         .request(httpRequest)
                         .putProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, "sts")
                         .putProperty(AwsV4HttpSigner.REGION_NAME, region)

--- a/util/src/test/java/io/kubernetes/client/util/credentials/EKSAuthenticationTest.java
+++ b/util/src/test/java/io/kubernetes/client/util/credentials/EKSAuthenticationTest.java
@@ -13,6 +13,7 @@ limitations under the License.
 package io.kubernetes.client.util.credentials;
 
 import io.kubernetes.client.openapi.ApiClient;
+import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -20,7 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -33,6 +34,9 @@ class EKSAuthenticationTest {
     @Mock
     private ApiClient apiClient;
 
+    @Mock
+    private OkHttpClient httpClient;
+
     private String region = "us-west-2";
 
     private String clusterName = "test-2";
@@ -40,9 +44,10 @@ class EKSAuthenticationTest {
   @Test
   void provideApiClient() {
         when(provider.resolveCredentials()).thenReturn(AwsSessionCredentials.create("ak", "sk", "session"));
+        when(apiClient.getHttpClient()).thenReturn(httpClient);
+        when(httpClient.newBuilder()).thenReturn(new OkHttpClient.Builder());
         EKSAuthentication authentication = new EKSAuthentication(provider, region, clusterName);
         authentication.provide(apiClient);
-        verify(apiClient).setApiKey(anyString());
-        verify(apiClient).setApiKeyPrefix(anyString());
+        verify(apiClient).setHttpClient(any(OkHttpClient.class));
     }
 }


### PR DESCRIPTION
Stacked on #4741

## Description

`EKSAuthentication` currently URL-encodes the full presigned STS `GetCallerIdentity` URL before building the `k8s-aws-v1.` bearer token.

However, the AWS signer already returns a presigned URL with encoded query parameters. Encoding the whole URL again makes the decoded token payload an encoded URL string, rather than the presigned STS URL expected by EKS. In practice, this causes EKS API requests using `EKSAuthentication` to fail with `401 Unauthorized`.

This change builds the EKS bearer token from the presigned STS URL directly and sets the STS request path explicitly to `/`, so the decoded token payload matches the form accepted by EKS.

## Changes

- Remove whole-URL encoding before base64url-encoding the EKS token payload
- Keep the presigned STS URL query parameter encoding produced by the AWS signer
- Set the STS request path explicitly to `/`

## References

- Amazon EKS docs show that the decoded `k8s-aws-v1.` token payload is a presigned STS `GetCallerIdentity` URL with `X-Amz-Expires=60`:
  https://docs.aws.amazon.com/eks/latest/best-practices/identity-and-access-management.html

- `aws-iam-authenticator` documents the same token construction: base64url encode the signed STS `GetCallerIdentity` request URL and prefix it with `k8s-aws-v1.`:
  https://github.com/kubernetes-sigs/aws-iam-authenticator#api-authorization-from-outside-a-cluster
  
 ## Validation

I verified this manually against a real EKS cluster by using `EKSAuthentication` to generate the bearer token and calling `CoreV1Api.listNamespace()`.

The previous token payload failed with `401 Unauthorized`, while the updated payload succeeded in listing namespaces.