### PR TITLE
fix: generate valid EKS authentication token payload

### DIFF
--- a/util/src/main/java/io/kubernetes/client/util/credentials/EKSAuthentication.java
+++ b/util/src/main/java/io/kubernetes/client/util/credentials/EKSAuthentication.java
@@ -82,12 +82,13 @@ public class EKSAuthentication implements Authentication {
     private static String presignedUrlToEncodedUrl(String presignedUrl) {
         return Base64.getUrlEncoder()
                 .withoutPadding()
-                .encodeToString(SdkHttpUtils.urlEncodeIgnoreSlashes(presignedUrl).getBytes(StandardCharsets.UTF_8));
+                .encodeToString(presignedUrl.getBytes(StandardCharsets.UTF_8));
     }
 
     private SdkHttpRequest generateStsRequest() {
         return SdkHttpRequest.builder()
                 .uri(stsEndpoint)
+                .encodedPath("/")
                 .putRawQueryParameter("Version", "2011-06-15")
                 .putRawQueryParameter("Action", "GetCallerIdentity")
                 .method(SdkHttpMethod.GET)


### PR DESCRIPTION
## Description

`EKSAuthentication` currently URL-encodes the entire presigned STS `GetCallerIdentity` URL before building the `k8s-aws-v1.` bearer token.

However, the presigned URL returned by the AWS signer already contains encoded query parameters. Encoding the entire URL again makes the decoded token payload an encoded URL string, rather than the presigned STS URL form used by `aws-iam-authenticator` and shown in the EKS docs.

For example, the decoded token payload form is:

```text
https://sts.ap-northeast-2.amazonaws.com/?Version=2011-06-15&Action=GetCallerIdentity&X-Amz-Credential=...%2F...
```

With the extra full-URL encoding step, the decoded payload instead becomes an encoded URL string:

```text
https%3A//sts.ap-northeast-2.amazonaws.com%3FVersion%3D2011-06-15%26Action%3DGetCallerIdentity%26X-Amz-Credential%3D...%252F...
```

I observed this causing EKS API requests using `EKSAuthentication` to fail with `401 Unauthorized`.

This change builds the EKS bearer token from the presigned STS URL directly. It also sets the STS request path explicitly to `/`, matching the working presigned URL form verified against EKS:

```text
https://sts...amazonaws.com/?...
```

## Changes

- Stop URL-encoding the entire presigned STS URL before base64url-encoding it
- Set the STS request path explicitly to `/`

## References

- Amazon EKS docs show a decoded `k8s-aws-v1.` token payload as a presigned STS `GetCallerIdentity` URL with `X-Amz-Expires=60`:
  https://docs.aws.amazon.com/eks/latest/best-practices/identity-and-access-management.html

- `aws-iam-authenticator` documents the same token construction: base64url encode the signed STS `GetCallerIdentity` request URL and prefix it with `k8s-aws-v1.`:
  https://github.com/kubernetes-sigs/aws-iam-authenticator#api-authorization-from-outside-a-cluster

## Validation

I verified this manually against a real EKS cluster by using `EKSAuthentication` to generate the bearer token and calling `CoreV1Api.listNamespace()`.

The previous token payload failed with `401 Unauthorized`, while the updated payload succeeded in listing namespaces.