### PR TITLE
fix(util): prevent non-tar copy path traversal on release-25

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,15 +28,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     - name: Setup Java
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
         distribution: 'temurin'
         java-version: 17.0.x
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
       with:
         languages: ${{ matrix.language }}
 
@@ -46,4 +46,4 @@ jobs:
       run: ./mvnw clean package -f "pom.xml" -B -V -e -Dfindbugs.skip -Dcheckstyle.skip -Dpmd.skip=true -Dspotbugs.skip -Denforcer.skip -Dmaven.javadoc.skip -DskipTests -Dmaven.test.skip.exec -Dlicense.skip=true -Drat.skip=true -Dspotless.check.skip=true
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3

--- a/.github/workflows/generate-crd.yml
+++ b/.github/workflows/generate-crd.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Run CRD Model Generation
         run: |
           read CRD_SRC_ARGS < <(echo '${{ github.event.inputs.crds }}' | perl -ne 'print join " ", map {"-u $_"} split /,/')
@@ -48,7 +48,7 @@ jobs:
             -p ${{ github.event.inputs.generatingJavaPackage }} \
             -o "$(pwd)/${GEN_DIR}"
           ls -lh ${GEN_DIR}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: generated-java-crd-model
           path: |

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -30,16 +30,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Java
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           token: ${{ secrets.PAT_TOKEN }}
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: 17.0.x
       - name: Checkout Gen
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           path: gen
           repository: kubernetes-client/gen
@@ -108,7 +108,7 @@ jobs:
           git push origin "$BRANCH"
       - name: Pull Request
         if: ${{ github.event.inputs.dry_run != 'true' }}
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2
         with:
           source_branch: ${{ env.BRANCH }}
           destination_branch: ${{ github.ref_name }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Verify Source Format
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: 11
@@ -30,14 +30,14 @@ jobs:
         os: [ macos-latest, windows-latest, ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ matrix.java }}-${{ hashFiles('pom.xml', '**/pom.xml') }}
@@ -55,8 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     name: GraalVM Maven Test
     steps:
-      - uses: actions/checkout@v5
-      - uses: graalvm/setup-graalvm@v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1
         with:
           version: '22.3.0'
           java-version: '17'
@@ -67,11 +67,11 @@ jobs:
     runs-on: ubuntu-latest
     name: End-to-End Test Against Real Cluster
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.12.0
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: 17.0.x
@@ -92,14 +92,14 @@ jobs:
     runs-on: ubuntu-latest
     name: Examples smoke test
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: 17.0.x
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -142,9 +142,9 @@ jobs:
           - 5000:5000
     name: CRD Java Models Code Generation
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@v5
+        uses: elgohr/Publish-Docker-Github-Action@1c2f28ccd9476e8a936ac9a1f287405504c93304 # v5
         with:
           name: kubernetes-client/java/crd-model-gen
           tags: gh-action-tmp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           echo "${{ github.event.inputs.releaseVersion }}" | perl -ne 'die unless m/^\d+\.\d+\.\d+$/'
           echo "${{ github.event.inputs.nextDevelopmentVersion }}" | perl -ne 'die unless m/^\d+\.\d+\.\d+-SNAPSHOT$/'
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           token: ${{ secrets.PAT_TOKEN }}
       - name: Check Actor
@@ -35,7 +35,7 @@ jobs:
           # Release actor should be in the OWNER list
           cat OWNERS | grep ${{ github.actor }}
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: 17.0.x
@@ -87,7 +87,7 @@ jobs:
           git push https://${{ github.token }}@github.com/${{ github.repository }}.git v${{ github.event.inputs.releaseVersion }}
       - name: Pull Request
         if: ${{ github.event.inputs.dry-run != 'true' }}
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2
         with:
           source_branch: automated-release-${{ github.event.inputs.releaseVersion }}
           destination_branch: ${{ github.ref_name }}
@@ -95,7 +95,7 @@ jobs:
           pr_title: "Automated Release: ${{ github.event.inputs.releaseVersion }}"
       - name: Publish Release
         if: ${{ github.event.inputs.dry-run != 'true' }}
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: v${{ github.event.inputs.releaseVersion }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: 17.0.x

--- a/util/src/main/java/io/kubernetes/client/Copy.java
+++ b/util/src/main/java/io/kubernetes/client/Copy.java
@@ -30,6 +30,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -241,8 +242,7 @@ public class Copy extends Exec {
     for (TreeNode childNode : node.getChildren()) {
       if (!childNode.isDir) {
         // Create file which is under 'node'
-        String filePath = genericPathBuilder(destination.toString(), childNode.name);
-        File f = new File(filePath);
+        File f = safeResolveWithinBase(destination, childNode.name).toFile();
         if (!f.createNewFile()) {
           throw new IOException("Failed to create file: " + f);
         }
@@ -254,8 +254,7 @@ public class Copy extends Exec {
         }
       } else {
         String newSrcPath = genericPathBuilder(srcPath, childNode.name);
-        // TODO: Change this once the method genericPathBuilder is changed to varargs
-        Path newDestination = Paths.get(destination.toString(), childNode.name);
+        Path newDestination = safeResolveWithinBase(destination, childNode.name);
         createFiles(childNode, namespace, pod, container, newSrcPath, newDestination);
       }
     }
@@ -276,8 +275,7 @@ public class Copy extends Exec {
     }
     for (TreeNode childNode : node.getChildren()) {
       if (childNode.isDir) {
-        String path = genericPathBuilder(destination.toString(), childNode.name);
-        Path newPath = Paths.get(path);
+        Path newPath = safeResolveWithinBase(destination, childNode.name);
         createDirectory(childNode, newPath);
       }
     }
@@ -304,20 +302,52 @@ public class Copy extends Exec {
           int len = line.length();
           // line = stripFileSeparators(line);
           if (line.charAt(line.length() - 1) == '/') {
+            String safeName = sanitizeRelativeEntryName(line.substring(0, len - 1));
             TreeNode subDirTree =
                 new TreeNode(
                     true,
-                    line.substring(0, len - 1),
+                    safeName,
                     false); // Stripping off '/' in the end of directory
             String path = genericPathBuilder(srcPath, subDirTree.name);
             createDirectoryTree(subDirTree, namespace, pod, container, path);
             node.getChildren().add(subDirTree);
           } else {
-            node.getChildren().add(new TreeNode(false, line, false));
+            node.getChildren().add(new TreeNode(false, sanitizeRelativeEntryName(line), false));
           }
         }
       }
     }
+  }
+
+  private Path safeResolveWithinBase(Path base, String entryName) throws IOException {
+    Path normalizedBase = base.toAbsolutePath().normalize();
+    Path resolved = normalizedBase.resolve(entryName).normalize();
+    if (!resolved.startsWith(normalizedBase)) {
+      throw new IOException("Invalid path entry: " + entryName);
+    }
+    return resolved;
+  }
+
+  private String sanitizeRelativeEntryName(String entryName) throws IOException {
+    String sanitized = Objects.requireNonNull(entryName, "entryName").trim();
+    if (sanitized.isEmpty()) {
+      throw new IOException("Invalid empty path entry");
+    }
+
+    // ls -F output should be a single relative path segment. Reject path separators and traversal.
+    if (sanitized.contains("/") || sanitized.contains("\\")) {
+      throw new IOException("Invalid path entry: " + entryName);
+    }
+
+    String normalized = FilenameUtils.normalize(sanitized, true);
+    if (normalized == null || normalized.startsWith("../") || normalized.startsWith("/")) {
+      throw new IOException("Invalid path entry: " + entryName);
+    }
+
+    if (normalized.endsWith("/")) {
+      normalized = normalized.substring(0, normalized.length() - 1);
+    }
+    return normalized;
   }
 
   /*

--- a/util/src/test/java/io/kubernetes/client/CopyTest.java
+++ b/util/src/test/java/io/kubernetes/client/CopyTest.java
@@ -27,15 +27,24 @@ import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.util.ClientBuilder;
 import io.kubernetes.client.util.exception.CopyNotSupportedException;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Tests for the Copy helper class */
 class CopyTest {
@@ -44,6 +53,71 @@ class CopyTest {
   private String[] cmd;
 
   private ApiClient client;
+
+  private static class MockProcess extends Process {
+    private final InputStream inputStream;
+
+    MockProcess(String stdout) {
+      this.inputStream = new ByteArrayInputStream(stdout.getBytes());
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+      return OutputStream.nullOutputStream();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return inputStream;
+    }
+
+    @Override
+    public InputStream getErrorStream() {
+      return InputStream.nullInputStream();
+    }
+
+    @Override
+    public int waitFor() {
+      return 0;
+    }
+
+    @Override
+    public int exitValue() {
+      return 0;
+    }
+
+    @Override
+    public void destroy() {
+      // no-op for tests
+    }
+  }
+
+  private static class MockCopy extends Copy {
+    private final Map<String, String> listingsByPath;
+
+    MockCopy(Map<String, String> listingsByPath) {
+      this.listingsByPath = listingsByPath;
+    }
+
+    @Override
+    public Process exec(
+        String namespace,
+        String name,
+        String[] command,
+        String container,
+        boolean stdin,
+        boolean tty) {
+      String cmd = command[2];
+      String srcPath = cmd.substring("ls -F ".length());
+      return new MockProcess(listingsByPath.getOrDefault(srcPath, ""));
+    }
+
+    @Override
+    public InputStream copyFileFromPod(String namespace, String pod, String srcPath)
+        throws ApiException, IOException {
+      return new ByteArrayInputStream("test-data".getBytes());
+    }
+  }
 
   @RegisterExtension
   static WireMockExtension apiServer =
@@ -224,5 +298,54 @@ class CopyTest {
             .withQueryParam("command", equalTo("sh"))
             .withQueryParam("command", equalTo("-c"))
             .withQueryParam("command", equalTo("tar --version")));
+  }
+
+  @Test
+  void rejectsPathTraversalInNonTarCopy(@TempDir Path tempDir) throws Exception {
+    Path sourceRoot = Paths.get("/src");
+    Path destinationRoot = tempDir.resolve("dest");
+    Path escapedFile = tempDir.resolve("escape.txt");
+
+    Map<String, String> listingsByPath = new HashMap<>();
+    listingsByPath.put(sourceRoot.toString(), "../escape.txt\n");
+
+    Copy copy = new MockCopy(listingsByPath);
+
+    assertThrows(
+        IOException.class,
+        () ->
+            copy.copyDirectoryFromPod(
+                namespace,
+                podName,
+                null,
+                sourceRoot.toString(),
+                destinationRoot,
+                false));
+
+    assertFalse(Files.exists(escapedFile));
+  }
+
+  @Test
+  void copiesSafeEntriesInNonTarMode(@TempDir Path tempDir) throws Exception {
+    Path sourceRoot = Paths.get("/src");
+    Path destinationRoot = tempDir.resolve("dest");
+    Files.createDirectories(destinationRoot);
+
+    Map<String, String> listingsByPath = new HashMap<>();
+    listingsByPath.put(sourceRoot.toString(), "safe.txt\n");
+
+    Copy copy = new MockCopy(listingsByPath);
+
+    copy.copyDirectoryFromPod(
+        namespace,
+        podName,
+        null,
+        sourceRoot.toString(),
+        destinationRoot,
+        false);
+
+    Path copied = destinationRoot.resolve("safe.txt");
+    assertTrue(Files.exists(copied));
+    assertEquals("test-data", Files.readString(copied));
   }
 }


### PR DESCRIPTION
Harden Copy non-tar directory copy against path traversal from pod-controlled ls -F output by sanitizing entry names and enforcing destination path containment. Add regression test for traversal and positive test for safe entries.