### PR TITLE
fix: avoid NPE in DeploymentHelper.equalIgnoreHash on templates with no labels

### DIFF
--- a/extended/src/main/java/io/kubernetes/client/extended/kubectl/util/deployment/DeploymentHelper.java
+++ b/extended/src/main/java/io/kubernetes/client/extended/kubectl/util/deployment/DeploymentHelper.java
@@ -138,10 +138,14 @@ public class DeploymentHelper {
    */
   private static boolean equalIgnoreHash(V1PodTemplateSpec template1, V1PodTemplateSpec template2) {
     if (!Objects.equals(template1.getSpec(), template2.getSpec())) return false;
-    V1ObjectMeta m1Copy = objectMetaDeepCopy(template1.getMetadata());
-    V1ObjectMeta m2Copy = objectMetaDeepCopy(template2.getMetadata());
-    m1Copy.getLabels().remove(DEFAULT_DEPLOYMENT_UNIQUE_LABEL_KEY);
-    m2Copy.getLabels().remove(DEFAULT_DEPLOYMENT_UNIQUE_LABEL_KEY);
+    V1ObjectMeta m1Copy = objectMetaDeepCopyOrEmpty(template1.getMetadata());
+    V1ObjectMeta m2Copy = objectMetaDeepCopyOrEmpty(template2.getMetadata());
+    if (m1Copy.getLabels() != null) {
+      m1Copy.getLabels().remove(DEFAULT_DEPLOYMENT_UNIQUE_LABEL_KEY);
+    }
+    if (m2Copy.getLabels() != null) {
+      m2Copy.getLabels().remove(DEFAULT_DEPLOYMENT_UNIQUE_LABEL_KEY);
+    }
     return m1Copy.equals(m2Copy);
   }
 
@@ -170,5 +174,18 @@ public class DeploymentHelper {
   private static V1ObjectMeta objectMetaDeepCopy(V1ObjectMeta meta) {
     String data = Yaml.dump(meta);
     return Yaml.loadAs(data, V1ObjectMeta.class);
+  }
+
+  /**
+   * Same as {@link #objectMetaDeepCopy(V1ObjectMeta)}, but returns a fresh empty {@link
+   * V1ObjectMeta} instead of throwing when {@code meta} is {@code null}. A pod template's {@code
+   * metadata} field is optional, so callers comparing two templates need to treat a missing
+   * metadata block as equivalent to an empty one rather than failing.
+   */
+  private static V1ObjectMeta objectMetaDeepCopyOrEmpty(V1ObjectMeta meta) {
+    if (meta == null) {
+      return new V1ObjectMeta();
+    }
+    return objectMetaDeepCopy(meta);
   }
 }

--- a/extended/src/test/java/io/kubernetes/client/extended/kubectl/util/deployment/DeploymentHelperTest.java
+++ b/extended/src/test/java/io/kubernetes/client/extended/kubectl/util/deployment/DeploymentHelperTest.java
@@ -89,6 +89,39 @@ class DeploymentHelperTest {
   }
 
   @Test
+  void getAllReplicaSetsShouldWorkWhenTemplateHasNoLabels() throws IOException, ApiException {
+    // Regression test: pod template metadata with no labels at all (so getLabels() is null)
+    // used to throw a NullPointerException in DeploymentHelper.equalIgnoreHash.
+    String deploymentJson =
+        "{\"metadata\":{\"name\":\"foo\",\"namespace\":\"default\",\"uid\":\"dep-uid\"},"
+            + "\"spec\":{\"selector\":{\"matchLabels\":{\"app\":\"bar\"}},"
+            + "\"template\":{\"spec\":{\"containers\":[{\"name\":\"c\",\"image\":\"busybox\"}]}}}}";
+    String replicaSetListJson =
+            "{\"items\":[{\"metadata\":{\"name\":\"foo-rs\",\"namespace\":\"default\",\"uid\":\"rs-uid\","
+                    + "\"creationTimestamp\":\"2021-08-05T08:20:22.000000Z\","
+                    + "\"ownerReferences\":[{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"name\":\"foo\","
+                    + "\"uid\":\"dep-uid\",\"controller\":true}]},"
+                    + "\"spec\":{\"replicas\":3,\"selector\":{\"matchLabels\":{\"app\":\"bar\"}},"
+                    + "\"template\":{\"spec\":{\"containers\":[{\"name\":\"c\",\"image\":\"busybox\"}]}}}}]}";
+
+    apiServer.stubFor(
+        get(urlPathEqualTo("/apis/apps/v1/namespaces/default/replicasets"))
+            .willReturn(aResponse().withStatus(200).withBody(replicaSetListJson)));
+    AppsV1Api api = new AppsV1Api(this.apiClient);
+
+    V1Deployment deployment = new JSON().deserialize(deploymentJson, V1Deployment.class);
+    List<V1ReplicaSet> oldRSes = new ArrayList<>();
+    List<V1ReplicaSet> allOldRSes = new ArrayList<>();
+
+    V1ReplicaSet newRs = DeploymentHelper.getAllReplicaSets(deployment, api, oldRSes, allOldRSes);
+
+    assertThat(newRs).isNotNull();
+    assertThat(newRs.getMetadata().getName()).isEqualTo("foo-rs");
+    assertThat(oldRSes).isEmpty();
+    assertThat(allOldRSes).isEmpty();
+  }
+
+  @Test
   void revisionShouldWork() throws IOException {
     V1ReplicaSetList replicaSetList =
         new JSON()


### PR DESCRIPTION
`DeploymentHelper.equalIgnoreHash` NPEs when a pod template has no labels (or no metadata at all), both are valid per the k8s API but weren't null-checked. This breaks `getAllReplicaSets`, which is used for deployment rollout status.

Added null checks before removing the pod-template-hash label, and a fallback for when metadata itself is null. Added a test that repros the old NPE and confirms it's fixed.